### PR TITLE
Wait until data stops arriving to signal file is open

### DIFF
--- a/docker/core.go
+++ b/docker/core.go
@@ -207,8 +207,6 @@ func (cli *Client) Open(ctx context.Context, node plugin.Entry) (plugin.IFileBuf
 	}()
 	// Wait for some output to buffer.
 	<-buffered
-	// Wait a short time for reading the stream.
-	time.Sleep(100 * time.Millisecond)
 
 	return buf, nil
 }

--- a/kubernetes/core.go
+++ b/kubernetes/core.go
@@ -256,8 +256,6 @@ func (cli *Client) Open(ctx context.Context, node plugin.Entry) (plugin.IFileBuf
 	}()
 	// Wait for some output to buffer.
 	<-buffered
-	// Wait a short time for reading the stream.
-	time.Sleep(100 * time.Millisecond)
 
 	return buf, nil
 }


### PR DESCRIPTION
Wait until we stop receiving data (for 100ms) or we've been reading for
5s (data's coming in too quickly) to signal the file is open. This
ensures most of the data you want has been loaded before anything tries
to use it.

Fixes #15.