### PR TITLE
Rename a few things for more consistent taxonomy, generalize logging

### DIFF
--- a/plugin/types.go
+++ b/plugin/types.go
@@ -71,7 +71,7 @@ const (
 
 // FS contains the core filesystem data.
 type FS struct {
-	Clients map[string]DirProtocol
+	Plugins map[string]DirProtocol
 }
 
 var _ fs.FS = (*FS)(nil)


### PR DESCRIPTION
Rename client to plugin in wash, name the FUSE server.

Move logging on FS (plugin registry) for listing and finding to the FUSE
interface functions so they're logged for all plugins as well.