### PR TITLE
List all kubernetes contexts

### DIFF
--- a/docker/core.go
+++ b/docker/core.go
@@ -24,7 +24,7 @@ type root struct {
 const validDuration = 100 * time.Millisecond
 
 // Create a new docker client.
-func Create(name string, cache *bigcache.BigCache) (plugin.DirProtocol, error) {
+func Create(name string, _ interface{}, cache *bigcache.BigCache) (plugin.DirProtocol, error) {
 	dockerCli, err := client.NewClientWithOpts(client.FromEnv)
 	if err != nil {
 		return nil, err

--- a/gcp/core.go
+++ b/gcp/core.go
@@ -30,7 +30,7 @@ type client struct {
 const validDuration = 100 * time.Millisecond
 
 // Create a new gcp client.
-func Create(name string, cache *bigcache.BigCache) (plugin.DirProtocol, error) {
+func Create(name string, _ interface{}, cache *bigcache.BigCache) (plugin.DirProtocol, error) {
 	// This API is terrible, but not supported by the better go sdk.
 	cloudPlatformScopes := append([]string{crm.CloudPlatformScope}, serviceScopes...)
 	oauthClient, err := google.DefaultClient(context.Background(), cloudPlatformScopes...)


### PR DESCRIPTION
Uses a `kubernetes_` prefix to identify context names.

Fixes #10.