### PR TITLE
Remove metadata_never_index file

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,13 @@ Operations that work:
 - `stat` (kind of, information's not very useful)
 - `xattr` and a new command `meta`
 
-NOTE: requires golang 1.11.4.
+> Requires golang 1.11+.
+
+### macOS Setup
 
 Obtain FUSE for OSX [here](https://osxfuse.github.io/).
+
+Add your mount directory to Spotlight's list of excluded directories to avoid heavy load.
 
 ### Container
 

--- a/plugin/core.go
+++ b/plugin/core.go
@@ -33,7 +33,7 @@ func Init(_slow bool) {
 
 // NewFS creates a new FS.
 func NewFS(plugins map[string]DirProtocol) *FS {
-	files := []string{".metadata_never_index", ".Trashes", ".fseventsd/no_log"}
+	files := []string{".Trashes", ".fseventsd/no_log"}
 	return &FS{Plugins: plugins, files: files, name: "/"}
 }
 


### PR DESCRIPTION
The metadata_never_index file prevented `find` from searching the
directory. Remove it. Instead the recommendation is to add the mount
point to Spotlight exclusions on macOS.