### PR TITLE
Add script to do godoc

### DIFF
--- a/godoc.sh
+++ b/godoc.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+
+mkdir -p /tmp/tmpgoroot/doc
+rm -rf /tmp/tmpgopath/src/github.com/puppetlabs/wash
+mkdir -p /tmp/tmpgopath/src/github.com/puppetlabs/wash
+tar -c --exclude='.git' --exclude='tmp' . | tar -x -C /tmp/tmpgopath/src/github.com/puppetlabs/wash
+echo "open http://localhost:6060/pkg/github.com/puppetlabs/wash\n"
+GOROOT=/tmp/tmpgoroot/ GOPATH=/tmp/tmpgopath/ godoc -http=localhost:6060
+


### PR DESCRIPTION
godoc support for modules isn't complete. Add a script to tar up the source and put it in a temp location with a gopath directory structure, then run godoc.