### PR TITLE
Use correct integer types for LS response

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -30,9 +30,9 @@ type LSItem struct {
 		Atime string `json:"Atime"`
 		Mtime string `json:"Mtime"`
 		Ctime string `json:"Ctime"`
-		Mode  int    `json:"Mode"`
-		Size  int    `json:"Size"`
-		Valid int    `json:"Valid"`
+		Mode  uint   `json:"Mode"`
+		Size  uint   `json:"Size"`
+		Valid uint   `json:"Valid"`
 	} `json:"attributes"`
 }
 

--- a/api/http.go
+++ b/api/http.go
@@ -157,6 +157,8 @@ var listHandler handler = func(w http.ResponseWriter, r *http.Request) *errorRes
 			"actions": supportedActionsOf(entry),
 		}
 
+		// TODO: use the FUSE logic for filling Attr. Not doing it yet because it overlaps
+		// with in-progress caching work.
 		if file, ok := entry.(plugin.File); ok {
 			result["attributes"] = file.Attr()
 		}


### PR DESCRIPTION
Attributes used signed rather than unsigned types, which could result in
an error unmarshaling the JSON response. This primarily came up due to a
change in the default size for some files, where they report an unknown
size by using the largest possible uint64 value.

Once caching work is done we need to rework getting Attr to use FUSE's
defaults.