### PR TITLE
Handle failures in plugins, loading kubernetes context

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -160,6 +160,7 @@ func initializePlugins() (*plugin.Registry, error) {
 		&docker.Root{},
 		&kubernetes.Root{},
 	} {
+		log.Infof("Loading %v plugin", plugin.Name())
 		if err := plugin.Init(); err != nil {
 			// %+v is a convention used by some errors to print additional context such as a stack trace
 			log.Warnf("%v plugin failed to load: %+v", plugin.Name(), err)

--- a/docker/root.go
+++ b/docker/root.go
@@ -11,25 +11,22 @@ import (
 
 // Root of the Docker plugin
 type Root struct {
-	plugin.EntryBase
-	client    *client.Client
 	resources []plugin.Entry
 }
 
+// Name returns 'docker'
+func (r *Root) Name() string { return "docker" }
+
 // Init for root
 func (r *Root) Init() error {
-	r.EntryBase = plugin.NewEntry("docker")
-	r.CacheConfig().TurnOffCaching()
-
 	dockerCli, err := client.NewClientWithOpts(client.FromEnv)
 	if err != nil {
 		return err
 	}
-	r.client = dockerCli
 
 	r.resources = []plugin.Entry{
-		&containers{EntryBase: plugin.NewEntry("containers"), client: r.client},
-		&volumes{EntryBase: plugin.NewEntry("volumes"), client: r.client},
+		&containers{EntryBase: plugin.NewEntry("containers"), client: dockerCli},
+		&volumes{EntryBase: plugin.NewEntry("volumes"), client: dockerCli},
 	}
 
 	return nil

--- a/kubernetes/root.go
+++ b/kubernetes/root.go
@@ -15,7 +15,6 @@ import (
 
 // Root of the Kubernetes plugin
 type Root struct {
-	plugin.EntryBase
 	contexts []plugin.Entry
 }
 
@@ -36,11 +35,11 @@ func createContext(raw clientcmdapi.Config, name string, access clientcmd.Config
 	return &k8context{plugin.NewEntry(name), clientset, cfg, defaultns}, nil
 }
 
+// Name returns 'kubernetes'
+func (r *Root) Name() string { return "kubernetes" }
+
 // Init for root
 func (r *Root) Init() error {
-	r.EntryBase = plugin.NewEntry("kubernetes")
-	r.CacheConfig().TurnOffCaching()
-
 	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
 	config := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, &clientcmd.ConfigOverrides{})
 	raw, err := config.RawConfig()

--- a/plugin/cache.go
+++ b/plugin/cache.go
@@ -75,7 +75,12 @@ func cachedOpHelper(op cachedOp, entry Entry, id string, generateValue func() (i
 		panic("The cache was not initialized. You can initialize the cache by invoking plugin.InitCache()")
 	}
 
-	config := entry.CacheConfig()
+	cached, ok := entry.(Cached)
+	if !ok {
+		return generateValue()
+	}
+
+	config := cached.CacheConfig()
 	if config == nil {
 		config = &defaultConfig
 	}

--- a/plugin/types.go
+++ b/plugin/types.go
@@ -12,6 +12,11 @@ import (
 // Entry is a basic named resource type.
 type Entry interface {
 	Name() string
+}
+
+// Cached is a resource that expects its method invocations to be cached.
+// If CacheConfig() returns nil, a default config will be used.
+type Cached interface {
 	CacheConfig() *CacheConfig
 }
 


### PR DESCRIPTION
An error loading a plugin no longer causes wash to exit. It now prints a
warning about which plugin failed to load.

The kubernetes plugin no longer errors if an invalid configuration is
found. It now prints a warning about which context failed.

Fixes #79.