### PR TITLE
Move /fs/list's response structure to the server; clean-up FUSE

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -22,21 +22,6 @@ type DomainSocketClient struct {
 
 var domainSocketBaseURL = "http://localhost"
 
-// LSItem represents a single entry from the result of issuing a wash "list"
-// request.
-type LSItem struct {
-	Actions    []string `json:"actions"`
-	Name       string   `json:"name"`
-	Attributes struct {
-		Atime string `json:"Atime"`
-		Mtime string `json:"Mtime"`
-		Ctime string `json:"Ctime"`
-		Mode  uint   `json:"Mode"`
-		Size  uint   `json:"Size"`
-		Valid uint   `json:"Valid"`
-	} `json:"attributes"`
-}
-
 // ForUNIXSocket returns a client suitable for making wash API calls over a UNIX
 // domain socket.
 func ForUNIXSocket(pathToSocket string) DomainSocketClient {
@@ -82,10 +67,10 @@ func (c *DomainSocketClient) performRequest(endpoint string, result interface{})
 }
 
 // List lists the resources located at "path".
-func (c *DomainSocketClient) List(path string) ([]LSItem, error) {
+func (c *DomainSocketClient) List(path string) ([]api.ListEntry, error) {
 	endpoint := fmt.Sprintf("/fs/list%s", path)
 
-	var ls []LSItem
+	var ls []api.ListEntry
 	if err := c.performRequest(endpoint, &ls); err != nil {
 		return nil, err
 	}

--- a/plugin/types.go
+++ b/plugin/types.go
@@ -112,12 +112,12 @@ type Writable interface {
 
 // Attributes of resources.
 type Attributes struct {
-	Atime time.Time
-	Mtime time.Time
-	Ctime time.Time
-	Mode  os.FileMode
-	Size  uint64
-	Valid time.Duration
+	Atime time.Time     `json:"Atime"`
+	Mtime time.Time     `json:"Mtime"`
+	Ctime time.Time     `json:"Ctime"`
+	Mode  os.FileMode   `json:"Mode"`
+	Size  uint64        `json:"Size"`
+	Valid time.Duration `json:"Valid"`
 }
 
 // SizeUnknown can be used to denote that the size is unknown and should be queried from content.


### PR DESCRIPTION
This commit moves the LSItem struct from the client to the server. It
also cleans up some of the duplicate FUSE code, which includes
centralizing the attributes logic in a FillAttr helper. The latter's
used by the /fs/list endpoint's handler.