### PR TITLE
Prototype data-driven plugin support

### DIFF
--- a/examples/data-plugin.yaml
+++ b/examples/data-plugin.yaml
@@ -1,0 +1,8 @@
+name: kubernetes2
+enum: [pod, persistentvolumeclaims]
+#list: kubectl api-resources --verbs=list -o name
+proto:
+  list: kubectl get {{.Label}} -o json
+  post: '{{range $i, $elem := .items}} {{$elem.metadata.name}} {{end}}'
+  proto:
+    metadata: kubectl get {{.Parent.Name}}/{{.Label}} -o json

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/imdario/mergo v0.3.6 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.5 // indirect
+	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -69,6 +69,8 @@ github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/json-iterator/go v1.1.5 h1:gL2yXlmiIo4+t+y32d4WGwOjKGYcGOuyrg46vadswDE=
 github.com/json-iterator/go v1.1.5/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
+github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
+github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=

--- a/plugin/data/invoker.go
+++ b/plugin/data/invoker.go
@@ -1,0 +1,44 @@
+package data
+
+import (
+	"bytes"
+	"fmt"
+	"html/template"
+	"io"
+	"os/exec"
+	"strings"
+
+	"github.com/kballard/go-shellquote"
+	"github.com/puppetlabs/wash/plugin"
+	log "github.com/sirupsen/logrus"
+)
+
+func invoke(input string, entry plugin.Entry) (io.Reader, error) {
+	t, err := template.New("invoke").Parse(input)
+	if err != nil {
+		return nil, err
+	}
+
+	var cmdstring strings.Builder
+	if err = t.Execute(&cmdstring, entry); err != nil {
+		return nil, err
+	}
+
+	log.Debugf("Invoking: %v", cmdstring.String())
+	segments, err := shellquote.Split(cmdstring.String())
+	if err != nil {
+		return nil, err
+	}
+	cmd := exec.Command(segments[0], segments[1:]...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err = cmd.Run()
+	if err != nil {
+		return nil, fmt.Errorf("%v:\n%v", err.Error(), string(stderr.Bytes()))
+	}
+	if stderr.String() != "" {
+		log.Debugf("Stderr: %v", stderr.String())
+	}
+	return &stdout, nil
+}

--- a/plugin/data/list.go
+++ b/plugin/data/list.go
@@ -1,0 +1,67 @@
+package data
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"html/template"
+	"strings"
+
+	"github.com/puppetlabs/wash/plugin"
+)
+
+type listableEntry struct {
+	entry `yaml:",inline"`
+}
+
+func (l *listableEntry) LS(ctx context.Context) ([]plugin.Entry, error) {
+	if l.Enum != nil {
+		entries := make([]plugin.Entry, len(l.Enum))
+		for i, name := range l.Enum {
+			entries[i] = newCopy(name, l, l.Proto)
+		}
+		return entries, nil
+	}
+
+	if l.List == "" {
+		return nil, fmt.Errorf("enum or list are required for %v", l.Name())
+	}
+
+	output, err := invoke(l.List, l)
+	if err != nil {
+		return nil, err
+	}
+
+	entries := make([]plugin.Entry, 0)
+	if l.Post != "" {
+		// Require structured JSON input
+		var data map[string]interface{}
+		dec := json.NewDecoder(output)
+		if err := dec.Decode(&data); err != nil {
+			return nil, err
+		}
+
+		t, err := template.New("process list").Parse(l.Post)
+		if err != nil {
+			return nil, err
+		}
+		var buf bytes.Buffer
+		if err = t.Execute(&buf, data); err != nil {
+			return nil, err
+		}
+		output = &buf
+	}
+
+	// Require a list of names
+	scanner := bufio.NewScanner(output)
+	for scanner.Scan() {
+		entries = append(entries, newCopy(strings.TrimSpace(scanner.Text()), l, l.Proto))
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return entries, nil
+}

--- a/plugin/data/root.go
+++ b/plugin/data/root.go
@@ -1,0 +1,31 @@
+package data
+
+import (
+	"io/ioutil"
+
+	"gopkg.in/yaml.v2"
+)
+
+// Root of the YAML plugin adapter
+type Root struct {
+	listableEntry `yaml:",inline"`
+}
+
+// Init does nothing.
+func (r *Root) Init() error {
+	return nil
+}
+
+// NewRoot loads the plugin description at path and returns a new plugin root.
+func NewRoot(path string) (*Root, error) {
+	input, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var plugin Root
+	if err := yaml.Unmarshal(input, &plugin); err != nil {
+		return nil, err
+	}
+	return &plugin, nil
+}

--- a/plugin/data/structure.go
+++ b/plugin/data/structure.go
@@ -1,0 +1,78 @@
+package data
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/puppetlabs/wash/plugin"
+)
+
+// Entry is the representation of a resource.
+//
+// Name can be omitted for all but the root entry. The act of listing entries will fill 'name'.
+//
+// The presence of 'enum' or 'list' enables LS(), and either the names of child entries or how to
+// query them. 'list' must produce a list of names.
+//
+// If 'post' and 'list' are both present, 'list' must instead produce JSON data, and 'post' will be
+// used to process the result of executing 'list'. 'list' can be templated to access fields of the
+// entry, and 'post' can be templated to access the resulting structured data from 'list'.
+//
+// The 'entry' field can be used to populate the child entries produced from 'enum' or 'list'.
+//
+// Metadata specifies how to retrieve metadata (if provided).
+type entry struct {
+	Label  string `yaml:"name"`
+	Parent plugin.Entry
+
+	Enum  []string `yaml:"enum,omitempty"`
+	List  string   `yaml:"list"`
+	Post  string   `yaml:"post"`
+	Proto *entry   `yaml:"proto"`
+
+	Meta string `yaml:"metadata"`
+}
+
+func (e *entry) Name() string {
+	return e.Label
+}
+
+func (e *entry) CacheConfig() *plugin.CacheConfig {
+	return nil
+}
+
+func (e *entry) Metadata(context.Context) (plugin.MetadataMap, error) {
+	if e.Meta == "" {
+		return plugin.MetadataMap{}, nil
+	}
+
+	output, err := invoke(e.Meta, e)
+	if err != nil {
+		return nil, err
+	}
+
+	var data plugin.MetadataMap
+	dec := json.NewDecoder(output)
+	if err := dec.Decode(&data); err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}
+
+func newCopy(name string, parent plugin.Entry, example *entry) plugin.Entry {
+	if example != nil && (example.List != "" || example.Enum != nil) {
+		newEntry := listableEntry{*example}
+		newEntry.Label = name
+		newEntry.Parent = parent
+		return &newEntry
+	}
+
+	var newEntry entry
+	if example != nil {
+		newEntry = *example
+	}
+	newEntry.Label = name
+	newEntry.Parent = parent
+	return &newEntry
+}


### PR DESCRIPTION
Supports describing a plugin via a YAML file that describes how to
create its hierarchical structure. Currently only supports listing
things.

Try adding `--plugin examples/data-plugin.yaml` to see the kubernetes2
plugin.