### PR TITLE
Return fuse.ENOENT in dir#Lookup instead of LS' error

### DIFF
--- a/fuse/dir.go
+++ b/fuse/dir.go
@@ -64,7 +64,7 @@ func (d *dir) Lookup(ctx context.Context, req *fuse.LookupRequest, resp *fuse.Lo
 	entries, err := d.children(ctx)
 	if err != nil {
 		log.Warnf("FUSE: Error[Find,%v,%v]: %v", d, req.Name, err)
-		return nil, err
+		return nil, fuse.ENOENT
 	}
 
 	for _, entry := range entries {


### PR DESCRIPTION
Previously, dir#Lookup would return LS' error. This resulted in some
strange I/O error messages being printed by common shell commands (e.g.
like cd).

This commit modifies dir#Lookup to return ENOENT instead. Wash already
logs LS' error message, so this should be OK.

Fixes #98.