### PR TITLE
Use golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,3 @@
+linters:
+  enable:
+    - errcheck

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,15 +11,10 @@ env:
 jobs:
   include:
   - name: Test Go stable
-  - name: Lint errcheck, golint, staticcheck
+  - name: Lint with golangci-lint
     before_script:
-    - go get -v github.com/kisielk/errcheck golang.org/x/lint/golint
-    - sudo curl -L https://github.com/dominikh/go-tools/releases/download/2019.1/staticcheck_linux_amd64 -o /usr/bin/staticcheck
-    - sudo chmod +x /usr/bin/staticcheck
-    script:
-    - errcheck ./...
-    - golint -set_exit_status ./...
-    - staticcheck ./...
+    - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.15.0
+    script: golangci-lint run -v
   - name: Build Docker container
     install: skip
     script: docker build .

--- a/staticcheck.conf
+++ b/staticcheck.conf
@@ -1,1 +1,0 @@
-checks = ["inherit", "-ST1005"]

--- a/volume/helpers_test.go
+++ b/volume/helpers_test.go
@@ -50,20 +50,20 @@ func TestStatParse(t *testing.T) {
 		Size:  0,
 	}, attr)
 
-	attr, _, err = StatParse("stat: failed")
+	_, _, err = StatParse("stat: failed")
 	assert.Equal(t, errors.New("Stat did not return 6 components: stat: failed"), err)
 
-	attr, _, err = StatParse("-1 1550611510 1550611448 1550611448 41ed mnt/path")
+	_, _, err = StatParse("-1 1550611510 1550611448 1550611448 41ed mnt/path")
 	if assert.NotNil(t, err) {
 		assert.Equal(t, &strconv.NumError{Func: "ParseUint", Num: "-1", Err: strconv.ErrSyntax}, err)
 	}
 
-	attr, _, err = StatParse("0 2019-01-01 2019-01-01 2019-01-01 41ed mnt/path")
+	_, _, err = StatParse("0 2019-01-01 2019-01-01 2019-01-01 41ed mnt/path")
 	if assert.NotNil(t, err) {
 		assert.Equal(t, &strconv.NumError{Func: "ParseInt", Num: "2019-01-01", Err: strconv.ErrSyntax}, err)
 	}
 
-	attr, _, err = StatParse("96 1550611510 1550611448 1550611448 zebra mnt/path")
+	_, _, err = StatParse("96 1550611510 1550611448 1550611448 zebra mnt/path")
 	if assert.NotNil(t, err) {
 		assert.Equal(t, &strconv.NumError{Func: "ParseUint", Num: "zebra", Err: strconv.ErrSyntax}, err)
 	}


### PR DESCRIPTION
Includes errcheck, golint, and staticcheck, as well as other static
analysis tools. Provides a nice interface and does a single parse pass
to speed up checking.

Lyra is also planning to adopt it:
https://github.com/lyraproj/lyra/issues/157.