### PR TITLE
Extract types from api package to a separate apitypes package

### DIFF
--- a/api/list.go
+++ b/api/list.go
@@ -6,22 +6,10 @@ import (
 	"net/http"
 
 	"github.com/gorilla/mux"
+	apitypes "github.com/puppetlabs/wash/api/types"
 	"github.com/puppetlabs/wash/plugin"
 	log "github.com/sirupsen/logrus"
 )
-
-// ListEntry represents a single entry from the result of issuing a wash "list"
-// request.
-//
-// TODO: We should put all the API-specific types in a separate package so that
-// clients do not have to import everything in api only to use a small subset
-// of its functionality (the response types).
-type ListEntry struct {
-	Actions    []string             `json:"actions"`
-	Name       string               `json:"name"`
-	Attributes plugin.Attributes    `json:"attributes"`
-	Errors     map[string]*ErrorObj `json:"errors"`
-}
 
 var listHandler handler = func(w http.ResponseWriter, r *http.Request) *errorResponse {
 	if r.Method != http.MethodGet {
@@ -47,11 +35,11 @@ var listHandler handler = func(w http.ResponseWriter, r *http.Request) *errorRes
 		return erroredActionResponse(path, listAction, err.Error())
 	}
 
-	info := func(entry plugin.Entry, entryID string) ListEntry {
-		result := ListEntry{
+	info := func(entry plugin.Entry, entryID string) apitypes.ListEntry {
+		result := apitypes.ListEntry{
 			Name:    entry.Name(),
 			Actions: supportedActionsOf(entry),
-			Errors:  make(map[string]*ErrorObj),
+			Errors:  make(map[string]*apitypes.ErrorObj),
 		}
 
 		err := plugin.FillAttr(r.Context(), entry, entryID, &result.Attributes)
@@ -62,7 +50,7 @@ var listHandler handler = func(w http.ResponseWriter, r *http.Request) *errorRes
 		return result
 	}
 
-	result := make([]ListEntry, len(entries)+1)
+	result := make([]apitypes.ListEntry, len(entries)+1)
 	result[0] = info(group, groupID)
 	result[0].Name = "."
 

--- a/api/types/error.go
+++ b/api/types/error.go
@@ -1,0 +1,26 @@
+package apitypes
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// ErrorFields represents the fields of an ErrorObj
+type ErrorFields = map[string]interface{}
+
+// ErrorObj represents an API error object
+type ErrorObj struct {
+	Kind   string      `json:"kind"`
+	Msg    string      `json:"msg"`
+	Fields ErrorFields `json:"fields"`
+}
+
+func (e *ErrorObj) Error() string {
+	jsonBytes, err := json.Marshal(e)
+	if err != nil {
+		// We should never hit this code-path, but better safe than sorry
+		return fmt.Sprintf("Kind: %v, Msg: %v, Fields: %v", e.Kind, e.Msg, e.Fields)
+	}
+
+	return string(jsonBytes)
+}

--- a/api/types/exec.go
+++ b/api/types/exec.go
@@ -1,0 +1,39 @@
+package apitypes
+
+import (
+	"time"
+)
+
+// ExecOptions are options that can be passed as part of an Exec call.
+// These are not identical to plugin.ExecOptions because initially the API only
+// supports receiving a string of input, not a reader.
+type ExecOptions struct {
+	Input string `json:"input"`
+}
+
+// ExecBody encapsulates the payload for a call to a plugin's Exec function
+type ExecBody struct {
+	Cmd  string      `json:"cmd"`
+	Args []string    `json:"args"`
+	Opts ExecOptions `json:"opts"`
+}
+
+// ExecPacketType identifies the packet type.
+type ExecPacketType = string
+
+// Enumerates packet types.
+const (
+	Stdout   ExecPacketType = "stdout"
+	Stderr   ExecPacketType = "stderr"
+	Exitcode ExecPacketType = "exitcode"
+)
+
+// ExecPacket is a single packet of results from an exec.
+// If TypeField is Stdout or Stderr, Data will be a string.
+// If TypeField is Exitcode, Data will be an int (or float64 if deserialized from JSON).
+type ExecPacket struct {
+	TypeField ExecPacketType `json:"type"`
+	Timestamp time.Time      `json:"timestamp"`
+	Data      interface{}    `json:"data"`
+	Err       *ErrorObj      `json:"error"`
+}

--- a/api/types/list.go
+++ b/api/types/list.go
@@ -1,0 +1,14 @@
+package apitypes
+
+import (
+	"github.com/puppetlabs/wash/plugin"
+)
+
+// ListEntry represents a single entry from the result of issuing a wash "list"
+// request.
+type ListEntry struct {
+	Actions    []string             `json:"actions"`
+	Name       string               `json:"name"`
+	Attributes plugin.Attributes    `json:"attributes"`
+	Errors     map[string]*ErrorObj `json:"errors"`
+}

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/puppetlabs/wash/api"
 	"github.com/puppetlabs/wash/api/client"
-	"github.com/puppetlabs/wash/cmd/util"
+	apitypes "github.com/puppetlabs/wash/api/types"
+	cmdutil "github.com/puppetlabs/wash/cmd/util"
 	"github.com/puppetlabs/wash/config"
 	"github.com/spf13/cobra"
 )
@@ -27,15 +27,15 @@ func execCommand() *cobra.Command {
 	return execCmd
 }
 
-func printPackets(pkts <-chan api.ExecPacket) int {
+func printPackets(pkts <-chan apitypes.ExecPacket) int {
 	exit := 0
 	for pkt := range pkts {
 		switch pktType := pkt.TypeField; pktType {
-		case api.Exitcode:
+		case apitypes.Exitcode:
 			exit = int(pkt.Data.(float64))
-		case api.Stdout:
+		case apitypes.Stdout:
 			fmt.Print(pkt.Data)
-		case api.Stderr:
+		case apitypes.Stderr:
 			fmt.Fprint(os.Stderr, pkt.Data)
 		}
 	}
@@ -60,7 +60,7 @@ func execMain(cmd *cobra.Command, args []string) exitCode {
 
 	conn := client.ForUNIXSocket(config.Socket)
 
-	ch, err := conn.Exec(apiPath, command, commandArgs, api.ExecOptions{})
+	ch, err := conn.Exec(apiPath, command, commandArgs, apitypes.ExecOptions{})
 	if err != nil {
 		cmdutil.ErrPrintf("%v\n", err)
 		return exitCode{1}

--- a/cmd/ls.go
+++ b/cmd/ls.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/puppetlabs/wash/api"
 	"github.com/puppetlabs/wash/api/client"
+	apitypes "github.com/puppetlabs/wash/api/types"
 	cmdutil "github.com/puppetlabs/wash/cmd/util"
 	"github.com/puppetlabs/wash/config"
 )
@@ -27,7 +27,7 @@ func lsCommand() *cobra.Command {
 	return lsCmd
 }
 
-func formatListEntries(ls []api.ListEntry) string {
+func formatListEntries(ls []apitypes.ListEntry) string {
 	headers := []cmdutil.ColumnHeader{
 		{ShortName: "size", FullName: "NAME"},
 		{ShortName: "ctime", FullName: "CREATED"},

--- a/cmd/ps.go
+++ b/cmd/ps.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/puppetlabs/wash/api"
 	"github.com/puppetlabs/wash/api/client"
+	apitypes "github.com/puppetlabs/wash/api/types"
 	cmdutil "github.com/puppetlabs/wash/cmd/util"
 	"github.com/puppetlabs/wash/config"
 )
@@ -28,16 +28,16 @@ func psCommand() *cobra.Command {
 	return psCmd
 }
 
-func collectOutput(ch <-chan api.ExecPacket) (string, error) {
+func collectOutput(ch <-chan apitypes.ExecPacket) (string, error) {
 	exit := 0
 	var stdout, stderr string
 	for pkt := range ch {
 		switch pktType := pkt.TypeField; pktType {
-		case api.Exitcode:
+		case apitypes.Exitcode:
 			exit = int(pkt.Data.(float64))
-		case api.Stdout:
+		case apitypes.Stdout:
 			stdout += pkt.Data.(string)
-		case api.Stderr:
+		case apitypes.Stderr:
 			stderr += pkt.Data.(string)
 		}
 	}
@@ -188,7 +188,7 @@ func psMain(cmd *cobra.Command, args []string) exitCode {
 	for i, key := range keys {
 		go func(k string, idx int) {
 			defer wg.Done()
-			ch, err := conn.Exec(k, "sh", []string{}, api.ExecOptions{Input: psScript})
+			ch, err := conn.Exec(k, "sh", []string{}, apitypes.ExecOptions{Input: psScript})
 			if err != nil {
 				cmdutil.ErrPrintf("errored on %v: %v\n", k, err)
 				return


### PR DESCRIPTION
The client and cmd packages previously depended directly on the api
package for type definitions. That exposed a lot more functionality than
is required to use the API. Extract types to a separate package so that
API consumers don't need to depend directly on the api package.