### PR TITLE
Clarify why the `client` package is not called `apiclient`

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -1,5 +1,9 @@
 package client
 
+// This package is named `client` instead of `apiclient` because a client
+// implies an API, so it is a bit redundant. However, because a client implies
+// an API, it makes sense to include this code in an api/client/ directory.
+
 import (
 	"bytes"
 	"context"


### PR DESCRIPTION
This keeps the API client package's naming consistent with apitypes.