### PR TITLE
Add a /cache/... endpoint that accepts DELETE to clear cache entries

### DIFF
--- a/api/cache.go
+++ b/api/cache.go
@@ -1,0 +1,39 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/puppetlabs/wash/journal"
+	"github.com/puppetlabs/wash/plugin"
+	log "github.com/sirupsen/logrus"
+)
+
+var cacheHandler handler = func(w http.ResponseWriter, r *http.Request) *errorResponse {
+	if r.Method != http.MethodDelete {
+		return httpMethodNotSupported(r.Method, r.URL.Path, []string{http.MethodDelete})
+	}
+
+	path := mux.Vars(r)["path"]
+	log.Infof("API: Cache DELETE %v", path)
+
+	ctx := r.Context()
+	journal.Record(ctx, "API: Cache DELETE %v", path)
+	deleted, err := plugin.ClearCacheFor(path)
+	if err != nil {
+		journal.Record(ctx, "API: Cache DELETE flush cache errored constructing regexp from %v: %v", path, err)
+		return unknownErrorResponse(fmt.Errorf("Could not use path %v in a regexp: %v", path, err))
+	}
+
+	w.WriteHeader(http.StatusOK)
+	jsonEncoder := json.NewEncoder(w)
+	if err = jsonEncoder.Encode(deleted); err != nil {
+		journal.Record(ctx, "API: Cache DELETE marshalling %v errored: %v", path, err)
+		return unknownErrorResponse(fmt.Errorf("Could not marshal deleted keys for %v: %v", path, err))
+	}
+
+	journal.Record(ctx, "API: Cache DELETE %v complete: %v", path, deleted)
+	return nil
+}

--- a/api/cache_test.go
+++ b/api/cache_test.go
@@ -1,0 +1,92 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gorilla/mux"
+	apitypes "github.com/puppetlabs/wash/api/types"
+	"github.com/puppetlabs/wash/plugin"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+)
+
+type CacheHandlerTestSuite struct {
+	suite.Suite
+	router *mux.Router
+}
+
+func (suite *CacheHandlerTestSuite) SetupSuite() {
+	plugin.InitCache()
+	suite.router = mux.NewRouter()
+	suite.router.Handle("/cache/{path:.*}", cacheHandler)
+}
+
+func (suite *CacheHandlerTestSuite) TearDownSuite() {
+	plugin.TeardownCache()
+}
+
+func (suite *CacheHandlerTestSuite) TestRejectsGet() {
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/cache/foo", nil)
+	w := httptest.NewRecorder()
+	suite.router.ServeHTTP(w, req)
+	suite.Equal(http.StatusNotFound, w.Code)
+	var resp apitypes.ErrorObj
+	if suite.Nil(json.Unmarshal(w.Body.Bytes(), &resp)) {
+		suite.Equal("puppetlabs.wash/http-method-not-supported", resp.Kind)
+		suite.Equal("The GET method is not supported for /cache/foo, supported methods are: DELETE", resp.Msg)
+		suite.Equal(apitypes.ErrorFields{"method": "GET", "path": "/cache/foo", "supported": []interface{}{"DELETE"}}, resp.Fields)
+	}
+}
+
+func (suite *CacheHandlerTestSuite) TestClearCache() {
+	// Populate the cache with a mocked resource and plugin.Cached*
+	var group mockedGroup
+	group.On("List", mock.Anything).Return([]plugin.Entry{}, nil)
+
+	if children, err := plugin.CachedList(context.Background(), &group, "/dir"); suite.Nil(err) {
+		suite.Equal([]plugin.Entry{}, children)
+	}
+
+	// Test clearing a different cache
+	req := httptest.NewRequest(http.MethodDelete, "http://example.com/cache/file", nil)
+	w := httptest.NewRecorder()
+	suite.router.ServeHTTP(w, req)
+	suite.Equal(http.StatusOK, w.Code)
+	suite.Equal("[]\n", w.Body.String())
+
+	if children, err := plugin.CachedList(context.Background(), &group, "/dir"); suite.Nil(err) {
+		suite.Equal([]plugin.Entry{}, children)
+	}
+
+	// Test clearing the cache
+	req = httptest.NewRequest(http.MethodDelete, "http://example.com/cache/dir", nil)
+	w = httptest.NewRecorder()
+	suite.router.ServeHTTP(w, req)
+	suite.Equal(http.StatusOK, w.Code)
+	suite.Equal(`["List::/dir"]`, strings.TrimSpace(w.Body.String()))
+
+	if children, err := plugin.CachedList(context.Background(), &group, "/dir"); suite.Nil(err) {
+		suite.Equal([]plugin.Entry{}, children)
+	}
+
+	group.AssertNumberOfCalls(suite.T(), "List", 2)
+}
+
+func TestCacheHandler(t *testing.T) {
+	suite.Run(t, new(CacheHandlerTestSuite))
+}
+
+type mockedGroup struct {
+	plugin.EntryBase
+	mock.Mock
+}
+
+func (g *mockedGroup) List(ctx context.Context) ([]plugin.Entry, error) {
+	args := g.Called(ctx)
+	return args.Get(0).([]plugin.Entry), args.Error(1)
+}

--- a/api/client/client.go
+++ b/api/client/client.go
@@ -74,7 +74,7 @@ func (c *DomainSocketClient) doRequest(method, endpoint string, body io.Reader) 
 }
 
 func (c *DomainSocketClient) getRequest(endpoint string, result interface{}) error {
-	respBody, err := c.doRequest("GET", endpoint, nil)
+	respBody, err := c.doRequest(http.MethodGet, endpoint, nil)
 	if err != nil {
 		log.Printf("Error performing GET request: %v", err)
 		return err
@@ -130,7 +130,7 @@ func (c *DomainSocketClient) Exec(path string, command string, args []string, op
 		return nil, err
 	}
 
-	respBody, err := c.doRequest("POST", endpoint, bytes.NewReader(jsonBody))
+	respBody, err := c.doRequest(http.MethodPost, endpoint, bytes.NewReader(jsonBody))
 	if err != nil {
 		log.Printf("Error performing POST request: %v", err)
 		return nil, err

--- a/api/server.go
+++ b/api/server.go
@@ -79,6 +79,7 @@ func StartAPI(registry *plugin.Registry, socketPath string) (chan<- context.Cont
 	r.Handle("/fs/read/{path:.+}", readHandler)
 	r.Handle("/fs/stream/{path:.+}", streamHandler)
 	r.Handle("/fs/exec/{path:.+}", execHandler)
+	r.Handle("/cache/{path:.*}", cacheHandler)
 
 	r.Use(addPluginRegistryAndJournalIDMiddleware)
 

--- a/datastore/cache.go
+++ b/datastore/cache.go
@@ -1,6 +1,7 @@
 package datastore
 
 import (
+	"regexp"
 	"time"
 
 	"github.com/hashicorp/vault/helper/locksutil"
@@ -92,4 +93,20 @@ func (cache *MemCache) Flush() {
 		cache.instance.DeleteExpired()
 	}
 	cache.instance.Flush()
+}
+
+// Delete removes entries from the cache that match the provided regexp.
+func (cache *MemCache) Delete(matcher *regexp.Regexp) []string {
+	items := cache.instance.Items()
+	deleted := make([]string, 0, len(items))
+	for k := range items {
+		if matcher.MatchString(k) {
+			log.Infof("Deleting cache entry %v", k)
+			cache.instance.Delete(k)
+			deleted = append(deleted, k)
+		} else {
+			log.Infof("Skipping %v", k)
+		}
+	}
+	return deleted
 }

--- a/datastore/cache_test.go
+++ b/datastore/cache_test.go
@@ -1,0 +1,35 @@
+package datastore
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type MemCacheTestSuite struct {
+	suite.Suite
+	mem *MemCache
+}
+
+func (suite *MemCacheTestSuite) SetupTest() {
+	suite.mem = NewMemCache()
+}
+
+func (suite *MemCacheTestSuite) TestClearCache() {
+	suite.mem.instance.SetDefault("an entry", struct{}{})
+	suite.mem.instance.SetDefault("another entry", struct{}{})
+	suite.NotNil(suite.mem.instance.Get("an entry"))
+
+	matcher, err := regexp.Compile("^.*n e.*$")
+	suite.Nil(err)
+	deleted := suite.mem.Delete(matcher)
+	suite.Equal([]string{"an entry"}, deleted)
+
+	suite.Nil(suite.mem.instance.Get("an entry"))
+	suite.NotNil(suite.mem.instance.Get("another entry"))
+}
+
+func TestMemCache(t *testing.T) {
+	suite.Run(t, new(MemCacheTestSuite))
+}

--- a/plugin/cache_test.go
+++ b/plugin/cache_test.go
@@ -1,0 +1,73 @@
+package plugin
+
+import (
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+)
+
+type updater struct {
+	mock.Mock
+}
+
+func (u *updater) Update() (interface{}, error) {
+	args := u.Called()
+	return args.Get(0), args.Error(1)
+}
+
+func cacheInit() (interface{}, error) { return struct{}{}, nil }
+
+type CacheTestSuite struct {
+	suite.Suite
+}
+
+func (suite *CacheTestSuite) SetupTest() {
+	InitCache()
+}
+
+func (suite *CacheTestSuite) getOrUpdate(key string, init func() (interface{}, error)) {
+	_, err := cache.GetOrUpdate(key, 30*time.Second, false, init)
+	suite.Nil(err)
+}
+
+func (suite *CacheTestSuite) TestClearCache() {
+	suite.getOrUpdate("Test::/", cacheInit)
+	deleted, err := ClearCacheFor("/")
+	if suite.Nil(err) {
+		suite.Equal([]string{"Test::/"}, deleted)
+	}
+
+	var m updater
+	m.On("Update").Return("hello", nil)
+	suite.getOrUpdate("Test::/", m.Update)
+	m.AssertExpectations(suite.T())
+}
+
+func (suite *CacheTestSuite) TestClearMultiple() {
+	suite.getOrUpdate("Test::/", cacheInit)
+	suite.getOrUpdate("Test::/a", cacheInit)
+	suite.getOrUpdate("Test::/a/b", cacheInit)
+	suite.getOrUpdate("Test::/ab", cacheInit)
+
+	deleted, err := ClearCacheFor("a")
+	if suite.Nil(err) {
+		sort.Strings(deleted)
+		suite.Equal([]string{"Test::/a", "Test::/a/b"}, deleted)
+	}
+
+	var m updater
+	m.On("Update").Return("hello", nil)
+	suite.getOrUpdate("Test::/", m.Update)
+	suite.getOrUpdate("Test::/a", m.Update)
+	suite.getOrUpdate("Test::/a/b", m.Update)
+	suite.getOrUpdate("Test::/ab", m.Update)
+	m.AssertNumberOfCalls(suite.T(), "Update", 2)
+	m.AssertExpectations(suite.T())
+}
+
+func TestCache(t *testing.T) {
+	suite.Run(t, new(CacheTestSuite))
+}

--- a/plugin/docker/volume.go
+++ b/plugin/docker/volume.go
@@ -37,7 +37,7 @@ func newVolume(c *client.Client, v *types.Volume) (*volume, error) {
 		client:    c,
 		startTime: startTime,
 	}
-	vol.CacheConfig().SetTTLOf(plugin.List, 30*time.Second)
+	vol.CacheConfig().SetTTLOf(plugin.List, 60*time.Second)
 
 	return vol, nil
 }

--- a/plugin/kubernetes/pvc.go
+++ b/plugin/kubernetes/pvc.go
@@ -35,7 +35,7 @@ func newPVC(pi typedv1.PersistentVolumeClaimInterface, pd typedv1.PodInterface, 
 		podi:      pd,
 		startTime: p.CreationTimestamp.Time,
 	}
-	vol.CacheConfig().SetTTLOf(plugin.List, 30*time.Second)
+	vol.CacheConfig().SetTTLOf(plugin.List, 60*time.Second)
 
 	return vol
 }

--- a/volume/file.go
+++ b/volume/file.go
@@ -26,7 +26,7 @@ func NewFile(name string, attr plugin.Attributes, cb ContentCB, path string) *Fi
 		contentcb: cb,
 		path:      path,
 	}
-	vf.CacheConfig().SetTTLOf(plugin.Open, 30*time.Second)
+	vf.CacheConfig().SetTTLOf(plugin.Open, 60*time.Second)
 
 	return vf
 }


### PR DESCRIPTION
Adds a `/cache/{path:.*}` that allows deleting entries from the cache.
Any entries that match or are children of the supplied `path` will be
deleted.

Also increases default cache expiration to 15s and expiration for slow
operations to 60s.

Resolves #105.