### PR TITLE
Add AWS plugin with S3 support

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -17,6 +17,7 @@ import (
 	"github.com/puppetlabs/wash/config"
 	"github.com/puppetlabs/wash/fuse"
 	"github.com/puppetlabs/wash/plugin"
+	"github.com/puppetlabs/wash/plugin/aws"
 	"github.com/puppetlabs/wash/plugin/docker"
 	"github.com/puppetlabs/wash/plugin/kubernetes"
 
@@ -181,6 +182,7 @@ func loadPlugin(registry *plugin.Registry, name string, root plugin.Root) {
 
 func loadInternalPlugins(registry *plugin.Registry) {
 	log.Info("Loading internal plugins")
+	loadPlugin(registry, "aws", &aws.Root{})
 	loadPlugin(registry, "docker", &docker.Root{})
 	loadPlugin(registry, "kubernetes", &kubernetes.Root{})
 	log.Info("Finished loading internal plugins")

--- a/fuse/file.go
+++ b/fuse/file.go
@@ -97,6 +97,10 @@ func (fh fileHandle) Release(ctx context.Context, req *fuse.ReleaseRequest) erro
 }
 
 // Read fills a buffer with the requested amount of data from the file.
+//
+// TODO: Pass the ctx into ReadAt. This is useful when the reader's API
+// lets you start from a specified offset when reading the data (e.g. like
+// AWS w/ S3 objects).
 func (fh fileHandle) Read(ctx context.Context, req *fuse.ReadRequest, resp *fuse.ReadResponse) error {
 	ctx = context.WithValue(ctx, journal.Key, journal.PIDToID(int(req.Pid)))
 

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/InVisionApp/tabular v0.3.0
 	github.com/Microsoft/go-winio v0.4.11 // indirect
 	github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 // indirect
+	github.com/aws/aws-sdk-go v1.17.14
 	github.com/docker/distribution v2.7.0+incompatible // indirect
 	github.com/docker/docker v1.13.1
 	github.com/docker/go-connections v0.4.0 // indirect
@@ -55,6 +56,7 @@ require (
 	google.golang.org/genproto v0.0.0-20181219182458-5a97ab628bfb // indirect
 	google.golang.org/grpc v1.17.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
+	gopkg.in/go-ini/ini.v1 v1.42.0
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.2.2
 	gotest.tools v2.2.0+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,8 @@ github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEV
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6 h1:G1bPvciwNyF7IUmKXNt9Ak3m6u9DE1rF+RmtIkBpVdA=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
+github.com/aws/aws-sdk-go v1.17.14 h1:IjqZDIQoLyZ48A93BxVrZOaIGgZPRi4nXt6WQUMJplY=
+github.com/aws/aws-sdk-go v1.17.14/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/client9/misspell v0.3.4 h1:ta993UF76GwbvJcIo3Y68y/M3WxlpEHPWIGDkJYwzJI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/coreos/etcd v3.3.10+incompatible h1:jFneRYjIvLMLhDLCzuTuU4rSJUjRplcJQ7pD7MnhC04=
@@ -30,6 +32,7 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/docker/distribution v2.7.0+incompatible h1:neUDAlf3wX6Ml4HdqTrbcOHXtfRN0TFIwt6YFL7N9RU=
 github.com/docker/distribution v2.7.0+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
+github.com/docker/engine v0.0.0-20190109173153-a79fabbfe841 h1:bh+ds2kkOK6xcnfqpoczeccc5Yk9aBfvdSqWHNV6jNg=
 github.com/docker/engine v0.0.0-20190109173153-a79fabbfe841/go.mod h1:3CPr2caMgTHxxIAZgEMd3uLYPDlRvPqCpyeRf6ncPcY=
 github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
@@ -76,6 +79,8 @@ github.com/imdario/mergo v0.3.6 h1:xTNEAn+kxVO7dTZGu0CegyqKZmoWFI0rF8UxjlB2d28=
 github.com/imdario/mergo v0.3.6/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=
+github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/json-iterator/go v1.1.5 h1:gL2yXlmiIo4+t+y32d4WGwOjKGYcGOuyrg46vadswDE=
 github.com/json-iterator/go v1.1.5/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/kisielk/gotool v1.0.0 h1:AV2c/EiW3KqPNT9ZKl07ehoAGi4C5/01Cfbblndcapg=
@@ -184,6 +189,8 @@ google.golang.org/grpc v1.17.0/go.mod h1:6QZJwpn2B+Zp71q/5VxRsJ6NXXVCE5NRUHRo+f3
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/go-ini/ini.v1 v1.42.0 h1:eKFG4TjDEB8wKQ68V7PVMpXsCZn/SENBMbZHqy7UIOs=
+gopkg.in/go-ini/ini.v1 v1.42.0/go.mod h1:M74/hG4RTwbkZyTEZ9iQwM4v6dFD4u6QBjoqT/pM8Kg=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=

--- a/plugin/aws/profile.go
+++ b/plugin/aws/profile.go
@@ -1,0 +1,43 @@
+package aws
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/puppetlabs/wash/journal"
+	"github.com/puppetlabs/wash/plugin"
+)
+
+// profile represents an AWS profile
+type profile struct {
+	plugin.EntryBase
+	resourcesDir []plugin.Entry
+}
+
+func newProfile(ctx context.Context, name string) (*profile, error) {
+	profile := profile{EntryBase: plugin.NewEntry(name)}
+	profile.CacheConfig().TurnOffCaching()
+
+	journal.Record(ctx, "Creating a new AWS session for the %v profile", name)
+
+	// Create the session. SharedConfigEnable tells AWS to load the profile
+	// config from the ~/.aws/credentials and ~/.aws/config files
+	session, err := session.NewSessionWithOptions(session.Options{
+		Profile:           profile.Name(),
+		SharedConfigState: session.SharedConfigEnable,
+	})
+	if err != nil {
+		return nil, err
+	}
+	profile.resourcesDir = []plugin.Entry{newResourcesDir(session)}
+
+	return &profile, nil
+}
+
+// List lists the resources directory
+func (p *profile) List(ctx context.Context) ([]plugin.Entry, error) {
+	return p.resourcesDir, nil
+}
+
+// TODO: Would implementing Metadata make sense here? What kind of information
+// would be useful?

--- a/plugin/aws/resourcesDir.go
+++ b/plugin/aws/resourcesDir.go
@@ -1,0 +1,34 @@
+package aws
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/puppetlabs/wash/plugin"
+)
+
+// resourcesDir represents the <profile>/resources directory
+type resourcesDir struct {
+	plugin.EntryBase
+	session   *session.Session
+	resources []plugin.Entry
+}
+
+func newResourcesDir(session *session.Session) *resourcesDir {
+	resourcesDir := &resourcesDir{
+		EntryBase: plugin.NewEntry("resources"),
+		session:   session,
+	}
+	resourcesDir.CacheConfig().TurnOffCaching()
+
+	resourcesDir.resources = []plugin.Entry{
+		newS3Dir(resourcesDir.session),
+	}
+
+	return resourcesDir
+}
+
+// List lists the available AWS resources
+func (r *resourcesDir) List(ctx context.Context) ([]plugin.Entry, error) {
+	return r.resources, nil
+}

--- a/plugin/aws/root.go
+++ b/plugin/aws/root.go
@@ -1,0 +1,70 @@
+package aws
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/puppetlabs/wash/journal"
+	"github.com/puppetlabs/wash/plugin"
+	"gopkg.in/go-ini/ini.v1"
+)
+
+// Root of the AWS plugin
+type Root struct {
+	plugin.EntryBase
+}
+
+func awsCredentialsFile() string {
+	if filename := os.Getenv("AWS_SHARED_CREDENTIALS_FILE"); len(filename) != 0 {
+		return filename
+	}
+
+	return filepath.Join(os.Getenv("HOME"), ".aws", "credentials")
+}
+
+// Init for root
+func (r *Root) Init() error {
+	r.EntryBase = plugin.NewEntry("aws")
+	r.CacheConfig().SetTTLOf(plugin.List, 5*time.Minute)
+
+	return nil
+}
+
+// List lists the available AWS profiles
+func (r *Root) List(ctx context.Context) ([]plugin.Entry, error) {
+	awsCredentials := awsCredentialsFile()
+	if _, err := os.Stat(awsCredentials); err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("could not load any profiles: the %v file does not exist", awsCredentials)
+		}
+
+		return nil, err
+	}
+
+	journal.Record(ctx, "Loading the profiles from %v", awsCredentials)
+
+	config, err := ini.Load(awsCredentials)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read %v: %v", awsCredentials, err)
+	}
+
+	var profiles []plugin.Entry
+	for _, section := range config.Sections() {
+		name := section.Name()
+		if name == "DEFAULT" {
+			continue
+		}
+
+		profile, err := newProfile(ctx, name)
+		if err != nil {
+			return nil, err
+		}
+
+		profiles = append(profiles, profile)
+	}
+
+	return profiles, nil
+}

--- a/plugin/aws/s3Bucket.go
+++ b/plugin/aws/s3Bucket.go
@@ -1,0 +1,118 @@
+package aws
+
+import (
+	"context"
+	"fmt"
+	"path"
+
+	"github.com/puppetlabs/wash/journal"
+	"github.com/puppetlabs/wash/plugin"
+
+	awsSDK "github.com/aws/aws-sdk-go/aws"
+	s3Client "github.com/aws/aws-sdk-go/service/s3"
+)
+
+// listObjects is a helper that lists the objects which start with a specific
+// prefix. We don't make it a method of s3Bucket because the helper's also
+// used by s3ObjectPrefix. While we could pass-around the same s3Bucket object to all
+// its s3ObjectPrefix children, doing so is not a good idea because (1) it is a bit overkill
+// to pass-around an entire object just to access only one of its methods and (2),
+// it makes it difficult to refresh the shared s3Bucket object when the original object
+// is evicted from the cache.
+func listObjects(ctx context.Context, client *s3Client.S3, bucket string, prefix string) ([]plugin.Entry, error) {
+	// TODO: Figure out what to log into the journal
+
+	request := &s3Client.ListObjectsInput{
+		Bucket:    awsSDK.String(bucket),
+		Prefix:    awsSDK.String(prefix),
+		Delimiter: awsSDK.String("/"),
+	}
+
+	resp, err := client.ListObjectsWithContext(ctx, request)
+	if err != nil {
+		return nil, err
+	}
+
+	// CommonPrefixes represent S3 object prefixes; Contents represent S3 objects.
+	numPrefixes := len(resp.CommonPrefixes)
+	numObjects := len(resp.Contents)
+	entries := make([]plugin.Entry, numPrefixes+numObjects)
+
+	journal.Record(
+		ctx,
+		"(Bucket %v, Prefix %v): Retrieved %v prefixes and %v objects",
+		bucket,
+		prefix,
+		numPrefixes,
+		numObjects,
+	)
+
+	for i, p := range resp.CommonPrefixes {
+		prefix := awsSDK.StringValue(p.Prefix)
+		entries[i] = newS3ObjectPrefix(bucket, prefix, client)
+	}
+
+	for i, o := range resp.Contents {
+		request := &s3Client.HeadObjectInput{
+			Bucket: awsSDK.String(bucket),
+			Key:    o.Key,
+		}
+
+		key := awsSDK.StringValue(o.Key)
+		name := path.Base(key)
+
+		// TODO: Once https://github.com/puppetlabs/wash/issues/123
+		// is resolved, we should move the HeadObject calls over to
+		// s3Object and cache its response.
+		resp, err := client.HeadObjectWithContext(ctx, request)
+		if err != nil {
+			// TODO: Should we log a warning here instead?
+			return nil, fmt.Errorf("could not get the metadata + attributes for object %v: %v", name, err)
+		}
+
+		attr := plugin.Attributes{
+			Mtime: awsSDK.TimeValue(resp.LastModified),
+			// TODO: Check for a negative size
+			Size: uint64(awsSDK.Int64Value(resp.ContentLength)),
+		}
+
+		// TODO: Right now, resp.Metadata includes the user-specified
+		// metadata. What else would be useful to include here?
+		//
+		// NOTE: Here's everything returned by HeadObjectOutput:
+		//
+		// https://docs.aws.amazon.com/sdk-for-go/api/service/s3/#HeadObjectOutput
+		//
+		metadata := plugin.ToMetadata(resp.Metadata)
+
+		entries[numPrefixes+i] = newS3Object(attr, metadata, bucket, key, client)
+	}
+
+	return entries, nil
+}
+
+// s3Bucket represents an S3 bucket.
+type s3Bucket struct {
+	plugin.EntryBase
+	attr   plugin.Attributes
+	client *s3Client.S3
+}
+
+func newS3Bucket(name string, attr plugin.Attributes, client *s3Client.S3) *s3Bucket {
+	return &s3Bucket{
+		EntryBase: plugin.NewEntry(name),
+		attr:      attr,
+		client:    client,
+	}
+}
+
+func (b *s3Bucket) List(ctx context.Context) ([]plugin.Entry, error) {
+	return listObjects(ctx, b.client, b.Name(), "")
+}
+
+func (b *s3Bucket) Attr() plugin.Attributes {
+	return b.attr
+}
+
+// TODO: Implement Metadata. What would be useful information that we could
+// include here?

--- a/plugin/aws/s3Dir.go
+++ b/plugin/aws/s3Dir.go
@@ -1,0 +1,68 @@
+package aws
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/puppetlabs/wash/journal"
+	"github.com/puppetlabs/wash/plugin"
+
+	awsSDK "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	s3Client "github.com/aws/aws-sdk-go/service/s3"
+)
+
+// s3Dir represents the resources/s3 directory
+type s3Dir struct {
+	plugin.EntryBase
+	session *session.Session
+	client  *s3Client.S3
+}
+
+func newS3Dir(session *session.Session) *s3Dir {
+	return &s3Dir{
+		EntryBase: plugin.NewEntry("s3"),
+		session:   session,
+		client:    s3Client.New(session),
+	}
+}
+
+// List lists the buckets.
+func (s *s3Dir) List(ctx context.Context) ([]plugin.Entry, error) {
+	resp, err := s.client.ListBucketsWithContext(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	journal.Record(ctx, "Listing %v S3 buckets", len(resp.Buckets))
+
+	buckets := make([]plugin.Entry, len(resp.Buckets))
+	for i, bucket := range resp.Buckets {
+		name := bucket.Name
+
+		locRequest := &s3Client.GetBucketLocationInput{
+			Bucket: name,
+		}
+		resp, err := s.client.GetBucketLocationWithContext(ctx, locRequest)
+		if err != nil {
+			// TODO: Should we log a warning and continue instead of returning an
+			// error?
+			return nil, fmt.Errorf("could not get the region of bucket %v: %v", name, err)
+		}
+
+		cfg := awsSDK.NewConfig()
+		cfg.WithRegion(awsSDK.StringValue(resp.LocationConstraint))
+
+		attr := plugin.Attributes{
+			Ctime: awsSDK.TimeValue(bucket.CreationDate),
+		}
+
+		buckets[i] = newS3Bucket(
+			awsSDK.StringValue(name),
+			attr,
+			s3Client.New(s.session, cfg),
+		)
+	}
+
+	return buckets, nil
+}

--- a/plugin/aws/s3Object.go
+++ b/plugin/aws/s3Object.go
@@ -1,0 +1,109 @@
+package aws
+
+import (
+	"context"
+	"errors"
+	"io"
+	"path"
+	"strconv"
+
+	"github.com/puppetlabs/wash/journal"
+	"github.com/puppetlabs/wash/plugin"
+
+	awsSDK "github.com/aws/aws-sdk-go/aws"
+	s3Client "github.com/aws/aws-sdk-go/service/s3"
+)
+
+// s3Object represents an S3 object.
+type s3Object struct {
+	plugin.EntryBase
+	attr     plugin.Attributes
+	metadata plugin.MetadataMap
+	bucket   string
+	key      string
+	client   *s3Client.S3
+}
+
+func newS3Object(attr plugin.Attributes, metadata plugin.MetadataMap, bucket string, key string, client *s3Client.S3) *s3Object {
+	o := &s3Object{
+		EntryBase: plugin.NewEntry(path.Base(key)),
+		attr:      attr,
+		metadata:  metadata,
+		bucket:    bucket,
+		key:       key,
+		client:    client,
+	}
+	o.CacheConfig().TurnOffCachingFor(plugin.Metadata)
+
+	return o
+}
+
+func (o *s3Object) Attr() plugin.Attributes {
+	return o.attr
+}
+
+func (o *s3Object) Metadata(ctx context.Context) (plugin.MetadataMap, error) {
+	return o.metadata, nil
+}
+
+func (o *s3Object) fetchContent(off int64) (io.ReadCloser, error) {
+	request := &s3Client.GetObjectInput{
+		Bucket: awsSDK.String(o.bucket),
+		Key:    awsSDK.String(o.key),
+		Range:  awsSDK.String("bytes=" + strconv.FormatInt(off, 10) + "-"),
+	}
+
+	resp, err := o.client.GetObject(request)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.Body, nil
+}
+
+func (o *s3Object) Open(ctx context.Context) (plugin.SizedReader, error) {
+	return &s3ObjectReader{o}, nil
+}
+
+func (o *s3Object) Stream(context.Context) (io.Reader, error) {
+	return o.fetchContent(0)
+}
+
+// TODO: Optimize this class later. For now, the simple implementation is
+// enough to get `cat` working for small objects and, for large objects, enough
+// to get it to print something to stdout without having to wait for the entire
+// object to be downloaded.
+//
+// https://github.com/kahing/goofys/blob/master/internal/file.go has some prior
+// art we could use to optimize this.
+type s3ObjectReader struct {
+	o *s3Object
+}
+
+func (s *s3ObjectReader) closeContent(content io.ReadCloser) {
+	if err := content.Close(); err != nil {
+		journal.Record(context.Background(), "aws.s3ObjectReader.ReadAt: failed to close %v's content: %v", s.o.key, err)
+	}
+}
+
+func (s *s3ObjectReader) ReadAt(p []byte, off int64) (int, error) {
+	if off < 0 {
+		return 0, errors.New("aws.s3ObjectReader.ReadAt: negative offset")
+	}
+
+	if off >= s.Size() {
+		return 0, io.EOF
+	}
+
+	content, err := s.o.fetchContent(off)
+	if err != nil {
+		return 0, err
+	}
+	defer s.closeContent(content)
+
+	return io.ReadFull(content, p)
+}
+
+func (s *s3ObjectReader) Size() int64 {
+	return int64(s.o.Attr().Size)
+}

--- a/plugin/aws/s3ObjectPrefix.go
+++ b/plugin/aws/s3ObjectPrefix.go
@@ -1,0 +1,36 @@
+package aws
+
+import (
+	"context"
+	"path"
+
+	"github.com/puppetlabs/wash/plugin"
+
+	s3Client "github.com/aws/aws-sdk-go/service/s3"
+)
+
+// s3ObjectPrefix represents a common prefix shared by a group of
+// S3 objects. Prefixes allow one to view an S3 bucket's contents
+// hierarchically. See https://docs.aws.amazon.com/AmazonS3/latest/dev/ListingKeysHierarchy.html
+// for more details.
+type s3ObjectPrefix struct {
+	plugin.EntryBase
+	bucket string
+	prefix string
+	client *s3Client.S3
+}
+
+func newS3ObjectPrefix(bucket string, prefix string, client *s3Client.S3) *s3ObjectPrefix {
+	return &s3ObjectPrefix{
+		EntryBase: plugin.NewEntry(path.Base(prefix)),
+		bucket:    bucket,
+		prefix:    prefix,
+		client:    client,
+	}
+}
+
+// List lists all S3 objects and S3 object prefixes that are
+// prefixed by the current S3 object prefix
+func (d *s3ObjectPrefix) List(ctx context.Context) ([]plugin.Entry, error) {
+	return listObjects(ctx, d.client, d.bucket, d.prefix)
+}


### PR DESCRIPTION
The AWS plugin is structured as `/aws/<profile>/<resources>/<resource_type>/...`
For S3, this translates to /aws/<profile>/<resources>/s3/<bucket>/<...>
where <...> is the hierarchy of the objects in the bucket. For example,
the S3 bucket "bucket" with objects "foo" and "bar/baz" is modeled as a
directory with the following structure:

```
bucket
  foo
  bar
    baz
```