### PR TITLE
Embed CacheConfig in the Entry interface

### DIFF
--- a/api/cache_test.go
+++ b/api/cache_test.go
@@ -90,7 +90,7 @@ func (suite *CacheHandlerTestSuite) TestRejectsGet() {
 func (suite *CacheHandlerTestSuite) TestClearCache() {
 	// Populate the cache with a mocked resource and plugin.Cached*
 	group := newMockedGroup()
-	group.CacheConfig().SetTestID("/dir")
+	group.SetTestID("/dir")
 	group.On("List", mock.Anything).Return([]plugin.Entry{}, nil)
 
 	if children, err := plugin.CachedList(context.Background(), group); suite.Nil(err) {

--- a/fuse/dir.go
+++ b/fuse/dir.go
@@ -22,7 +22,7 @@ var _ = fs.NodeRequestLookuper(&dir{})
 var _ = fs.HandleReadDirAller(&dir{})
 
 func newDir(e plugin.Group) *dir {
-	return &dir{e, e.CacheConfig().ID()}
+	return &dir{e, e.ID()}
 }
 
 func (d *dir) Entry() plugin.Entry {

--- a/fuse/file.go
+++ b/fuse/file.go
@@ -24,7 +24,7 @@ var _ = fs.NodeGetxattrer(&file{})
 var _ = fs.NodeListxattrer(&file{})
 
 func newFile(e plugin.Entry) *file {
-	return &file{e, e.CacheConfig().ID()}
+	return &file{e, e.ID()}
 }
 
 func (f *file) Entry() plugin.Entry {

--- a/plugin/aws/ec2Dir.go
+++ b/plugin/aws/ec2Dir.go
@@ -23,7 +23,7 @@ func newEC2Dir(session *session.Session) *ec2Dir {
 		session:   session,
 		client:    ec2Client.New(session),
 	}
-	ec2Dir.CacheConfig().TurnOffCaching()
+	ec2Dir.TurnOffCaching()
 
 	ec2Dir.entries = []plugin.Entry{
 		newEC2InstancesDir(ec2Dir.session, ec2Dir.client),

--- a/plugin/aws/ec2Instance.go
+++ b/plugin/aws/ec2Instance.go
@@ -73,7 +73,7 @@ func newEC2Instance(ctx context.Context, ID string, session *session.Session, cl
 		cloudwatchClient: cloudwatchlogs.New(session),
 		attr:             attr,
 	}
-	ec2Instance.CacheConfig().TurnOffCachingFor(plugin.List)
+	ec2Instance.TurnOffCachingFor(plugin.List)
 
 	ec2Instance.entries = []plugin.Entry{
 		newEC2InstanceMetadataJSON(ec2Instance),

--- a/plugin/aws/profile.go
+++ b/plugin/aws/profile.go
@@ -16,7 +16,7 @@ type profile struct {
 
 func newProfile(ctx context.Context, name string) (*profile, error) {
 	profile := profile{EntryBase: plugin.NewEntry(name)}
-	profile.CacheConfig().TurnOffCaching()
+	profile.TurnOffCaching()
 
 	journal.Record(ctx, "Creating a new AWS session for the %v profile", name)
 

--- a/plugin/aws/resourcesDir.go
+++ b/plugin/aws/resourcesDir.go
@@ -19,7 +19,7 @@ func newResourcesDir(session *session.Session) *resourcesDir {
 		EntryBase: plugin.NewEntry("resources"),
 		session:   session,
 	}
-	resourcesDir.CacheConfig().TurnOffCaching()
+	resourcesDir.TurnOffCaching()
 
 	resourcesDir.resources = []plugin.Entry{
 		newS3Dir(resourcesDir.session),

--- a/plugin/aws/root.go
+++ b/plugin/aws/root.go
@@ -41,7 +41,7 @@ func awsCredentialsFile() (string, error) {
 // Init for root
 func (r *Root) Init() error {
 	r.EntryBase = plugin.NewEntry("aws")
-	r.CacheConfig().SetTTLOf(plugin.List, 1*time.Minute)
+	r.SetTTLOf(plugin.List, 1*time.Minute)
 
 	return nil
 }

--- a/plugin/aws/s3Object.go
+++ b/plugin/aws/s3Object.go
@@ -33,7 +33,7 @@ func newS3Object(attr plugin.Attributes, metadata plugin.MetadataMap, bucket str
 		key:       key,
 		client:    client,
 	}
-	o.CacheConfig().TurnOffCachingFor(plugin.Metadata)
+	o.TurnOffCachingFor(plugin.Metadata)
 
 	return o
 }

--- a/plugin/docker/root.go
+++ b/plugin/docker/root.go
@@ -23,7 +23,7 @@ func (r *Root) Init() error {
 	}
 
 	r.EntryBase = plugin.NewEntry("docker")
-	r.CacheConfig().TurnOffCaching()
+	r.TurnOffCaching()
 	r.resources = []plugin.Entry{
 		&containers{EntryBase: plugin.NewEntry("containers"), client: dockerCli},
 		&volumes{EntryBase: plugin.NewEntry("volumes"), client: dockerCli},

--- a/plugin/docker/volume.go
+++ b/plugin/docker/volume.go
@@ -37,7 +37,7 @@ func newVolume(c *client.Client, v *types.Volume) (*volume, error) {
 		client:    c,
 		startTime: startTime,
 	}
-	vol.CacheConfig().SetTTLOf(plugin.List, 60*time.Second)
+	vol.SetTTLOf(plugin.List, 60*time.Second)
 
 	return vol, nil
 }

--- a/plugin/entryBase.go
+++ b/plugin/entryBase.go
@@ -1,0 +1,87 @@
+package plugin
+
+import (
+	"flag"
+	"time"
+)
+
+type cacheableOp int8
+
+const (
+	// List represents Group#List
+	List cacheableOp = iota
+	// Open represents Readable#Open
+	Open
+	// Metadata represents Resource#Metadata
+	Metadata
+)
+
+var cacheableOpToNameMap = [3]string{"List", "Open", "Metadata"}
+
+// EntryBase implements Entry, making it easy to create new entries.
+// You should use plugin.NewEntry to create new EntryBase objects.
+type EntryBase struct {
+	name string
+	// id represents the entry's wash ID. It is set in CachedList.
+	id  string
+	ttl [3]time.Duration
+}
+
+// NewEntry creates a new entry
+func NewEntry(name string) EntryBase {
+	e := EntryBase{name: name}
+	for op := range e.ttl {
+		e.SetTTLOf(cacheableOp(op), 15*time.Second)
+	}
+
+	return e
+}
+
+// Name returns the entry's name.
+func (e *EntryBase) Name() string {
+	return e.name
+}
+
+// ID returns the entry's wash ID
+func (e *EntryBase) ID() string {
+	return e.id
+}
+
+// SetTTLOf sets the specified op's TTL
+func (e *EntryBase) SetTTLOf(op cacheableOp, ttl time.Duration) {
+	e.ttl[op] = ttl
+}
+
+// TurnOffCachingFor turns off caching for the specified op
+func (e *EntryBase) TurnOffCachingFor(op cacheableOp) {
+	e.SetTTLOf(op, -1)
+}
+
+// TurnOffCaching turns off caching for all ops
+func (e *EntryBase) TurnOffCaching() {
+	for op := range e.ttl {
+		e.TurnOffCachingFor(cacheableOp(op))
+	}
+}
+
+func (e *EntryBase) getTTLOf(op cacheableOp) time.Duration {
+	return e.ttl[op]
+}
+
+func (e *EntryBase) setID(id string) {
+	e.id = id
+}
+
+// SetTestID sets the entry's cache ID for testing.
+// It can only be called by the tests.
+func (e *EntryBase) SetTestID(id string) {
+	if notRunningTests() {
+		panic("SetTestID can be only be called by the tests")
+	}
+
+	e.setID(id)
+}
+
+func notRunningTests() bool {
+	return flag.Lookup("test.v") == nil
+}

--- a/plugin/entryBase_test.go
+++ b/plugin/entryBase_test.go
@@ -1,0 +1,50 @@
+package plugin
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type EntryBaseTestSuite struct {
+	suite.Suite
+}
+
+func (suite *EntryBaseTestSuite) TestNewEntry() {
+	e := NewEntry("foo")
+	assertOpTTL := func(op cacheableOp, opName string, expectedTTL time.Duration) {
+		actualTTL := e.getTTLOf(op)
+		suite.Equal(
+			expectedTTL,
+			actualTTL,
+			"expected the TTL of %v to be %v, but got %v instead",
+			opName,
+			expectedTTL,
+			actualTTL,
+		)
+	}
+
+	suite.Equal("foo", e.Name())
+	assertOpTTL(List, "List", 15*time.Second)
+	assertOpTTL(Open, "Open", 15*time.Second)
+	assertOpTTL(Metadata, "Metadata", 15*time.Second)
+
+	e.setID("/foo")
+	suite.Equal("/foo", e.ID())
+
+	e.SetTTLOf(List, 40*time.Second)
+	assertOpTTL(List, "List", 40*time.Second)
+
+	e.TurnOffCachingFor(List)
+	assertOpTTL(List, "List", -1)
+
+	e.TurnOffCaching()
+	assertOpTTL(Open, "Open", -1)
+	assertOpTTL(Metadata, "Metadata", -1)
+
+}
+
+func TestEntryBase(t *testing.T) {
+	suite.Run(t, new(EntryBaseTestSuite))
+}

--- a/plugin/externalPluginRoot.go
+++ b/plugin/externalPluginRoot.go
@@ -57,7 +57,6 @@ func (r *ExternalPluginRoot) Init() error {
 
 	r.ExternalPluginEntry = entry
 	r.ExternalPluginEntry.script = script
-	r.ExternalPluginEntry.washPath = "/" + r.Name()
 
 	return nil
 }

--- a/plugin/externalPluginRoot_test.go
+++ b/plugin/externalPluginRoot_test.go
@@ -15,8 +15,8 @@ type ExternalPluginRootTestSuite struct {
 func (suite *ExternalPluginRootTestSuite) TestInit() {
 	mockScript := &mockExternalPluginScript{path: "plugin_script"}
 	root := &ExternalPluginRoot{&ExternalPluginEntry{
-		script:   mockScript,
-		washPath: "/foo",
+		EntryBase: NewEntry("foo"),
+		script:    mockScript,
 	}}
 
 	mockInvokeAndWait := func(stdout []byte, err error) {
@@ -42,10 +42,8 @@ func (suite *ExternalPluginRootTestSuite) TestInit() {
 	if suite.NoError(err) {
 		expectedRoot := &ExternalPluginRoot{
 			ExternalPluginEntry: &ExternalPluginEntry{
-				name:             "foo",
+				EntryBase:        NewEntry("foo"),
 				supportedActions: []string{"list"},
-				cacheConfig:      newCacheConfig(),
-				washPath:         "/foo",
 				script:           root.script,
 			},
 		}

--- a/plugin/helpers.go
+++ b/plugin/helpers.go
@@ -18,11 +18,6 @@ import (
 // DefaultTimeout is the default timeout for prefetching
 var DefaultTimeout = 10 * time.Second
 
-// NewEntry creates a new named entry
-func NewEntry(name string) EntryBase {
-	return EntryBase{name, newCacheConfig()}
-}
-
 // ToMetadata converts an object to a metadata result. If the input is already an array of bytes, it
 // must contain a serialized JSON object. Will panic if given something besides a struct or []byte.
 func ToMetadata(obj interface{}) MetadataMap {

--- a/plugin/helpers_test.go
+++ b/plugin/helpers_test.go
@@ -114,7 +114,7 @@ func newHelpersTestsMockEntry() *helpersTestsMockEntry {
 		EntryBase: NewEntry("mockEntry"),
 	}
 
-	e.CacheConfig().TurnOffCaching()
+	e.TurnOffCaching()
 
 	return e
 }
@@ -134,7 +134,7 @@ func newHelpersTestsMockGroup() *helpersTestsMockGroup {
 		EntryBase: NewEntry("mockEntry"),
 	}
 
-	e.CacheConfig().TurnOffCaching()
+	e.TurnOffCaching()
 
 	return e
 }

--- a/plugin/kubernetes/pvc.go
+++ b/plugin/kubernetes/pvc.go
@@ -35,7 +35,7 @@ func newPVC(pi typedv1.PersistentVolumeClaimInterface, pd typedv1.PodInterface, 
 		podi:      pd,
 		startTime: p.CreationTimestamp.Time,
 	}
-	vol.CacheConfig().SetTTLOf(plugin.List, 60*time.Second)
+	vol.SetTTLOf(plugin.List, 60*time.Second)
 
 	return vol
 }

--- a/plugin/kubernetes/root.go
+++ b/plugin/kubernetes/root.go
@@ -46,7 +46,7 @@ func (r *Root) Init() error {
 	}
 
 	r.EntryBase = plugin.NewEntry("kubernetes")
-	r.CacheConfig().TurnOffCaching()
+	r.TurnOffCaching()
 
 	contexts := make([]plugin.Entry, 0)
 	for name := range raw.Contexts {

--- a/plugin/registry.go
+++ b/plugin/registry.go
@@ -22,8 +22,8 @@ func NewRegistry() *Registry {
 	// CachedList sets the cache IDs of the Plugin roots to
 	// "/<root_name>" (e.g. "/docker", "/kubernetes", "/aws"),
 	// and all other IDs are correctly set to <parent_id> + "/" + <name>.
-	r.CacheConfig().id = ""
-	r.CacheConfig().TurnOffCaching()
+	r.setID("")
+	r.TurnOffCaching()
 
 	return r
 }

--- a/plugin/types.go
+++ b/plugin/types.go
@@ -9,24 +9,18 @@ import (
 
 // ==== Wash Protocols and Resources ====
 
-// Entry is a basic named resource type.
+// Entry is a basic named resource type. It is a sealed
+// interface, meaning you must use plugin.NewEntry when
+// creating your plugin objects.
 type Entry interface {
 	Name() string
-	CacheConfig() *CacheConfig
+	ID() string
+	SetTTLOf(op cacheableOp, ttl time.Duration)
+	TurnOffCachingFor(op cacheableOp)
+	TurnOffCaching()
+	getTTLOf(op cacheableOp) time.Duration
+	setID(id string)
 }
-
-// EntryBase implements Entry, making it easy to create new entries.
-// EntryBase includes a default caching configuration.
-type EntryBase struct {
-	name        string
-	cacheConfig *CacheConfig
-}
-
-// Name returns the entry's name.
-func (e *EntryBase) Name() string { return e.name }
-
-// CacheConfig returns the entry's cache config.
-func (e *EntryBase) CacheConfig() *CacheConfig { return e.cacheConfig }
 
 // MetadataMap maps keys to arbitrary structured data.
 type MetadataMap = map[string]interface{}

--- a/volume/dir.go
+++ b/volume/dir.go
@@ -31,7 +31,7 @@ func NewDir(name string, attr plugin.Attributes, cb ContentCB, path string, dirs
 		path:      path,
 		dirs:      dirs,
 	}
-	vd.CacheConfig().SetTTLOf(plugin.Open, 60*time.Second)
+	vd.SetTTLOf(plugin.Open, 60*time.Second)
 
 	return vd
 }

--- a/volume/file.go
+++ b/volume/file.go
@@ -26,7 +26,7 @@ func NewFile(name string, attr plugin.Attributes, cb ContentCB, path string) *Fi
 		contentcb: cb,
 		path:      path,
 	}
-	vf.CacheConfig().SetTTLOf(plugin.Open, 60*time.Second)
+	vf.SetTTLOf(plugin.Open, 60*time.Second)
 
 	return vf
 }


### PR DESCRIPTION
This commit removes CacheConfig by embedding its methods in the Entry
interface. Doing so makes the code easier to read and maintain because
it avoids passing around a CacheConfig pointer, and it structurally
captures the fact that all entries have cacheable operations.

Additionally, this commit makes plugin.Entry a sealed interface,
which forces internal plugin authors to use plugin.NewEntry when
creating their objects.