### PR TITLE
Add version command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,10 @@ jobs:
   - stage: deploy
     name: Deploy to GitHub Releases
     if: branch = master AND type = push
+    env: LINKFLAGS="-w -s -X github.com/puppetlabs/wash/cmd.version=${TRAVIS_TAG}" CGO_ENABLED=0
     script:
-    - CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -a -installsuffix cgo -ldflags="-w -s" -o ${PROJECT_NAME}-${TRAVIS_TAG}-x86_64-apple-darwin
-    - CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -installsuffix cgo -ldflags="-w -s" -o ${PROJECT_NAME}-${TRAVIS_TAG}-x86_64-unknown-linux
+    - GOOS=darwin GOARCH=amd64 go build -ldflags="$LINKFLAGS" -o ${PROJECT_NAME}-${TRAVIS_TAG}-x86_64-apple-darwin
+    - GOOS=linux GOARCH=amd64 go build -ldflags="$LINKFLAGS" -o ${PROJECT_NAME}-${TRAVIS_TAG}-x86_64-unknown-linux
     deploy:
       provider: releases
       api_key:

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"github.com/puppetlabs/wash/cmd/util"
+	cmdutil "github.com/puppetlabs/wash/cmd/util"
 	"github.com/spf13/cobra"
 )
 
@@ -45,6 +45,7 @@ func rootCommand() *cobra.Command {
 		SilenceErrors: true,
 	}
 
+	rootCmd.AddCommand(versionCommand())
 	rootCmd.AddCommand(serverCommand())
 	rootCmd.AddCommand(metaCommand())
 	rootCmd.AddCommand(lsCommand())

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,27 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// Version is set with `go build -ldflags="-X github.com/puppetlabs/wash/cmd.version=${VERSION}"`
+// as part of tagged builds. A local build might use `cmd.version=$(git describe --always)` instead.
+var version = "unknown"
+
+func versionCommand() *cobra.Command {
+	versionCmd := &cobra.Command{
+		Use:   "version",
+		Short: "Print wash version",
+	}
+
+	versionCmd.RunE = toRunE(versionMain)
+
+	return versionCmd
+}
+
+func versionMain(cmd *cobra.Command, args []string) exitCode {
+	fmt.Println(version)
+	return exitCode{0}
+}


### PR DESCRIPTION
Lists the current version. Version is set with `go build -ldflags="-X
github.com/puppetlabs/wash/cmd.version=${VERSION}"` as part of tagged
builds.

Resolves #144.

Signed-off-by: Michael Smith <michael.smith@puppet.com>