### PR TITLE
Add plugin.CachedOp

### DIFF
--- a/plugin/entryBase_test.go
+++ b/plugin/entryBase_test.go
@@ -12,8 +12,17 @@ type EntryBaseTestSuite struct {
 }
 
 func (suite *EntryBaseTestSuite) TestNewEntry() {
+	suite.Panics(
+		func() { NewEntry("") },
+		"plugin.NewEntry: received an empty name",
+	)
+	suite.Panics(
+		func() { NewEntry("/foo/") },
+		"plugin.NewEntry: received a name containing a /",
+	)
+
 	e := NewEntry("foo")
-	assertOpTTL := func(op cacheableOp, opName string, expectedTTL time.Duration) {
+	assertOpTTL := func(op actionOpCode, opName string, expectedTTL time.Duration) {
 		actualTTL := e.getTTLOf(op)
 		suite.Equal(
 			expectedTTL,

--- a/plugin/externalPluginEntry_test.go
+++ b/plugin/externalPluginEntry_test.go
@@ -116,7 +116,7 @@ func (suite *ExternalPluginEntryTestSuite) TestDecodeExternalPluginEntry() {
 	decodedEntry.CacheTTLs = decodedCacheTTLs{List: 1}
 	entryWithCacheConfig, err := decodedEntry.toExternalPluginEntry()
 	if suite.NoError(err) {
-		expectedTTLs := NewEntry("").ttl
+		expectedTTLs := NewEntry("mock").ttl
 		expectedTTLs[List] = decodedEntry.CacheTTLs.List * time.Second
 		suite.Equal(expectedTTLs, entryWithCacheConfig.EntryBase.ttl)
 	}

--- a/plugin/helpers_test.go
+++ b/plugin/helpers_test.go
@@ -113,7 +113,7 @@ func newHelpersTestsMockEntry() *helpersTestsMockEntry {
 	e := &helpersTestsMockEntry{
 		EntryBase: NewEntry("mockEntry"),
 	}
-
+	e.SetTestID("id")
 	e.TurnOffCaching()
 
 	return e
@@ -133,7 +133,7 @@ func newHelpersTestsMockGroup() *helpersTestsMockGroup {
 	e := &helpersTestsMockGroup{
 		EntryBase: NewEntry("mockEntry"),
 	}
-
+	e.SetTestID("id")
 	e.TurnOffCaching()
 
 	return e

--- a/plugin/registry.go
+++ b/plugin/registry.go
@@ -14,15 +14,10 @@ type Registry struct {
 // NewRegistry creates a new plugin registry object
 func NewRegistry() *Registry {
 	r := &Registry{
-		EntryBase: NewEntry("/"),
+		EntryBase: newEntryBase("/"),
 		plugins:   make(map[string]Root),
 	}
-
-	// Set the registry's ID to the empty string. This way,
-	// CachedList sets the cache IDs of the Plugin roots to
-	// "/<root_name>" (e.g. "/docker", "/kubernetes", "/aws"),
-	// and all other IDs are correctly set to <parent_id> + "/" + <name>.
-	r.setID("")
+	r.setID("/")
 	r.TurnOffCaching()
 
 	return r

--- a/plugin/types.go
+++ b/plugin/types.go
@@ -15,10 +15,10 @@ import (
 type Entry interface {
 	Name() string
 	ID() string
-	SetTTLOf(op cacheableOp, ttl time.Duration)
-	TurnOffCachingFor(op cacheableOp)
+	SetTTLOf(op actionOpCode, ttl time.Duration)
+	TurnOffCachingFor(op actionOpCode)
 	TurnOffCaching()
-	getTTLOf(op cacheableOp) time.Duration
+	getTTLOf(op actionOpCode) time.Duration
 	setID(id string)
 }
 


### PR DESCRIPTION
This commit adds plugin.CachedOp. Plugin authors can use this method
when they need more fine-grained caching than is provided by the
existing CachedList, CachedOpen, and CachedMetadata methods.

This commit also does some small cleanup of the code, specifically:

* plugin.NewEntry now validates that the provided name is non-empty and
that it does not contain a "/". If this validation fails, then Wash will
panic.

* All of the plugin.Cached* methods will panic if entry.ID() is empty
(i.e. if the entry's ID was not set).

* As a consequence of ^, plugin.Registry's ID is now set to "/" instead
of the empty string. This makes more sense since plugin.Registry
represents Wash's root.

Resolves https://github.com/puppetlabs/wash/issues/123

Signed-off-by: Enis Inan <enis.inan@puppet.com>