### PR TITLE
Skip the '/' common prefix for S3 buckets

### DIFF
--- a/plugin/aws/s3Bucket.go
+++ b/plugin/aws/s3Bucket.go
@@ -47,6 +47,10 @@ func listObjects(ctx context.Context, client *s3Client.S3, bucket string, prefix
 
 	for i, p := range resp.CommonPrefixes {
 		prefix := awsSDK.StringValue(p.Prefix)
+		// Skip the top-level '/' prefix, it would be redundant to list it.
+		if prefix == "/" {
+			continue
+		}
 		entries[i] = newS3ObjectPrefix(bucket, prefix, client)
 	}
 

--- a/plugin/entryBase.go
+++ b/plugin/entryBase.go
@@ -2,6 +2,7 @@ package plugin
 
 import (
 	"flag"
+	"fmt"
 	"strings"
 	"time"
 )
@@ -46,7 +47,7 @@ func NewEntry(name string) EntryBase {
 		panic("plugin.NewEntry: received an empty name")
 	}
 	if strings.Contains(name, "/") {
-		panic("plugin.NewEntry: received a name containing a /")
+		panic(fmt.Sprintf("plugin.NewEntry: received name %v containing a /", name))
 	}
 
 	return newEntryBase(name)


### PR DESCRIPTION
Entries can no longer contain '/', and listing it as a subdirectory
would be redundant (its contents are already listed in the base s3
directory).

Fixes #152.

Signed-off-by: Michael Smith <michael.smith@puppet.com>