### PR TITLE
Default region to us-east-1 when not specified

### DIFF
--- a/plugin/aws/s3Dir.go
+++ b/plugin/aws/s3Dir.go
@@ -50,7 +50,11 @@ func (s *s3Dir) List(ctx context.Context) ([]plugin.Entry, error) {
 			return nil, fmt.Errorf("could not get the region of bucket %v: %v", name, err)
 		}
 
-		region := awsSDK.StringValue(resp.LocationConstraint)
+		// The response will be empty if the bucket is in Amazon's default region (us-east-1)
+		region := "us-east-1"
+		if resp.LocationConstraint != nil {
+			region = awsSDK.StringValue(resp.LocationConstraint)
+		}
 
 		cfg := awsSDK.NewConfig()
 		cfg.WithRegion(region)


### PR DESCRIPTION
The S3 API will not return a LocationConstraint for a bucket hosted in
its default region, US East (N. Virginia) aka us-east-1. Explicitly use
this region when no LocationConstraint is returned.

Fixes #153.

Signed-off-by: Michael Smith <michael.smith@puppet.com>