### PR TITLE
Fixes for ps

### DIFF
--- a/cmd/ps.go
+++ b/cmd/ps.go
@@ -62,7 +62,7 @@ pid=$$
 for i in $procs; do
 	if [ -d $i -a ${i#/proc/} -ne $pid ]; then
 	  cmdline=$(cat $i/cmdline | tr '\0' ' ')
-		printf '%s\t%s\t%s' "$cmdline" "$(cat $i/stat)" "$(cat $i/statm)"
+		printf '%s\t%s\t%s\n' "$cmdline" "$(cat $i/stat)" "$(cat $i/statm)"
 	fi
 done
 `
@@ -80,7 +80,7 @@ type psresult struct {
 func parseEntry(line string) (psresult, error) {
 	tokens := strings.Split(strings.TrimSpace(line), "\t")
 	if len(tokens) != 3 {
-		return psresult{}, fmt.Errorf("Line did not have 3 tokens: %v", tokens)
+		return psresult{}, fmt.Errorf("Line had %v, not 3 tokens: %#v", len(tokens), tokens)
 	}
 	stat := string(tokens[1])
 	// statm := tokens[2]

--- a/plugin/docker/container.go
+++ b/plugin/docker/container.go
@@ -78,7 +78,8 @@ func (c *container) Exec(ctx context.Context, cmd string, args []string, opts pl
 	if opts.Stdin != nil {
 		go func() {
 			_, writeErr = io.Copy(resp.Conn, opts.Stdin)
-			journal.Record(ctx, "Closed execution response stream for %v: %v", c.Name(), writeErr)
+			respErr := resp.CloseWrite()
+			journal.Record(ctx, "Closed execution input stream for %v: %v, %v", c.Name(), writeErr, respErr)
 		}()
 	}
 


### PR DESCRIPTION
When exec included input, Docker exec would hang. This was a regression introduced with commit e5f8c80, where it removed closing the write stream after copying input. Restore the call to `CloseWrite` so that `wash ps` works again on Docker containers.

Also fix ps when multiple processes are present on the target.