### PR TITLE
Add goreportcard badge and shrink release packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,14 +21,16 @@ jobs:
     if: branch = master AND type = push
     env: LINKFLAGS="-w -s -X github.com/puppetlabs/wash/cmd.version=${TRAVIS_TAG}" CGO_ENABLED=0
     script:
-    - GOOS=darwin GOARCH=amd64 go build -ldflags="$LINKFLAGS" -o ${PROJECT_NAME}-${TRAVIS_TAG}-x86_64-apple-darwin
-    - GOOS=linux GOARCH=amd64 go build -ldflags="$LINKFLAGS" -o ${PROJECT_NAME}-${TRAVIS_TAG}-x86_64-unknown-linux
+    - GOOS=darwin GOARCH=amd64 go build -ldflags="$LINKFLAGS"
+    - tar czf ${PROJECT_NAME}-${TRAVIS_TAG}-x86_64-apple-darwin.tgz wash
+    - GOOS=linux GOARCH=amd64 go build -ldflags="$LINKFLAGS"
+    - tar czf ${PROJECT_NAME}-${TRAVIS_TAG}-x86_64-unknown-linux.tgz wash
     deploy:
       provider: releases
       api_key:
         secure: PVefYvPRdpOtWvvZEG9wxv2HxjBUQ1/t1XsXQFOuF30/YzjY4EHaYBH/RXtFzuiCqpyk5GA1dWVUSE356Aka2Y3JlqImv1d0n+prrG2fEJBEtaDlR7Q6DeIiONPsCMxWyJ22r+bBz3C1Qq+QwSLzFuTN1XKIQTFdzIaqnIO7rthPNZNSfMmreed6SXfFmnsIcA+7TG+k4iDYz8COSDrYdjaiHnejvHlUiXh9Rfa3LzTdC4rxtOKofbUa9Qei08mSaSuRGD0U0vymOfFKf/QjNuwFmGSbdIH+1KmCOD9MV/47l6xZMDHDL4mLabsDB9ipf9LFAWmN9pQ/a5UoPyh4IXgaP7NeS3ISNlbKSCx7S70In8/whQv7jB8a5dNuo8HtKx0wzdQ9pKDBDt/N3h1YYJhGR2UF4JJd1CkBytRgIKzjZ5D7Ky+j23Vr6/+lvCRL0CN3RvvBP91/rfyO61eW4FGo+J/Es2u5+HPjVST4S4ntZnTDA6I2K1js8AbG1ofalivpcth4i+2zoKANXEjlXgUUI63gypBvyKGgHHouQTzKuyeIPBzlhYCIrQVhN5QG2+Lc9w7A2KqeRm0vxQ9elEKO1i5bSzSxYUXLMVSPkted0+gSPRRp4i67wOUO+1V9cLubbXm8PG1E1DhpiOQnxQb2DnaaVlL1mr3XQVDl6BY=
       file_glob: true
-      file: ${PROJECT_NAME}-${TRAVIS_TAG}-*
+      file: ${PROJECT_NAME}-${TRAVIS_TAG}-*.tgz
       skip_cleanup: true
       on:
         repo: puppetlabs/wash

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # wash (Wide Area SHell)
 
-[![GitHub release](https://img.shields.io/github/release/puppetlabs/wash.svg)](https://github.com/puppetlabs/wash/releases/) [![Build Status](https://travis-ci.com/puppetlabs/wash.svg)](https://travis-ci.com/puppetlabs/wash) [![GoDoc](https://godoc.org/github.com/puppetlabs/wash?status.svg)](https://godoc.org/github.com/puppetlabs/wash)
+[![GitHub release](https://img.shields.io/github/release/puppetlabs/wash.svg)](https://github.com/puppetlabs/wash/releases/) [![Build Status](https://travis-ci.com/puppetlabs/wash.svg)](https://travis-ci.com/puppetlabs/wash) [![GoDoc](https://godoc.org/github.com/puppetlabs/wash?status.svg)](https://godoc.org/github.com/puppetlabs/wash) [![Go Report Card](https://goreportcard.com/badge/github.com/puppetlabs/wash)](https://goreportcard.com/report/github.com/puppetlabs/wash)
 
 `wash` helps you deal with all your remote or cloud-native infrastructure using the UNIX-y patterns and tools you already know and love!
 

--- a/plugin/aws/ec2Instance.go
+++ b/plugin/aws/ec2Instance.go
@@ -479,7 +479,7 @@ func sendEvent(e *cloudwatchlogs.OutputLogEvent, stream *plugin.OutputStream) er
 	//
 	// NOTE: Since SSM uses bufio.Scanner to parse each message, there's a
 	// chance that the printed stdout/stderr stream can end in an extra
-	// newline character. Unfortunately, we don't have an easy way of determing
+	// newline character. Unfortunately, we don't have an easy way of determining
 	// whether the last message did end in a new line, so let this be a known
 	// issue until there's a good reason for us to address it.
 	message := awsSDK.StringValue(e.Message) + "\n"

--- a/plugin/docker/volume.go
+++ b/plugin/docker/volume.go
@@ -128,7 +128,7 @@ func (v *volume) List(ctx context.Context) ([]plugin.Entry, error) {
 func (v *volume) createContainer(ctx context.Context, cmd []string) (string, error) {
 	// Use tty to avoid messing with the extra log formatting.
 	cfg := docontainer.Config{Image: "busybox", Cmd: cmd, Tty: true}
-	mounts := []mount.Mount{mount.Mount{
+	mounts := []mount.Mount{{
 		Type:     mount.TypeVolume,
 		Source:   v.Name(),
 		Target:   mountpoint,

--- a/plugin/kubernetes/pvc.go
+++ b/plugin/kubernetes/pvc.go
@@ -117,12 +117,12 @@ func (v *pvc) createPod(cmd []string) (string, error) {
 		},
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{
-				corev1.Container{
+				{
 					Name:  "busybox",
 					Image: "busybox",
 					Args:  cmd,
 					VolumeMounts: []corev1.VolumeMount{
-						corev1.VolumeMount{
+						{
 							Name:      v.Name(),
 							MountPath: mountpoint,
 							ReadOnly:  true,
@@ -132,7 +132,7 @@ func (v *pvc) createPod(cmd []string) (string, error) {
 			},
 			RestartPolicy: corev1.RestartPolicyNever,
 			Volumes: []corev1.Volume{
-				corev1.Volume{
+				{
 					Name: v.Name(),
 					VolumeSource: corev1.VolumeSource{
 						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{


### PR DESCRIPTION
Tar and gzip builds for release to shrink size to ~28% of uncompressed size for hosting/downloads. This also preserves the executable bit and allows us to leave the executable named `wash` after unpacking.