### PR TITLE
Move the mounted API socket to a secure path

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"path/filepath"
 
 	"github.com/gorilla/mux"
 	apitypes "github.com/puppetlabs/wash/api/types"
@@ -76,14 +77,17 @@ func StartAPI(registry *plugin.Registry, socketPath string) (chan<- context.Cont
 		// Socket already exists, so nuke it and recreate it
 		log.Infof("API: Cleaning up old socket")
 		if err := os.Remove(socketPath); err != nil {
-			log.Warnf("API: %v", err)
+			return nil, nil, err
+		}
+	} else {
+		// Ensure the parent directory for the socket path exists
+		if err := os.MkdirAll(filepath.Dir(socketPath), 0750); err != nil {
 			return nil, nil, err
 		}
 	}
 
 	server, err := net.Listen("unix", socketPath)
 	if err != nil {
-		log.Warnf("API: %v", err)
 		return nil, nil, err
 	}
 

--- a/config/core.go
+++ b/config/core.go
@@ -3,6 +3,8 @@
 package config
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/viper"
@@ -20,7 +22,11 @@ var Socket string
 // Load Wash's config.
 func Load() error {
 	// Set any defaults
-	viper.SetDefault(SocketKey, "/tmp/wash-api.sock")
+	cdir, err := os.UserCacheDir()
+	if err != nil {
+		return err
+	}
+	viper.SetDefault(SocketKey, filepath.Join(cdir, "wash", "wash-api.sock"))
 
 	// Tell viper that the config. can be read from WASH_<entry>
 	// environment variables


### PR DESCRIPTION
Previously it defaulted to creation in `/tmp`, which is usually readable
by anyone on the system. Since access to the API server often grants
admin privileges to execute commands over any configured plugins, move
the socket to a secure location: the UserCacheDir.

Signed-off-by: Michael Smith <michael.smith@puppet.com>