### PR TITLE
Delay getting region for bucket

### DIFF
--- a/plugin/aws/s3Dir.go
+++ b/plugin/aws/s3Dir.go
@@ -2,7 +2,6 @@ package aws
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/puppetlabs/wash/journal"
 	"github.com/puppetlabs/wash/plugin"
@@ -38,34 +37,10 @@ func (s *s3Dir) List(ctx context.Context) ([]plugin.Entry, error) {
 
 	buckets := make([]plugin.Entry, len(resp.Buckets))
 	for i, bucket := range resp.Buckets {
-		name := awsSDK.StringValue(bucket.Name)
-
-		locRequest := &s3Client.GetBucketLocationInput{
-			// Re-use bucket.Name to avoid a redundant cast of name
-			// using awsSDK.String(name)
-			Bucket: bucket.Name,
-		}
-		resp, err := s.client.GetBucketLocationWithContext(ctx, locRequest)
-		if err != nil {
-			// TODO: Should we log a warning and continue instead of returning an
-			// error?
-			return nil, fmt.Errorf("could not get the region of bucket %v: %v", name, err)
-		}
-
-		// The response will be empty if the bucket is in Amazon's default region (us-east-1)
-		region := "us-east-1"
-		if resp.LocationConstraint != nil {
-			region = awsSDK.StringValue(resp.LocationConstraint)
-		}
-
-		cfg := awsSDK.NewConfig()
-		cfg.WithRegion(region)
-
 		buckets[i] = newS3Bucket(
-			name,
+			awsSDK.StringValue(bucket.Name),
 			awsSDK.TimeValue(bucket.CreationDate),
-			region,
-			s3Client.New(s.session, cfg),
+			s.session,
 		)
 	}
 


### PR DESCRIPTION
Querying the region for every bucket when listing available buckets
results in many queries to list them. We only need the region when we're
listing the contents of the bucket. Delay getting the region name until
we need it.

The region result will be cached indefinitely. If there's an error,
delete the cache entry for the bucket to force a retry.

This saves ~4 seconds for listing an s3 account with ~180 buckets. It
now takes ~4 seconds to do the initial listing, then ~100ms for each
subsequent listing when the cache expires.

Signed-off-by: Michael Smith <michael.smith@puppet.com>