### PR TITLE
Use a positive TTL for CachedOp

### DIFF
--- a/plugin/aws/s3Bucket.go
+++ b/plugin/aws/s3Bucket.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ekinanp/go-cache"
 	"github.com/puppetlabs/wash/journal"
 	"github.com/puppetlabs/wash/plugin"
 
@@ -216,9 +215,9 @@ func (b *s3Bucket) Metadata(ctx context.Context) (plugin.MetadataMap, error) {
 
 func (b *s3Bucket) getRegion(ctx context.Context) (string, error) {
 	// Note that the callback to CachedOp also creates a new client for that region.
-	// We use CachedOp with no expiration to ensure region is only fetched once, but
-	// to allow forcing a retry by deleting the cache entry if there was an error.
-	resp, err := plugin.CachedOp("Region", b, cache.NoExpiration, func() (interface{}, error) {
+	// We use CachedOp with a long expiration to ensure region is fetched infrequently.
+	// You can force a retry by deleting the cache entry if there was an error.
+	resp, err := plugin.CachedOp("Region", b, 24*time.Hour, func() (interface{}, error) {
 		locRequest := &s3Client.GetBucketLocationInput{Bucket: awsSDK.String(b.Name())}
 		resp, err := b.client.GetBucketLocationWithContext(ctx, locRequest)
 		if err != nil {


### PR DESCRIPTION
CachedOp panics if given a negative TTL. Use a long positive TTL instead
to accomplish a similar goal. Fixes a regression introduced by #170.

Signed-off-by: Michael Smith <michael.smith@puppet.com>