### PR TITLE
Add support for IAM Roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ We've implemented some neat features inside of `wash` to support the above goals
     * `kubernetes` - presents a filesystem hierarchy of pods, containers, and persistent volume claims
         - uses contexts from `~/.kube/config`
     * `aws` - presents a filesystem hierarchy for EC2 and S3
-        - uses `AWS_SHARED_CREDENTIALS_FILE` environment variable or `$HOME/.aws/credentials`
+        - uses `AWS_SHARED_CREDENTIALS_FILE` environment variable or `$HOME/.aws/credentials` and `AWS_CONFIG_FILE` environment variable or `$HOME/.aws/config` to find profiles and configure the SDK
+        - IAM roles are supported when configured as described [here](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-role.html). If using MFA, `wash` will prompt for it on standard input. Note that currently `region` will also need to be specified with the profile.
 
 * [External plugins](https://github.com/puppetlabs/wash/tree/master/docs/external_plugins)
     * `wash` allows for easy creation of out-of-process plugins using any language you want, from `bash` to `go` or anything in-between!

--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ We've implemented some neat features inside of `wash` to support the above goals
         - uses contexts from `~/.kube/config`
     * `aws` - presents a filesystem hierarchy for EC2 and S3
         - uses `AWS_SHARED_CREDENTIALS_FILE` environment variable or `$HOME/.aws/credentials` and `AWS_CONFIG_FILE` environment variable or `$HOME/.aws/config` to find profiles and configure the SDK
-        - IAM roles are supported when configured as described [here](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-role.html). If using MFA, `wash` will prompt for it on standard input. Note that currently `region` will also need to be specified with the profile.
+        - IAM roles are supported when configured as described [here](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-role.html). Note that currently `region` will also need to be specified with the profile.
+        - if using MFA, `wash` will prompt for it on standard input. Credentials are valid for 15 minutes. They are cached under `wash/aws-credentials` in your [user cache directory](#user-cache-directory) so they can be re-used across server restarts. `wash` may have to re-prompt for a new MFA token in response to navigating the `wash` environment to authorize a new session.
 
 * [External plugins](https://github.com/puppetlabs/wash/tree/master/docs/external_plugins)
     * `wash` allows for easy creation of out-of-process plugins using any language you want, from `bash` to `go` or anything in-between!
@@ -158,7 +159,11 @@ Try exploring `mnt/docker/volumes` to interact with the volume created for Redis
 
 ### Record of Activity
 
-All operations have their activity recorded to journals in `wash/activity` under your user cache directory, identified by process ID and executable name. The user cache directory is `$XDG_CACHE_HOME` or `$HOME/.cache` on Unix systems, `$HOME/Library/Caches` on macOS, and `%LocalAppData%` on Windows.
+All operations have their activity recorded to journals in `wash/activity` under your [user cache directory](#user-cache-directory), identified by process ID and executable name.
+
+### User Cache Directory
+
+`wash` uses a user-specific cache directory to store running state. The user cache directory is `$XDG_CACHE_HOME` or `$HOME/.cache` on Unix systems, `$HOME/Library/Caches` on macOS, and `%LocalAppData%` on Windows.
 
 ## Known Issues
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Ensure `$GOPATH/bin` is part of `$PATH`.
 
 ### Additional macOS Setup
 
-> If using iTerm2 and ZSH, we recommend installing [ZSH's iTerm2 shell integration](https://www.iterm2.com/documentation-shell-integration.html) to avoid [issue#84](https://github.com/puppetlabs/wash/issues/84).
+> If using iTerm2, we recommend installing [iTerm2's shell integration](https://www.iterm2.com/documentation-shell-integration.html) to avoid [issue#84](https://github.com/puppetlabs/wash/issues/84).
 
 Obtain FUSE for OSX [here](https://osxfuse.github.io/).
 

--- a/plugin/aws/fileCacheProvider.go
+++ b/plugin/aws/fileCacheProvider.go
@@ -1,0 +1,161 @@
+package aws
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/puppetlabs/wash/journal"
+)
+
+// FileCacheProvider is a credentials.Provider implementation that wraps an underlying Provider
+// (contained in credentials.Credentials) and provides caching support for credentials for the
+// specified profile.
+type FileCacheProvider struct {
+	credentials      *credentials.Credentials
+	profile          string
+	cachedCredential cachedCredential
+}
+
+// NewFileCacheProvider creates a new Provider implementation that wraps a provided Credentials,
+// and works with an on disk cache to speed up credential usage when the cached copy is not expired.
+// If there are any problems accessing or initializing the cache, an error will be returned, and
+// callers should just use the existing credentials provider.
+func newFileCacheProvider(ctx context.Context, profile string, creds *credentials.Credentials) (FileCacheProvider, error) {
+	if creds == nil {
+		return FileCacheProvider{}, errors.New("no underlying Credentials object provided")
+	}
+
+	filename, err := cacheFilename(profile)
+	if err != nil {
+		return FileCacheProvider{}, err
+	}
+
+	// load credential if it exists.
+	var cachedCredential cachedCredential
+	if info, err := os.Stat(filename); !os.IsNotExist(err) {
+		if info.Mode()&0077 != 0 {
+			// cache file has secret credentials and should only be accessible to the user, refuse to use it.
+			return FileCacheProvider{}, fmt.Errorf("cache file %s is not private, please ensure only current user has access", filename)
+		}
+
+		journal.Record(ctx, "Loading cached credentials from %v", filename)
+		cachedCredential, err = readCache(filename)
+		if err != nil {
+			// can't read or parse cache, refuse to use it.
+			return FileCacheProvider{}, err
+		}
+	}
+
+	return FileCacheProvider{creds, profile, cachedCredential}, nil
+}
+
+// Retrieve implements the Provider interface, returning the cached credential if not expired,
+// otherwise fetching the credential from the underlying Provider and caching the results on disk
+// with an expiration time.
+func (f *FileCacheProvider) Retrieve() (credentials.Value, error) {
+	if !f.cachedCredential.IsExpired() {
+		// use the cached credential
+		return f.cachedCredential.Credential, nil
+	}
+
+	// fetch the credentials from the underlying Provider
+	credential, err := f.credentials.Get()
+	if err != nil {
+		return credential, err
+	}
+
+	expiration, err := f.credentials.ExpiresAt()
+	if err != nil {
+		// Fallback to the original credential
+		journal.Record(context.Background(), "Unable to cache credential for %s: %v", f.profile, err)
+		return credential, nil
+	}
+
+	// underlying provider supports Expirer interface, so we can cache
+	filename, err := cacheFilename(f.profile)
+	if err != nil {
+		journal.Record(context.Background(), "Unable to determine cache location for %s: %v", f.profile, err)
+		return credential, nil
+	}
+
+	// update cached credential and save to disk
+	f.cachedCredential = cachedCredential{credential, expiration}
+	if err = writeCache(filename, f.cachedCredential); err != nil {
+		journal.Record(context.Background(), "Unable to update credential cache %s: %v", filename, err)
+	} else {
+		journal.Record(context.Background(), "Updated cached credential %s", filename)
+	}
+	return credential, err
+}
+
+// IsExpired implements the Provider interface, deferring to the cached credential first,
+// but fall back to the underlying Provider if it is expired.
+func (f *FileCacheProvider) IsExpired() bool {
+	return f.cachedCredential.IsExpired() && f.credentials.IsExpired()
+}
+
+// ExpiresAt implements the Expirer interface, and gives access to the expiration time of the credential
+func (f *FileCacheProvider) ExpiresAt() time.Time {
+	return f.cachedCredential.Expiration
+}
+
+// cacheFilename returns the name of the credential cache file for requested profile. It also
+// makes sure the directory containing the cache file exists.
+func cacheFilename(profile string) (string, error) {
+	cdir, err := os.UserCacheDir()
+	if err != nil {
+		return "", err
+	}
+	cachedir := filepath.Join(cdir, "wash", "aws-credentials")
+
+	// ensure cache directory exists
+	if err = os.MkdirAll(cachedir, 0750); err != nil {
+		return "", err
+	}
+
+	return filepath.Join(cachedir, profile+".json"), nil
+}
+
+// cachedCredential is a single cached credential, along with expiration time
+type cachedCredential struct {
+	Credential credentials.Value
+	Expiration time.Time
+}
+
+// IsExpired determines if the cached credential has expired
+func (c *cachedCredential) IsExpired() bool {
+	return c.Expiration.Before(time.Now())
+}
+
+// readCache reads the contents of the credential cache and returns the
+// parsed json as a cachedCredential object.
+func readCache(filename string) (cache cachedCredential, err error) {
+	data, err := ioutil.ReadFile(filename)
+	if err != nil {
+		err = fmt.Errorf("unable to open file %s: %v", filename, err)
+		return
+	}
+
+	err = json.Unmarshal(data, &cache)
+	if err != nil {
+		err = fmt.Errorf("unable to parse file %s: %v", filename, err)
+	}
+	return
+}
+
+// writeCache writes a cachedCredential to the specified file as json.
+func writeCache(filename string, cache cachedCredential) error {
+	data, err := json.Marshal(cache)
+	if err != nil {
+		return err
+	}
+	// write privately owned by the user
+	return ioutil.WriteFile(filename, data, 0600)
+}

--- a/plugin/aws/profile.go
+++ b/plugin/aws/profile.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"context"
 
+	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/puppetlabs/wash/journal"
 	"github.com/puppetlabs/wash/plugin"
@@ -23,8 +24,9 @@ func newProfile(ctx context.Context, name string) (*profile, error) {
 	// Create the session. SharedConfigEnable tells AWS to load the profile
 	// config from the ~/.aws/credentials and ~/.aws/config files
 	session, err := session.NewSessionWithOptions(session.Options{
-		Profile:           profile.Name(),
-		SharedConfigState: session.SharedConfigEnable,
+		Profile:                 profile.Name(),
+		AssumeRoleTokenProvider: stscreds.StdinTokenProvider,
+		SharedConfigState:       session.SharedConfigEnable,
 	})
 	if err != nil {
 		return nil, err

--- a/plugin/aws/profile.go
+++ b/plugin/aws/profile.go
@@ -2,7 +2,9 @@ package aws
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/puppetlabs/wash/journal"
@@ -12,6 +14,7 @@ import (
 // profile represents an AWS profile
 type profile struct {
 	plugin.EntryBase
+	session      *session.Session
 	resourcesDir []plugin.Entry
 }
 
@@ -23,15 +26,29 @@ func newProfile(ctx context.Context, name string) (*profile, error) {
 
 	// Create the session. SharedConfigEnable tells AWS to load the profile
 	// config from the ~/.aws/credentials and ~/.aws/config files
-	session, err := session.NewSessionWithOptions(session.Options{
-		Profile:                 profile.Name(),
+	sess, err := session.NewSessionWithOptions(session.Options{
+		Profile:                 name,
 		AssumeRoleTokenProvider: stscreds.StdinTokenProvider,
 		SharedConfigState:       session.SharedConfigEnable,
 	})
 	if err != nil {
 		return nil, err
 	}
-	profile.resourcesDir = []plugin.Entry{newResourcesDir(session)}
+
+	if cacheProvider, err := newFileCacheProvider(ctx, name, sess.Config.Credentials); err == nil {
+		journal.Record(ctx, "Using cached credentials for %v profile", name)
+		sess.Config.Credentials = credentials.NewCredentials(&cacheProvider)
+	} else {
+		journal.Record(ctx, "Unable to use cached credentials for %v profile: %v", name, err)
+	}
+
+	// Force retrieving credentials now to expose errors early.
+	if _, err := sess.Config.Credentials.Get(); err != nil {
+		return nil, fmt.Errorf("Unable to get credentials for %v: %v", name, err)
+	}
+
+	profile.session = sess
+	profile.resourcesDir = []plugin.Entry{newResourcesDir(sess)}
 
 	return &profile, nil
 }

--- a/plugin/aws/root.go
+++ b/plugin/aws/root.go
@@ -76,7 +76,9 @@ func (r *Root) Init() error {
 	r.EntryBase = plugin.NewEntry("aws")
 	r.SetTTLOf(plugin.List, 1*time.Minute)
 
-	return nil
+	// Force authorizing profiles on startup
+	_, err := r.List(context.Background())
+	return err
 }
 
 // List the available AWS profiles
@@ -99,7 +101,7 @@ func (r *Root) List(ctx context.Context) ([]plugin.Entry, error) {
 		return nil, err
 	}
 
-	journal.Record(ctx, "Loading the profiles from %v and %v", awsConfig, awsCredentials)
+	journal.Record(ctx, "Loading profiles from %v and %v", awsConfig, awsCredentials)
 
 	cred, err := ini.Load(awsCredentials)
 	if err != nil {


### PR DESCRIPTION
Adds support for IAM Roles when configured according to https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-role.html.

Includes file caching of credentials requested with MFA, and uses that to prompt for credentials on startup and cache them for later sessions.

Credentials retrieved currently last 15 minutes. See aws/aws-sdk-go#2532 for discussion of why we haven't modified that yet.

Known issue: `region` is not correctly inherited from the `source_profile`.

Resolves #168.

Signed-off-by: Michael Smith <michael.smith@puppet.com>