### PR TITLE
Trim 'profile ' from config names

### DIFF
--- a/plugin/aws/root.go
+++ b/plugin/aws/root.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/puppetlabs/wash/journal"
@@ -118,7 +119,10 @@ func (r *Root) List(ctx context.Context) ([]plugin.Entry, error) {
 		names[section.Name()] = struct{}{}
 	}
 	for _, section := range config.Sections() {
-		names[section.Name()] = struct{}{}
+		// https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html
+		// Named profiles in config begin with 'profile '. Trim that so config and credentials
+		// entries match up.
+		names[strings.TrimPrefix(section.Name(), "profile ")] = struct{}{}
 	}
 
 	var profiles []plugin.Entry


### PR DESCRIPTION
According to https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html, `config` and `credentials` files have different naming formats. Trim `profile ` from names in `config` to allow them to match names in `credentials`.

Signed-off-by: Michael Smith <michael.smith@puppet.com>