### PR TITLE
Make AWS credential errors more helpful

### DIFF
--- a/plugin/aws/fileCacheProvider.go
+++ b/plugin/aws/fileCacheProvider.go
@@ -74,7 +74,6 @@ func (f *FileCacheProvider) Retrieve() (credentials.Value, error) {
 	expiration, err := f.credentials.ExpiresAt()
 	if err != nil {
 		// Fallback to the original credential
-		journal.Record(context.Background(), "Unable to cache credential for %s: %v", f.profile, err)
 		return credential, nil
 	}
 
@@ -89,8 +88,6 @@ func (f *FileCacheProvider) Retrieve() (credentials.Value, error) {
 	f.cachedCredential = cachedCredential{credential, expiration}
 	if err = writeCache(filename, f.cachedCredential); err != nil {
 		journal.Record(context.Background(), "Unable to update credential cache %s: %v", filename, err)
-	} else {
-		journal.Record(context.Background(), "Updated cached credential %s", filename)
 	}
 	return credential, err
 }

--- a/plugin/aws/profile.go
+++ b/plugin/aws/profile.go
@@ -36,7 +36,6 @@ func newProfile(ctx context.Context, name string) (*profile, error) {
 	}
 
 	if cacheProvider, err := newFileCacheProvider(ctx, name, sess.Config.Credentials); err == nil {
-		journal.Record(ctx, "Using cached credentials for %v profile", name)
 		sess.Config.Credentials = credentials.NewCredentials(&cacheProvider)
 	} else {
 		journal.Record(ctx, "Unable to use cached credentials for %v profile: %v", name, err)

--- a/plugin/aws/root.go
+++ b/plugin/aws/root.go
@@ -133,7 +133,8 @@ func (r *Root) List(ctx context.Context) ([]plugin.Entry, error) {
 
 		profile, err := newProfile(ctx, name)
 		if err != nil {
-			return nil, err
+			journal.Record(ctx, err.Error())
+			continue
 		}
 
 		profiles = append(profiles, profile)


### PR DESCRIPTION
Also allow auth to fail while still loading remaining profiles. A common
case where profiles fail are when loading multiple roles for the same
account, where the same MFA token needs to be used but AWS requires that
each login use a different iteration of the token.

Remove caching messages that didn't provide actionable output to make
logs clearer.