### PR TITLE
Create FUSE server obj, configure it to pass-in the PID

### DIFF
--- a/fuse/file.go
+++ b/fuse/file.go
@@ -28,7 +28,6 @@ func newFile(e plugin.Entry) *file {
 
 // Open a file for reading.
 func (f *file) Open(ctx context.Context, req *fuse.OpenRequest, resp *fuse.OpenResponse) (fs.Handle, error) {
-	ctx = context.WithValue(ctx, journal.Key, journal.PIDToID(int(req.Pid)))
 	journal.Record(ctx, "FUSE: Open %v", f)
 
 	// Initiate content request and return a channel providing the results.
@@ -61,8 +60,6 @@ var _ = fs.HandleReader(fileHandle{})
 
 // Release closes the open file.
 func (fh fileHandle) Release(ctx context.Context, req *fuse.ReleaseRequest) error {
-	ctx = context.WithValue(ctx, journal.Key, journal.PIDToID(int(req.Pid)))
-
 	log.Infof("FUSE: Release[pid=%v] %v", req.Pid, fh.id)
 	journal.Record(ctx, "FUSE: Release %v", fh.id)
 	if closer, ok := fh.r.(io.Closer); ok {
@@ -73,8 +70,6 @@ func (fh fileHandle) Release(ctx context.Context, req *fuse.ReleaseRequest) erro
 
 // Read fills a buffer with the requested amount of data from the file.
 func (fh fileHandle) Read(ctx context.Context, req *fuse.ReadRequest, resp *fuse.ReadResponse) error {
-	ctx = context.WithValue(ctx, journal.Key, journal.PIDToID(int(req.Pid)))
-
 	buf := make([]byte, req.Size)
 	n, err := fh.r.ReadAt(buf, req.Offset)
 	if err == io.EOF {


### PR DESCRIPTION
This ensures that all of our FUSE methods write to the right journal
regardless of whether the PID's included in the method's request.

Signed-off-by: Enis Inan <enis.inan@puppet.com>