### PR TITLE
Enable caching for an EC2 instance

### DIFF
--- a/plugin/aws/ec2Instance.go
+++ b/plugin/aws/ec2Instance.go
@@ -49,7 +49,7 @@ func newEC2Instance(ctx context.Context, inst *ec2Client.Instance, session *sess
 		ssmClient:        ssm.New(session),
 		cloudwatchClient: cloudwatchlogs.New(session),
 	}
-	ec2Instance.DisableDefaultCaching()
+	ec2Instance.SetTTLOf(plugin.ListOp, 30*time.Second)
 
 	metaObj := newDescribeInstanceResult(inst)
 


### PR DESCRIPTION
This was previously turned off because the instances' metadata.json and
console output files were stored as struct fields. However, the
attributes-metadata work moved those over to List. That work should have
re-enabled caching since entry attributes are now refreshed via a call
to the parent's CachedList.

Signed-off-by: Enis Inan <enis.inan@puppet.com>

Contributions to this project require sign-off consistent with the [Developers Certificate of Origin](https://developercertificate.org). This can be as simple as using `git commit -s` on each commit.