### PR TITLE
Improve debugging using activity journal

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -153,7 +153,8 @@ func loadLogger(levelStr string, logfile string) (*os.File, error) {
 
 	log.SetLevel(level)
 	log.SetFormatter(&log.TextFormatter{
-		FullTimestamp: true,
+		FullTimestamp:   true,
+		TimestampFormat: time.RFC3339Nano,
 	})
 
 	var logFH *os.File

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -16,6 +16,7 @@ import (
 	cmdutil "github.com/puppetlabs/wash/cmd/util"
 	"github.com/puppetlabs/wash/config"
 	"github.com/puppetlabs/wash/fuse"
+	"github.com/puppetlabs/wash/journal"
 	"github.com/puppetlabs/wash/plugin"
 	"github.com/puppetlabs/wash/plugin/aws"
 	"github.com/puppetlabs/wash/plugin/docker"
@@ -67,6 +68,11 @@ func serverMain(cmd *cobra.Command, args []string) exitCode {
 			}
 		}()
 	}
+
+	// Close any open journals on shutdown to ensure remaining entries are flushed to disk.
+	defer func() {
+		journal.CloseAll()
+	}()
 
 	registry := plugin.NewRegistry()
 	loadInternalPlugins(registry)

--- a/fuse/dir.go
+++ b/fuse/dir.go
@@ -39,7 +39,7 @@ func (d *dir) Lookup(ctx context.Context, req *fuse.LookupRequest, resp *fuse.Lo
 
 	entries, err := d.children(ctx)
 	if err != nil {
-		log.Warnf("FUSE: Error[Find,%v,%v]: %v", d, req.Name, err)
+		log.Warnf("FUSE: Error[Find,%v,%v,jid=%v]: %v", d, req.Name, journal.GetID(ctx), err)
 		journal.Record(ctx, "FUSE: Find %v in %v errored: %v", req.Name, d, err)
 		return nil, fuse.ENOENT
 	}
@@ -51,7 +51,7 @@ func (d *dir) Lookup(ctx context.Context, req *fuse.LookupRequest, resp *fuse.Lo
 		return nil, fuse.ENOENT
 	}
 
-	log.Infof("FUSE: Find[d,pid=%v] %v/%v", req.Pid, d, cname)
+	log.Infof("FUSE: Find[d,jid=%v] %v/%v", journal.GetID(ctx), d, cname)
 	if plugin.ListAction.IsSupportedOn(entry) {
 		childdir := newDir(d.entry.(plugin.Group), entry.(plugin.Group))
 		journal.Record(ctx, "FUSE: Found directory %v", childdir)
@@ -77,12 +77,12 @@ func (d *dir) ReadDirAll(ctx context.Context) ([]fuse.Dirent, error) {
 
 	entries, err := d.children(ctx)
 	if err != nil {
-		log.Warnf("FUSE: Error[List,%v]: %v", d, err)
+		log.Warnf("FUSE: Error[List,%v,jid=%v]: %v", d, journal.GetID(ctx), err)
 		journal.Record(ctx, "FUSE: List %v errored: %v", d, err)
 		return nil, err
 	}
 
-	log.Infof("FUSE: List %v in %v", len(entries), d)
+	log.Infof("FUSE: List[jid=%v] %v in %v", journal.GetID(ctx), len(entries), d)
 
 	res := make([]fuse.Dirent, 0, len(entries))
 	for cname, entry := range entries {

--- a/journal/core_test.go
+++ b/journal/core_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestRecord(t *testing.T) {
 	// Ensure the cache is cleaned up afterward.
-	defer journalCache.Flush()
+	defer CloseAll()
 
 	// Log to a journal
 	Record(context.WithValue(context.Background(), Key, "1"), "hello there")
@@ -27,7 +27,7 @@ func TestRecord(t *testing.T) {
 
 func TestLogExpired(t *testing.T) {
 	// Ensure the cache is cleaned up afterward.
-	defer journalCache.Flush()
+	defer CloseAll()
 
 	// Ensure entries use a very short
 	expires = 1 * time.Millisecond
@@ -46,7 +46,7 @@ func TestLogExpired(t *testing.T) {
 
 func TestLogReused(t *testing.T) {
 	// Ensure the cache is cleaned up afterward.
-	defer journalCache.Flush()
+	defer CloseAll()
 	ctx := context.WithValue(context.Background(), Key, "3")
 
 	// Log twice

--- a/plugin/aws/ec2Instance.go
+++ b/plugin/aws/ec2Instance.go
@@ -106,7 +106,7 @@ func (d describeInstanceResult) toMeta() plugin.EntryMetadata {
 }
 
 func (inst *ec2Instance) cachedDescribeInstance(ctx context.Context) (describeInstanceResult, error) {
-	info, err := plugin.CachedOp("DescribeInstance", inst, 15*time.Second, func() (interface{}, error) {
+	info, err := plugin.CachedOp(ctx, "DescribeInstance", inst, 15*time.Second, func() (interface{}, error) {
 		request := &ec2Client.DescribeInstancesInput{
 			InstanceIds: []*string{
 				awsSDK.String(inst.Name()),

--- a/plugin/aws/ec2InstanceConsoleOutput.go
+++ b/plugin/aws/ec2InstanceConsoleOutput.go
@@ -62,7 +62,7 @@ func (o consoleOutput) toMeta() plugin.EntryMetadata {
 }
 
 func (cl *ec2InstanceConsoleOutput) cachedConsoleOutput(ctx context.Context) (consoleOutput, error) {
-	output, err := plugin.CachedOp("ConsoleOutput", cl, 30*time.Second, func() (interface{}, error) {
+	output, err := plugin.CachedOp(ctx, "ConsoleOutput", cl, 30*time.Second, func() (interface{}, error) {
 		request := &ec2Client.GetConsoleOutputInput{
 			InstanceId: awsSDK.String(cl.inst.Name()),
 		}

--- a/plugin/aws/s3Bucket.go
+++ b/plugin/aws/s3Bucket.go
@@ -217,7 +217,7 @@ func (b *s3Bucket) getRegion(ctx context.Context) (string, error) {
 	// Note that the callback to CachedOp also creates a new client for that region.
 	// We use CachedOp with a long expiration to ensure region is fetched infrequently.
 	// You can force a retry by deleting the cache entry if there was an error.
-	resp, err := plugin.CachedOp("Region", b, 24*time.Hour, func() (interface{}, error) {
+	resp, err := plugin.CachedOp(ctx, "Region", b, 24*time.Hour, func() (interface{}, error) {
 		locRequest := &s3Client.GetBucketLocationInput{Bucket: awsSDK.String(b.Name())}
 		resp, err := b.client.GetBucketLocationWithContext(ctx, locRequest)
 		if err != nil {

--- a/plugin/aws/s3Object.go
+++ b/plugin/aws/s3Object.go
@@ -51,7 +51,7 @@ func newS3Object(o *s3Client.Object, name string, bucket string, key string, cli
 }
 
 func (o *s3Object) cachedHeadObject(ctx context.Context) (*s3Client.HeadObjectOutput, error) {
-	resp, err := plugin.CachedOp("HeadObject", o, 15*time.Second, func() (interface{}, error) {
+	resp, err := plugin.CachedOp(ctx, "HeadObject", o, 15*time.Second, func() (interface{}, error) {
 		request := &s3Client.HeadObjectInput{
 			Bucket: awsSDK.String(o.bucket),
 			Key:    awsSDK.String(o.key),

--- a/plugin/cache_test.go
+++ b/plugin/cache_test.go
@@ -148,7 +148,7 @@ func (suite *CacheTestSuite) TestCachedOp() {
 	makePanicFunc := func(opName string, ttl time.Duration) func() {
 		return func() {
 			entry := newCacheTestsMockEntry("mock")
-			_, _ = CachedOp("List", entry, ttl, func() (interface{}, error) { return nil, nil })
+			_, _ = CachedOp(context.Background(), "List", entry, ttl, func() (interface{}, error) { return nil, nil })
 		}
 	}
 
@@ -178,7 +178,7 @@ func (suite *CacheTestSuite) TestCachedOp() {
 	opKey := "Op::id"
 	generateValueMatcher := suite.makeGenerateValueMatcher("result")
 	suite.cache.On("GetOrUpdate", opKey, opTTL, false, mock.MatchedBy(generateValueMatcher)).Return("result", nil).Once()
-	v, err := CachedOp(opName, entry, opTTL, op)
+	v, err := CachedOp(context.Background(), opName, entry, opTTL, op)
 	if suite.NoError(err) {
 		suite.Equal("result", v)
 	}

--- a/plugin/kubernetes/pod.go
+++ b/plugin/kubernetes/pod.go
@@ -81,7 +81,7 @@ func (p *pod) fetchLogContent(ctx context.Context) ([]byte, error) {
 }
 
 func (p *pod) cachedPodInfo(ctx context.Context) (podInfoResult, error) {
-	cachedPdInfo, err := plugin.CachedOp("PodInfo", p, 15*time.Second, func() (interface{}, error) {
+	cachedPdInfo, err := plugin.CachedOp(ctx, "PodInfo", p, 15*time.Second, func() (interface{}, error) {
 		result := podInfoResult{}
 		pd, err := p.client.CoreV1().Pods(p.ns).Get(p.Name(), metav1.GetOptions{})
 		if err != nil {


### PR DESCRIPTION
Move to nanosecond granularity logging to debug slow operations.

Consistently print the journal ID for logged actions, and write all FUSE
activity to the journal.

Signed-off-by: Michael Smith <michael.smith@puppet.com>