### PR TITLE
Fix deadlock

### DIFF
--- a/api/cache_test.go
+++ b/api/cache_test.go
@@ -27,7 +27,8 @@ func newMockCache() *mockCache {
 	return &mockCache{items: make(map[string]interface{})}
 }
 
-func (m *mockCache) GetOrUpdate(key string, ttl time.Duration, resetTTLOnHit bool, generateValue func() (interface{}, error)) (interface{}, error) {
+func (m *mockCache) GetOrUpdate(cat, key string, ttl time.Duration, resetTTLOnHit bool, generateValue func() (interface{}, error)) (interface{}, error) {
+	key = cat + "::" + key
 	if v, ok := m.items[key]; ok {
 		return v, nil
 	}

--- a/datastore/cache_test.go
+++ b/datastore/cache_test.go
@@ -37,23 +37,23 @@ func (suite *MemCacheTestSuite) validate(item interface{}, err error) {
 func (suite *MemCacheTestSuite) TestGetOrUpdateNoReset() {
 	suite.thing.On("update").Return(anything, nil)
 
-	suite.validate(suite.mem.GetOrUpdate("an entry", time.Second, false, suite.update))
-	item, ok := suite.mem.instance.Get("an entry")
+	suite.validate(suite.mem.GetOrUpdate("cat", "an entry", time.Second, false, suite.update))
+	item, ok := suite.mem.instance.Get("cat::an entry")
 	if suite.True(ok) {
 		suite.Equal("anything", item)
 	}
 
-	suite.validate(suite.mem.GetOrUpdate("an entry", time.Nanosecond, false, suite.update))
+	suite.validate(suite.mem.GetOrUpdate("cat", "an entry", time.Nanosecond, false, suite.update))
 	time.Sleep(time.Nanosecond)
-	item, ok = suite.mem.instance.Get("an entry")
+	item, ok = suite.mem.instance.Get("cat::an entry")
 	if suite.True(ok) {
 		suite.Equal("anything", item)
 	}
 	suite.thing.AssertNumberOfCalls(suite.T(), "update", 1)
 
-	suite.mem.instance.Delete("an entry")
-	suite.validate(suite.mem.GetOrUpdate("an entry", time.Second, false, suite.update))
-	item, ok = suite.mem.instance.Get("an entry")
+	suite.mem.instance.Delete("cat::an entry")
+	suite.validate(suite.mem.GetOrUpdate("cat", "an entry", time.Second, false, suite.update))
+	item, ok = suite.mem.instance.Get("cat::an entry")
 	if suite.True(ok) {
 		suite.Equal("anything", item)
 	}
@@ -63,13 +63,13 @@ func (suite *MemCacheTestSuite) TestGetOrUpdateNoReset() {
 func (suite *MemCacheTestSuite) TestGetOrUpdateExpire() {
 	suite.thing.On("update").Return(anything, nil)
 
-	suite.validate(suite.mem.GetOrUpdate("an entry", time.Nanosecond, false, suite.update))
+	suite.validate(suite.mem.GetOrUpdate("cat", "an entry", time.Nanosecond, false, suite.update))
 	time.Sleep(time.Nanosecond)
-	_, ok := suite.mem.instance.Get("an entry")
+	_, ok := suite.mem.instance.Get("cat::an entry")
 	suite.False(ok)
 
-	suite.validate(suite.mem.GetOrUpdate("an entry", time.Second, false, suite.update))
-	item, ok := suite.mem.instance.Get("an entry")
+	suite.validate(suite.mem.GetOrUpdate("cat", "an entry", time.Second, false, suite.update))
+	item, ok := suite.mem.instance.Get("cat::an entry")
 	if suite.True(ok) {
 		suite.Equal("anything", item)
 	}
@@ -79,20 +79,20 @@ func (suite *MemCacheTestSuite) TestGetOrUpdateExpire() {
 func (suite *MemCacheTestSuite) TestGetOrUpdateWithReset() {
 	suite.thing.On("update").Return(anything, nil)
 
-	suite.validate(suite.mem.GetOrUpdate("an entry", time.Second, true, suite.update))
-	item, ok := suite.mem.instance.Get("an entry")
+	suite.validate(suite.mem.GetOrUpdate("cat", "an entry", time.Second, true, suite.update))
+	item, ok := suite.mem.instance.Get("cat::an entry")
 	if suite.True(ok) {
 		suite.Equal("anything", item)
 	}
 
-	suite.validate(suite.mem.GetOrUpdate("an entry", time.Nanosecond, true, suite.update))
+	suite.validate(suite.mem.GetOrUpdate("cat", "an entry", time.Nanosecond, true, suite.update))
 	time.Sleep(time.Nanosecond)
-	_, ok = suite.mem.instance.Get("an entry")
+	_, ok = suite.mem.instance.Get("cat::an entry")
 	suite.False(ok)
 	suite.thing.AssertNumberOfCalls(suite.T(), "update", 1)
 
-	suite.validate(suite.mem.GetOrUpdate("an entry", time.Second, true, suite.update))
-	item, ok = suite.mem.instance.Get("an entry")
+	suite.validate(suite.mem.GetOrUpdate("cat", "an entry", time.Second, true, suite.update))
+	item, ok = suite.mem.instance.Get("cat::an entry")
 	if suite.True(ok) {
 		suite.Equal("anything", item)
 	}
@@ -158,11 +158,11 @@ func (suite *MemCacheEvictedTestSuite) TestExpired() {
 	suite.mem.instance.Set("an entry", struct{}{}, time.Nanosecond)
 	time.Sleep(time.Nanosecond)
 
-	_, err := suite.mem.GetOrUpdate("an entry", time.Second, false, func() (interface{}, error) {
+	_, err := suite.mem.GetOrUpdate("cat", "an entry", time.Second, false, func() (interface{}, error) {
 		return nil, errors.New("nope")
 	})
 	suite.Equal(errors.New("nope"), err)
-	if val, ok := suite.mem.instance.Get("an entry"); suite.True(ok) {
+	if val, ok := suite.mem.instance.Get("cat::an entry"); suite.True(ok) {
 		suite.Equal(errors.New("nope"), val)
 	}
 }

--- a/journal/core.go
+++ b/journal/core.go
@@ -79,7 +79,8 @@ func Record(ctx context.Context, msg string, a ...interface{}) {
 
 	log.Debugf(msg, a...)
 
-	obj, err := journalCache.GetOrUpdate(id, expires, true, func() (interface{}, error) {
+	// This is a single-use cache, so pass in an empty category.
+	obj, err := journalCache.GetOrUpdate("", id, expires, true, func() (interface{}, error) {
 		jdir := Dir()
 		if err := os.MkdirAll(jdir, 0750); err != nil {
 			return nil, err

--- a/plugin/aws/ec2Instance.go
+++ b/plugin/aws/ec2Instance.go
@@ -50,6 +50,7 @@ func newEC2Instance(ctx context.Context, inst *ec2Client.Instance, session *sess
 		cloudwatchClient: cloudwatchlogs.New(session),
 	}
 	ec2Instance.SetTTLOf(plugin.ListOp, 30*time.Second)
+	ec2Instance.DisableCachingFor(plugin.MetadataOp)
 
 	metaObj := newDescribeInstanceResult(inst)
 

--- a/plugin/cache.go
+++ b/plugin/cache.go
@@ -241,5 +241,5 @@ func cachedOp(ctx context.Context, opName string, entry Entry, ttl time.Duration
 		return op()
 	}
 
-	return cache.GetOrUpdate(opName+"::"+entry.id(), ttl, false, op)
+	return cache.GetOrUpdate(opName, entry.id(), ttl, false, op)
 }


### PR DESCRIPTION
Allow cached lookup of one category within a cached lookup of a different category of call to work without deadlock. Fixes an issue where CachedList would call cachedDescribeInstance in ec2Instance and sometimes deadlock trying to use the same mutex.

Also avoid caching MetadataOp on ec2InstanceMetadataJSON unnecessarily.