### PR TITLE
Enable caching on Entry creation

### DIFF
--- a/api/cache_test.go
+++ b/api/cache_test.go
@@ -82,7 +82,6 @@ func (suite *CacheHandlerTestSuite) TestRejectsGet() {
 func (suite *CacheHandlerTestSuite) TestClearCache() {
 	// Populate the cache with a mocked resource and plugin.Cached*
 	group := newMockedGroup()
-	group.SetTestID("/dir")
 	group.On("List", mock.Anything).Return([]plugin.Entry{}, nil)
 
 	expectedChildren := make(map[string]plugin.Entry)
@@ -102,11 +101,11 @@ func (suite *CacheHandlerTestSuite) TestClearCache() {
 	}
 
 	// Test clearing the cache
-	req = httptest.NewRequest(http.MethodDelete, "http://example.com/cache?path=dir", nil)
+	req = httptest.NewRequest(http.MethodDelete, "http://example.com/cache?path=%2FmockGroup", nil)
 	w = httptest.NewRecorder()
 	suite.router.ServeHTTP(w, req)
 	suite.Equal(http.StatusOK, w.Code)
-	suite.Equal(`["List::/dir"]`, strings.TrimSpace(w.Body.String()))
+	suite.Equal(`["List::/mockGroup"]`, strings.TrimSpace(w.Body.String()))
 
 	if children, err := plugin.CachedList(context.Background(), group); suite.Nil(err) {
 		suite.Equal(expectedChildren, children)
@@ -126,7 +125,7 @@ type mockedGroup struct {
 
 func newMockedGroup() *mockedGroup {
 	g := &mockedGroup{
-		EntryBase: plugin.NewEntry("mockGroup"),
+		EntryBase: plugin.NewRootEntry("mockGroup"),
 	}
 
 	return g

--- a/api/helpers_test.go
+++ b/api/helpers_test.go
@@ -120,9 +120,9 @@ func (suite *HelpersTestSuite) TestFindEntry() {
 		}
 	}
 
-	foo := plugin.NewEntry("foo/bar")
-	group := &mockGroup{plugin.NewEntry("root"), []plugin.Entry{&foo}}
-	group.SetTestID("/root")
+	group := &mockGroup{EntryBase: plugin.NewRootEntry("root")}
+	foo := group.NewEntry("foo/bar")
+	group.entries = []plugin.Entry{&foo}
 	group.DisableDefaultCaching()
 	for _, c := range []testcase{
 		{[]string{"not found"}, "", entryNotFoundResponse("not found", "The not found entry does not exist")},
@@ -132,8 +132,9 @@ func (suite *HelpersTestSuite) TestFindEntry() {
 		runTestCase(group, c)
 	}
 
-	baz := plugin.NewEntry("baz")
-	nestedGroup := &mockGroup{plugin.NewEntry("bar"), []plugin.Entry{&baz}}
+	nestedGroup := &mockGroup{EntryBase: group.NewEntry("bar")}
+	baz := nestedGroup.NewEntry("baz")
+	nestedGroup.entries = []plugin.Entry{&baz}
 	nestedGroup.DisableDefaultCaching()
 	group.entries = append(group.entries, nestedGroup)
 	for _, c := range []testcase{
@@ -145,7 +146,7 @@ func (suite *HelpersTestSuite) TestFindEntry() {
 	}
 
 	// Finally, test the duplicate cname error response
-	duplicateFoo := plugin.NewEntry("foo#bar")
+	duplicateFoo := group.NewEntry("foo#bar")
 	group.entries = append(group.entries, &duplicateFoo)
 	expectedErr := plugin.DuplicateCNameErr{
 		ParentPath:                      plugin.Path(group),

--- a/fuse/dir.go
+++ b/fuse/dir.go
@@ -55,15 +55,6 @@ func (d *dir) Lookup(ctx context.Context, req *fuse.LookupRequest, resp *fuse.Lo
 	if plugin.ListAction.IsSupportedOn(entry) {
 		childdir := newDir(d.entry.(plugin.Group), entry.(plugin.Group))
 		journal.Record(ctx, "FUSE: Found directory %v", childdir)
-		// Prefetch directory entries into the cache
-		go func() {
-			// Need to use a different context here because we still want the prefetch
-			// to happen even when the current context is cancelled.
-			jid := journal.PIDToID(int(req.Pid))
-			ctx := context.WithValue(context.Background(), journal.Key, jid)
-			_, err := childdir.children(ctx)
-			journal.Record(ctx, "FUSE: Prefetching children of %v complete: %v", childdir, err)
-		}()
 		return childdir, nil
 	}
 

--- a/plugin/aws/ec2Dir.go
+++ b/plugin/aws/ec2Dir.go
@@ -17,16 +17,16 @@ type ec2Dir struct {
 	entries []plugin.Entry
 }
 
-func newEC2Dir(session *session.Session) *ec2Dir {
+func newEC2Dir(parent plugin.Entry, session *session.Session) *ec2Dir {
 	ec2Dir := &ec2Dir{
-		EntryBase: plugin.NewEntry("ec2"),
+		EntryBase: parent.NewEntry("ec2"),
 		session:   session,
 		client:    ec2Client.New(session),
 	}
 	ec2Dir.DisableDefaultCaching()
 
 	ec2Dir.entries = []plugin.Entry{
-		newEC2InstancesDir(ec2Dir.session, ec2Dir.client),
+		newEC2InstancesDir(parent, ec2Dir.session, ec2Dir.client),
 	}
 
 	return ec2Dir

--- a/plugin/aws/ec2Instance.go
+++ b/plugin/aws/ec2Instance.go
@@ -41,9 +41,9 @@ const (
 	EC2InstanceStopped           = 80
 )
 
-func newEC2Instance(ctx context.Context, inst *ec2Client.Instance, session *session.Session, client *ec2Client.EC2) *ec2Instance {
+func newEC2Instance(ctx context.Context, parent plugin.Entry, inst *ec2Client.Instance, session *session.Session, client *ec2Client.EC2) *ec2Instance {
 	ec2Instance := &ec2Instance{
-		EntryBase:        plugin.NewEntry(awsSDK.StringValue(inst.InstanceId)),
+		EntryBase:        parent.NewEntry(awsSDK.StringValue(inst.InstanceId)),
 		session:          session,
 		client:           client,
 		ssmClient:        ssm.New(session),
@@ -106,7 +106,7 @@ func (d describeInstanceResult) toMeta() plugin.EntryMetadata {
 }
 
 func (inst *ec2Instance) cachedDescribeInstance(ctx context.Context) (describeInstanceResult, error) {
-	info, err := plugin.CachedOp(ctx, "DescribeInstance", inst, 15*time.Second, func() (interface{}, error) {
+	info, err := plugin.CachedOp("DescribeInstance", inst, 15*time.Second, func() (interface{}, error) {
 		request := &ec2Client.DescribeInstancesInput{
 			InstanceIds: []*string{
 				awsSDK.String(inst.Name()),

--- a/plugin/aws/ec2InstanceConsoleOutput.go
+++ b/plugin/aws/ec2InstanceConsoleOutput.go
@@ -26,9 +26,9 @@ func newEC2InstanceConsoleOutput(ctx context.Context, inst *ec2Instance, latest 
 	}
 
 	if cl.latest {
-		cl.EntryBase = plugin.NewEntry("console-latest.out")
+		cl.EntryBase = inst.NewEntry("console-latest.out")
 	} else {
-		cl.EntryBase = plugin.NewEntry("console.out")
+		cl.EntryBase = inst.NewEntry("console.out")
 	}
 	cl.DisableDefaultCaching()
 
@@ -62,7 +62,7 @@ func (o consoleOutput) toMeta() plugin.EntryMetadata {
 }
 
 func (cl *ec2InstanceConsoleOutput) cachedConsoleOutput(ctx context.Context) (consoleOutput, error) {
-	output, err := plugin.CachedOp(ctx, "ConsoleOutput", cl, 30*time.Second, func() (interface{}, error) {
+	output, err := plugin.CachedOp("ConsoleOutput", cl, 30*time.Second, func() (interface{}, error) {
 		request := &ec2Client.GetConsoleOutputInput{
 			InstanceId: awsSDK.String(cl.inst.Name()),
 		}

--- a/plugin/aws/ec2InstanceMetadataJSON.go
+++ b/plugin/aws/ec2InstanceMetadataJSON.go
@@ -17,7 +17,7 @@ type ec2InstanceMetadataJSON struct {
 
 func newEC2InstanceMetadataJSON(ctx context.Context, inst *ec2Instance) (*ec2InstanceMetadataJSON, error) {
 	im := &ec2InstanceMetadataJSON{
-		EntryBase: plugin.NewEntry("metadata.json"),
+		EntryBase: inst.NewEntry("metadata.json"),
 		inst:      inst,
 	}
 	im.DisableDefaultCaching()

--- a/plugin/aws/ec2InstancesDir.go
+++ b/plugin/aws/ec2InstancesDir.go
@@ -21,9 +21,9 @@ type ec2InstancesDir struct {
 	client  *ec2Client.EC2
 }
 
-func newEC2InstancesDir(session *session.Session, client *ec2Client.EC2) *ec2InstancesDir {
+func newEC2InstancesDir(parent plugin.Entry, session *session.Session, client *ec2Client.EC2) *ec2InstancesDir {
 	ec2InstancesDir := &ec2InstancesDir{
-		EntryBase: plugin.NewEntry("instances"),
+		EntryBase: parent.NewEntry("instances"),
 		session:   session,
 		client:    client,
 	}
@@ -52,6 +52,7 @@ func (is *ec2InstancesDir) List(ctx context.Context) ([]plugin.Entry, error) {
 		for i, instance := range reservation.Instances {
 			instances[i] = newEC2Instance(
 				ctx,
+				is,
 				instance,
 				is.session,
 				is.client,

--- a/plugin/aws/profile.go
+++ b/plugin/aws/profile.go
@@ -18,8 +18,8 @@ type profile struct {
 	resourcesDir []plugin.Entry
 }
 
-func newProfile(ctx context.Context, name string) (*profile, error) {
-	profile := profile{EntryBase: plugin.NewEntry(name)}
+func newProfile(ctx context.Context, parent plugin.Entry, name string) (*profile, error) {
+	profile := profile{EntryBase: parent.NewEntry(name)}
 	profile.DisableDefaultCaching()
 
 	journal.Record(ctx, "Creating a new AWS session for the %v profile", name)
@@ -47,7 +47,7 @@ func newProfile(ctx context.Context, name string) (*profile, error) {
 	}
 
 	profile.session = sess
-	profile.resourcesDir = []plugin.Entry{newResourcesDir(sess)}
+	profile.resourcesDir = []plugin.Entry{newResourcesDir(&profile, sess)}
 
 	return &profile, nil
 }

--- a/plugin/aws/resourcesDir.go
+++ b/plugin/aws/resourcesDir.go
@@ -14,16 +14,16 @@ type resourcesDir struct {
 	resources []plugin.Entry
 }
 
-func newResourcesDir(session *session.Session) *resourcesDir {
+func newResourcesDir(parent plugin.Entry, session *session.Session) *resourcesDir {
 	resourcesDir := &resourcesDir{
-		EntryBase: plugin.NewEntry("resources"),
+		EntryBase: parent.NewEntry("resources"),
 		session:   session,
 	}
 	resourcesDir.DisableDefaultCaching()
 
 	resourcesDir.resources = []plugin.Entry{
-		newS3Dir(resourcesDir.session),
-		newEC2Dir(resourcesDir.session),
+		newS3Dir(parent, resourcesDir.session),
+		newEC2Dir(parent, resourcesDir.session),
 	}
 
 	return resourcesDir

--- a/plugin/aws/root.go
+++ b/plugin/aws/root.go
@@ -74,7 +74,7 @@ func exists(path string) error {
 
 // Init for root
 func (r *Root) Init() error {
-	r.EntryBase = plugin.NewEntry("aws")
+	r.EntryBase = plugin.NewRootEntry("aws")
 	r.SetTTLOf(plugin.ListOp, 1*time.Minute)
 
 	// Force authorizing profiles on startup
@@ -131,7 +131,7 @@ func (r *Root) List(ctx context.Context) ([]plugin.Entry, error) {
 			continue
 		}
 
-		profile, err := newProfile(ctx, name)
+		profile, err := newProfile(ctx, r, name)
 		if err != nil {
 			journal.Record(ctx, err.Error())
 			continue

--- a/plugin/aws/s3Dir.go
+++ b/plugin/aws/s3Dir.go
@@ -18,9 +18,9 @@ type s3Dir struct {
 	client  *s3Client.S3
 }
 
-func newS3Dir(session *session.Session) *s3Dir {
+func newS3Dir(parent plugin.Entry, session *session.Session) *s3Dir {
 	return &s3Dir{
-		EntryBase: plugin.NewEntry("s3"),
+		EntryBase: parent.NewEntry("s3"),
 		session:   session,
 		client:    s3Client.New(session),
 	}
@@ -38,6 +38,7 @@ func (s *s3Dir) List(ctx context.Context) ([]plugin.Entry, error) {
 	buckets := make([]plugin.Entry, len(resp.Buckets))
 	for i, bucket := range resp.Buckets {
 		buckets[i] = newS3Bucket(
+			s,
 			awsSDK.StringValue(bucket.Name),
 			awsSDK.TimeValue(bucket.CreationDate),
 			s.session,

--- a/plugin/aws/s3Object.go
+++ b/plugin/aws/s3Object.go
@@ -22,9 +22,9 @@ type s3Object struct {
 	client *s3Client.S3
 }
 
-func newS3Object(o *s3Client.Object, name string, bucket string, key string, client *s3Client.S3) *s3Object {
+func newS3Object(parent plugin.Entry, o *s3Client.Object, name string, bucket string, key string, client *s3Client.S3) *s3Object {
 	s3Obj := &s3Object{
-		EntryBase: plugin.NewEntry(name),
+		EntryBase: parent.NewEntry(name),
 		bucket:    bucket,
 		key:       key,
 		client:    client,
@@ -51,7 +51,7 @@ func newS3Object(o *s3Client.Object, name string, bucket string, key string, cli
 }
 
 func (o *s3Object) cachedHeadObject(ctx context.Context) (*s3Client.HeadObjectOutput, error) {
-	resp, err := plugin.CachedOp(ctx, "HeadObject", o, 15*time.Second, func() (interface{}, error) {
+	resp, err := plugin.CachedOp("HeadObject", o, 15*time.Second, func() (interface{}, error) {
 		request := &s3Client.HeadObjectInput{
 			Bucket: awsSDK.String(o.bucket),
 			Key:    awsSDK.String(o.key),

--- a/plugin/aws/s3ObjectPrefix.go
+++ b/plugin/aws/s3ObjectPrefix.go
@@ -19,9 +19,9 @@ type s3ObjectPrefix struct {
 	client *s3Client.S3
 }
 
-func newS3ObjectPrefix(name string, bucket string, prefix string, client *s3Client.S3) *s3ObjectPrefix {
+func newS3ObjectPrefix(parent plugin.Entry, name string, bucket string, prefix string, client *s3Client.S3) *s3ObjectPrefix {
 	return &s3ObjectPrefix{
-		EntryBase: plugin.NewEntry(name),
+		EntryBase: parent.NewEntry(name),
 		bucket:    bucket,
 		prefix:    prefix,
 		client:    client,
@@ -31,5 +31,5 @@ func newS3ObjectPrefix(name string, bucket string, prefix string, client *s3Clie
 // List lists all S3 objects and S3 object prefixes that are
 // prefixed by the current S3 object prefix
 func (d *s3ObjectPrefix) List(ctx context.Context) ([]plugin.Entry, error) {
-	return listObjects(ctx, d.client, d.bucket, d.prefix)
+	return listObjects(ctx, d, d.client, d.bucket, d.prefix)
 }

--- a/plugin/docker/container.go
+++ b/plugin/docker/container.go
@@ -30,7 +30,7 @@ func (c *container) Metadata(ctx context.Context) (plugin.EntryMetadata, error) 
 func (c *container) List(ctx context.Context) ([]plugin.Entry, error) {
 	// TODO: May be worth creating a helper that makes it easy to create
 	// read-only files. Lots of shared code between these two.
-	cm := &containerMetadata{plugin.NewEntry("metadata.json"), c}
+	cm := &containerMetadata{c.NewEntry("metadata.json"), c}
 	cm.DisableDefaultCaching()
 	meta, err := cm.Metadata(ctx)
 	if err != nil {
@@ -40,7 +40,7 @@ func (c *container) List(ctx context.Context) ([]plugin.Entry, error) {
 	cmAttr.SetSize(uint64(meta["Size"].(int64)))
 	cm.SetAttributes(cmAttr)
 
-	clf := &containerLogFile{plugin.NewEntry("log"), c.Name(), c.client}
+	clf := &containerLogFile{c.NewEntry("log"), c.Name(), c.client}
 	clf.DisableCachingFor(plugin.MetadataOp)
 	meta, err = clf.Metadata(ctx)
 	if err != nil {

--- a/plugin/docker/containers.go
+++ b/plugin/docker/containers.go
@@ -26,7 +26,7 @@ func (cs *containers) List(ctx context.Context) ([]plugin.Entry, error) {
 	keys := make([]plugin.Entry, len(containers))
 	for i, inst := range containers {
 		cont := &container{
-			EntryBase: plugin.NewEntry(inst.ID),
+			EntryBase: cs.NewEntry(inst.ID),
 			client:    cs.client,
 		}
 

--- a/plugin/docker/root.go
+++ b/plugin/docker/root.go
@@ -26,11 +26,11 @@ func (r *Root) Init() error {
 		return err
 	}
 
-	r.EntryBase = plugin.NewEntry("docker")
+	r.EntryBase = plugin.NewRootEntry("docker")
 	r.DisableDefaultCaching()
 	r.resources = []plugin.Entry{
-		&containers{EntryBase: plugin.NewEntry("containers"), client: dockerCli},
-		&volumes{EntryBase: plugin.NewEntry("volumes"), client: dockerCli},
+		&containers{EntryBase: r.NewEntry("containers"), client: dockerCli},
+		&volumes{EntryBase: r.NewEntry("volumes"), client: dockerCli},
 	}
 
 	return nil

--- a/plugin/docker/volume.go
+++ b/plugin/docker/volume.go
@@ -25,14 +25,14 @@ type volume struct {
 
 const mountpoint = "/mnt"
 
-func newVolume(c *client.Client, v *types.Volume) (*volume, error) {
+func newVolume(parent plugin.Entry, c *client.Client, v *types.Volume) (*volume, error) {
 	startTime, err := time.Parse(time.RFC3339, v.CreatedAt)
 	if err != nil {
 		return nil, err
 	}
 
 	vol := &volume{
-		EntryBase: plugin.NewEntry(v.Name),
+		EntryBase: parent.NewEntry(v.Name),
 		client:    c,
 	}
 	vol.SetTTLOf(plugin.ListOp, 60*time.Second)
@@ -114,9 +114,9 @@ func (v *volume) List(ctx context.Context) ([]plugin.Entry, error) {
 	entries := make([]plugin.Entry, 0, len(root))
 	for name, attr := range root {
 		if attr.Mode().IsDir() {
-			entries = append(entries, vol.NewDir(name, attr, v.getContentCB(), "/"+name, dirs))
+			entries = append(entries, vol.NewDir(v, name, attr, v.getContentCB(), "/"+name, dirs))
 		} else {
-			entries = append(entries, vol.NewFile(name, attr, v.getContentCB(), "/"+name))
+			entries = append(entries, vol.NewFile(v, name, attr, v.getContentCB(), "/"+name))
 		}
 	}
 	return entries, nil

--- a/plugin/docker/volumes.go
+++ b/plugin/docker/volumes.go
@@ -24,7 +24,7 @@ func (vs *volumes) List(ctx context.Context) ([]plugin.Entry, error) {
 	journal.Record(ctx, "Listing %v volumes in %v", len(volumes.Volumes), vs)
 	keys := make([]plugin.Entry, len(volumes.Volumes))
 	for i, inst := range volumes.Volumes {
-		if keys[i], err = newVolume(vs.client, inst); err != nil {
+		if keys[i], err = newVolume(vs, vs.client, inst); err != nil {
 			return nil, err
 		}
 	}

--- a/plugin/entryBase_test.go
+++ b/plugin/entryBase_test.go
@@ -24,15 +24,15 @@ func (suite *EntryBaseTestSuite) assertOpTTL(e EntryBase, op defaultOpCode, opNa
 	)
 }
 
-func (suite *EntryBaseTestSuite) TestNewEntry() {
+func (suite *EntryBaseTestSuite) TestNewRootEntry() {
 	suite.Panics(
-		func() { NewEntry("") },
-		"plugin.NewEntry: received an empty name",
+		func() { NewRootEntry("") },
+		"plugin.NewRootEntry: received an empty name",
 	)
 
 	initialAttr := EntryAttributes{}
 	initialAttr.SetCtime(time.Now())
-	e := NewEntry("foo")
+	e := NewRootEntry("foo")
 
 	e.SetAttributes(initialAttr)
 	suite.Equal(initialAttr, e.attr)
@@ -41,8 +41,6 @@ func (suite *EntryBaseTestSuite) TestNewEntry() {
 	suite.assertOpTTL(e, ListOp, "List", 15*time.Second)
 	suite.assertOpTTL(e, OpenOp, "Open", 15*time.Second)
 	suite.assertOpTTL(e, MetadataOp, "Metadata", 15*time.Second)
-
-	e.setID("/foo")
 	suite.Equal("/foo", e.id())
 
 	e.SetTTLOf(ListOp, 40*time.Second)
@@ -56,8 +54,15 @@ func (suite *EntryBaseTestSuite) TestNewEntry() {
 	suite.assertOpTTL(e, MetadataOp, "Metadata", -1)
 }
 
+func (suite *EntryBaseTestSuite) TestNewEntry() {
+	foo := NewRootEntry("foo")
+	bar := foo.NewEntry("bar")
+	suite.Equal("bar", bar.Name())
+	suite.Equal("/foo/bar", bar.id())
+}
+
 func (suite *EntryBaseTestSuite) TestMetadata() {
-	e := NewEntry("foo")
+	e := NewRootEntry("foo")
 
 	meta, err := e.Metadata(context.Background())
 	if suite.NoError(err) {
@@ -67,7 +72,8 @@ func (suite *EntryBaseTestSuite) TestMetadata() {
 }
 
 func (suite *EntryBaseTestSuite) TestSetSlashReplacementChar() {
-	e := NewEntry("foo/bar")
+	// TODO: NewRootEntry should reject slashes and we should test NewEntry.
+	e := NewRootEntry("foo/bar")
 
 	suite.Panics(
 		func() { e.SetSlashReplacementChar('/') },

--- a/plugin/externalPluginEntry.go
+++ b/plugin/externalPluginEntry.go
@@ -74,7 +74,7 @@ type decodedExternalPluginEntry struct {
 	State                string            `json:"state"`
 }
 
-func (e decodedExternalPluginEntry) toExternalPluginEntry() (*externalPluginEntry, error) {
+func (e decodedExternalPluginEntry) toExternalPluginEntry(parent Entry) (*externalPluginEntry, error) {
 	if e.Name == "" {
 		return nil, fmt.Errorf("the entry name must be provided")
 	}
@@ -83,7 +83,7 @@ func (e decodedExternalPluginEntry) toExternalPluginEntry() (*externalPluginEntr
 	}
 
 	entry := &externalPluginEntry{
-		EntryBase:        NewEntry(e.Name),
+		EntryBase:        parent.NewEntry(e.Name),
 		supportedActions: e.SupportedActions,
 		state:            e.State,
 	}
@@ -143,7 +143,7 @@ func (e *externalPluginEntry) List(ctx context.Context) ([]Entry, error) {
 
 	entries := make([]Entry, len(decodedEntries))
 	for i, decodedExternalPluginEntry := range decodedEntries {
-		entry, err := decodedExternalPluginEntry.toExternalPluginEntry()
+		entry, err := decodedExternalPluginEntry.toExternalPluginEntry(e)
 		if err != nil {
 			return nil, err
 		}

--- a/plugin/externalPluginRoot.go
+++ b/plugin/externalPluginRoot.go
@@ -44,7 +44,7 @@ func (r *externalPluginRoot) Init() error {
 		return fmt.Errorf("could not decode the plugin root from stdout: %v", err)
 	}
 
-	entry, err := decodedRoot.toExternalPluginEntry()
+	entry, err := decodedRoot.toExternalPluginEntry(r)
 	if err != nil {
 		return err
 	}

--- a/plugin/externalPluginRoot_test.go
+++ b/plugin/externalPluginRoot_test.go
@@ -15,7 +15,7 @@ type ExternalPluginRootTestSuite struct {
 func (suite *ExternalPluginRootTestSuite) TestInit() {
 	mockScript := &mockExternalPluginScript{path: "plugin_script"}
 	root := &externalPluginRoot{&externalPluginEntry{
-		EntryBase: NewEntry("foo"),
+		EntryBase: NewRootEntry("foo"),
 		script:    mockScript,
 	}}
 
@@ -42,7 +42,7 @@ func (suite *ExternalPluginRootTestSuite) TestInit() {
 	if suite.NoError(err) {
 		expectedRoot := &externalPluginRoot{
 			externalPluginEntry: &externalPluginEntry{
-				EntryBase:        NewEntry("foo"),
+				EntryBase:        root.NewEntry("foo"),
 				supportedActions: []string{"list"},
 				script:           root.script,
 			},

--- a/plugin/helpers.go
+++ b/plugin/helpers.go
@@ -17,16 +17,15 @@ import (
 var DefaultTimeout = 10 * time.Second
 
 /*
-Name returns the entry's name as it was passed into
-plugin.NewEntry. It is meant to be called by other
-Wash packages. Plugin authors should use EntryBase#Name
-when writing their plugins.
+Name returns the entry's name as it was passed into NewEntry
+It is meant to be called by other Wash packages. Plugin
+authors should use EntryBase#Name when writing their plugins.
 */
 func Name(e Entry) string {
 	// The reason we don't expose EntryBase#Name in the Entry
 	// interface is so plugin authors don't override it. It ensures
-	// that whatever name they pass into plugin.NewEntry is the
-	// name received by Wash.
+	// that whatever name they pass into NewEntry is the name
+	// received by Wash.
 	return e.name()
 }
 

--- a/plugin/helpers_test.go
+++ b/plugin/helpers_test.go
@@ -15,10 +15,13 @@ import (
 
 type HelpersTestSuite struct {
 	suite.Suite
+	root Entry
 }
 
 func (suite *HelpersTestSuite) SetupSuite() {
 	SetTestCache(datastore.NewMemCache())
+	root := NewRootEntry("root")
+	suite.root = &root
 }
 
 func (suite *HelpersTestSuite) TearDownSuite() {
@@ -26,12 +29,12 @@ func (suite *HelpersTestSuite) TearDownSuite() {
 }
 
 func (suite *HelpersTestSuite) TestName() {
-	e := NewEntry("foo")
+	e := suite.root.NewEntry("foo")
 	suite.Equal(Name(&e), "foo")
 }
 
 func (suite *HelpersTestSuite) TestCName() {
-	e := NewEntry("foo/bar/baz")
+	e := suite.root.NewEntry("foo/bar/baz")
 	suite.Equal("foo#bar#baz", CName(&e))
 
 	e.SetSlashReplacementChar(':')
@@ -39,10 +42,9 @@ func (suite *HelpersTestSuite) TestCName() {
 }
 
 func (suite *HelpersTestSuite) TestPath() {
-	e := NewEntry("foo")
-	e.setID("/foo/bar")
+	e := suite.root.NewEntry("bar")
 
-	suite.Equal(Path(&e), "/foo/bar")
+	suite.Equal(Path(&e), "/root/bar")
 }
 
 func (suite *HelpersTestSuite) TestParseMode() {
@@ -112,9 +114,8 @@ type helpersTestsMockEntry struct {
 
 func newHelpersTestsMockEntry() *helpersTestsMockEntry {
 	e := &helpersTestsMockEntry{
-		EntryBase: NewEntry("mockEntry"),
+		EntryBase: NewRootEntry("mockEntry"),
 	}
-	e.SetTestID("id")
 	e.DisableDefaultCaching()
 
 	return e

--- a/plugin/kubernetes/context.go
+++ b/plugin/kubernetes/context.go
@@ -26,12 +26,12 @@ func (c *k8context) List(ctx context.Context) ([]plugin.Entry, error) {
 		if err != nil {
 			journal.Record(ctx, "Error loading default namespace, metadata will not be available: %v", err)
 		}
-		return []plugin.Entry{newNamespace(c.defaultns, ns, c.client, c.config)}, nil
+		return []plugin.Entry{newNamespace(c, c.defaultns, ns, c.client, c.config)}, nil
 	}
 
 	namespaces := make([]plugin.Entry, len(nsList.Items))
 	for i, ns := range nsList.Items {
-		namespaces[i] = newNamespace(ns.Name, &ns, c.client, c.config)
+		namespaces[i] = newNamespace(c, ns.Name, &ns, c.client, c.config)
 	}
 	journal.Record(ctx, "Listing namespaces: %+v", namespaces)
 	return namespaces, nil

--- a/plugin/kubernetes/namespace.go
+++ b/plugin/kubernetes/namespace.go
@@ -18,11 +18,11 @@ type namespace struct {
 	resourcetypes []plugin.Entry
 }
 
-func newNamespace(name string, meta *corev1.Namespace, c *k8s.Clientset, cfg *rest.Config) *namespace {
-	ns := &namespace{EntryBase: plugin.NewEntry(name), metadata: meta, client: c, config: cfg}
+func newNamespace(parent plugin.Entry, name string, meta *corev1.Namespace, c *k8s.Clientset, cfg *rest.Config) *namespace {
+	ns := &namespace{EntryBase: parent.NewEntry(name), metadata: meta, client: c, config: cfg}
 	ns.resourcetypes = []plugin.Entry{
-		&pods{plugin.NewEntry("pods"), c, cfg, name},
-		&pvcs{plugin.NewEntry("persistentvolumeclaims"), c, name},
+		&pods{ns.NewEntry("pods"), c, cfg, name},
+		&pvcs{ns.NewEntry("persistentvolumeclaims"), c, name},
 	}
 	return ns
 }

--- a/plugin/kubernetes/pod.go
+++ b/plugin/kubernetes/pod.go
@@ -24,9 +24,9 @@ type pod struct {
 	ns     string
 }
 
-func newPod(ctx context.Context, client *k8s.Clientset, config *rest.Config, ns string, p *corev1.Pod) (*pod, error) {
+func newPod(ctx context.Context, parent plugin.Entry, client *k8s.Clientset, config *rest.Config, ns string, p *corev1.Pod) (*pod, error) {
 	pd := &pod{
-		EntryBase: plugin.NewEntry(p.Name),
+		EntryBase: parent.NewEntry(p.Name),
 		client:    client,
 		config:    config,
 		ns:        ns,
@@ -81,7 +81,7 @@ func (p *pod) fetchLogContent(ctx context.Context) ([]byte, error) {
 }
 
 func (p *pod) cachedPodInfo(ctx context.Context) (podInfoResult, error) {
-	cachedPdInfo, err := plugin.CachedOp(ctx, "PodInfo", p, 15*time.Second, func() (interface{}, error) {
+	cachedPdInfo, err := plugin.CachedOp("PodInfo", p, 15*time.Second, func() (interface{}, error) {
 		result := podInfoResult{}
 		pd, err := p.client.CoreV1().Pods(p.ns).Get(p.Name(), metav1.GetOptions{})
 		if err != nil {

--- a/plugin/kubernetes/pods.go
+++ b/plugin/kubernetes/pods.go
@@ -25,7 +25,7 @@ func (ps *pods) List(ctx context.Context) ([]plugin.Entry, error) {
 	}
 	entries := make([]plugin.Entry, len(podList.Items))
 	for i, p := range podList.Items {
-		pd, err := newPod(ctx, ps.client, ps.config, ps.ns, &p)
+		pd, err := newPod(ctx, ps, ps.client, ps.config, ps.ns, &p)
 		if err != nil {
 			return nil, err
 		}

--- a/plugin/kubernetes/pvc.go
+++ b/plugin/kubernetes/pvc.go
@@ -27,9 +27,9 @@ const mountpoint = "/mnt"
 
 var errPodTerminated = errors.New("Pod terminated unexpectedly")
 
-func newPVC(pi typedv1.PersistentVolumeClaimInterface, pd typedv1.PodInterface, p *corev1.PersistentVolumeClaim) *pvc {
+func newPVC(parent plugin.Entry, pi typedv1.PersistentVolumeClaimInterface, pd typedv1.PodInterface, p *corev1.PersistentVolumeClaim) *pvc {
 	vol := &pvc{
-		EntryBase: plugin.NewEntry(p.Name),
+		EntryBase: parent.NewEntry(p.Name),
 		pvci:      pi,
 		podi:      pd,
 	}
@@ -98,9 +98,9 @@ func (v *pvc) List(ctx context.Context) ([]plugin.Entry, error) {
 	entries := make([]plugin.Entry, 0, len(root))
 	for name, attr := range root {
 		if attr.Mode().IsDir() {
-			entries = append(entries, volume.NewDir(name, attr, v.getContentCB(), "/"+name, dirs))
+			entries = append(entries, volume.NewDir(v, name, attr, v.getContentCB(), "/"+name, dirs))
 		} else {
-			entries = append(entries, volume.NewFile(name, attr, v.getContentCB(), "/"+name))
+			entries = append(entries, volume.NewFile(v, name, attr, v.getContentCB(), "/"+name))
 		}
 	}
 	return entries, nil

--- a/plugin/kubernetes/pvcs.go
+++ b/plugin/kubernetes/pvcs.go
@@ -24,7 +24,7 @@ func (pv *pvcs) List(ctx context.Context) ([]plugin.Entry, error) {
 	}
 	entries := make([]plugin.Entry, len(pvcList.Items))
 	for i, p := range pvcList.Items {
-		entries[i] = newPVC(pvcI, pv.client.CoreV1().Pods(pv.ns), &p)
+		entries[i] = newPVC(pv, pvcI, pv.client.CoreV1().Pods(pv.ns), &p)
 	}
 	return entries, nil
 }

--- a/plugin/kubernetes/root.go
+++ b/plugin/kubernetes/root.go
@@ -22,7 +22,7 @@ type Root struct {
 	contexts []plugin.Entry
 }
 
-func createContext(raw clientcmdapi.Config, name string, access clientcmd.ConfigAccess) (plugin.Entry, error) {
+func (r *Root) createContext(raw clientcmdapi.Config, name string, access clientcmd.ConfigAccess) (plugin.Entry, error) {
 	config := clientcmd.NewNonInteractiveClientConfig(raw, name, &clientcmd.ConfigOverrides{}, access)
 	cfg, err := config.ClientConfig()
 	if err != nil {
@@ -36,7 +36,7 @@ func createContext(raw clientcmdapi.Config, name string, access clientcmd.Config
 	if err != nil {
 		return nil, err
 	}
-	return &k8context{plugin.NewEntry(name), clientset, cfg, defaultns}, nil
+	return &k8context{r.NewEntry(name), clientset, cfg, defaultns}, nil
 }
 
 // Init for root
@@ -48,12 +48,12 @@ func (r *Root) Init() error {
 		return err
 	}
 
-	r.EntryBase = plugin.NewEntry("kubernetes")
+	r.EntryBase = plugin.NewRootEntry("kubernetes")
 	r.DisableDefaultCaching()
 
 	contexts := make([]plugin.Entry, 0)
 	for name := range raw.Contexts {
-		ctx, err := createContext(raw, name, config.ConfigAccess())
+		ctx, err := r.createContext(raw, name, config.ConfigAccess())
 		if err != nil {
 			journal.Record(context.Background(), "loading context %v failed: %+v", name, err)
 			continue

--- a/plugin/registry.go
+++ b/plugin/registry.go
@@ -17,10 +17,9 @@ type Registry struct {
 // NewRegistry creates a new plugin registry object
 func NewRegistry() *Registry {
 	r := &Registry{
-		EntryBase: NewEntry("/"),
+		EntryBase: NewRootEntry("/"),
 		plugins:   make(map[string]Root),
 	}
-	r.setID("/")
 	r.DisableDefaultCaching()
 
 	return r

--- a/plugin/registry_test.go
+++ b/plugin/registry_test.go
@@ -49,7 +49,7 @@ func (suite *RegistryTestSuite) TestPluginNameRegex() {
 
 func (suite *RegistryTestSuite) TestRegisterPlugin() {
 	reg := NewRegistry()
-	m := &mockRoot{EntryBase: NewEntry("mine")}
+	m := &mockRoot{EntryBase: NewRootEntry("mine")}
 	m.On("Init").Return(nil)
 
 	suite.NoError(reg.RegisterPlugin(m))
@@ -59,7 +59,7 @@ func (suite *RegistryTestSuite) TestRegisterPlugin() {
 
 func (suite *RegistryTestSuite) TestRegisterPluginInitError() {
 	reg := NewRegistry()
-	m := &mockRoot{EntryBase: NewEntry("mine")}
+	m := &mockRoot{EntryBase: NewRootEntry("mine")}
 	m.On("Init").Return(errors.New("failed"))
 
 	suite.EqualError(reg.RegisterPlugin(m), "failed")
@@ -70,7 +70,7 @@ func (suite *RegistryTestSuite) TestRegisterPluginInitError() {
 func (suite *RegistryTestSuite) TestRegisterPluginInvalidPluginName() {
 	panicFunc := func() {
 		reg := NewRegistry()
-		m := &mockRoot{EntryBase: NewEntry("b@dname")}
+		m := &mockRoot{EntryBase: NewRootEntry("b@dname")}
 		_ = reg.RegisterPlugin(m)
 	}
 
@@ -83,7 +83,7 @@ func (suite *RegistryTestSuite) TestRegisterPluginInvalidPluginName() {
 func (suite *RegistryTestSuite) TestRegisterPluginRegisteredPlugin() {
 	panicFunc := func() {
 		reg := NewRegistry()
-		m1 := &mockRoot{EntryBase: NewEntry("mine")}
+		m1 := &mockRoot{EntryBase: NewRootEntry("mine")}
 		_ = reg.RegisterPlugin(m1)
 		_ = reg.RegisterPlugin(m1)
 	}

--- a/plugin/types.go
+++ b/plugin/types.go
@@ -8,7 +8,7 @@ type, and initialize it via NewEntry. For example
 		plugin.EntryBase
 	}
 	...
-	rsc := myResource{plugin.NewEntry("a resource")}
+	rsc := myResource{parentResource.NewEntry("a resource")}
 EntryBase gives the resource a name - which is how it will be displayed in the filesystem
 or referenced via the API - and tools for controlling how its data is cached.
 
@@ -31,16 +31,15 @@ import (
 	"time"
 )
 
-// Entry is a basic named resource type. It is a sealed
-// interface, meaning you must use plugin.NewEntry when
-// creating your plugin objects.
+// Entry is a basic named resource type. It is a sealed interface meaning
+// you must use NewRootEntry, then NewEntry when creating your plugin objects.
 type Entry interface {
 	Metadata(ctx context.Context) (EntryMetadata, error)
+	NewEntry(string) EntryBase
 	name() string
 	attributes() EntryAttributes
 	slashReplacementChar() rune
 	id() string
-	setID(id string)
 	getTTLOf(op defaultOpCode) time.Duration
 }
 

--- a/volume/dir.go
+++ b/volume/dir.go
@@ -22,9 +22,9 @@ type Dir struct {
 }
 
 // NewDir creates a Dir populated from dirs.
-func NewDir(name string, attr plugin.EntryAttributes, cb ContentCB, path string, dirs DirMap) *Dir {
+func NewDir(parent plugin.Entry, name string, attr plugin.EntryAttributes, cb ContentCB, path string, dirs DirMap) *Dir {
 	vd := &Dir{
-		EntryBase: plugin.NewEntry(name),
+		EntryBase: parent.NewEntry(name),
 		contentcb: cb,
 		path:      path,
 		dirs:      dirs,
@@ -41,9 +41,9 @@ func (v *Dir) List(ctx context.Context) ([]plugin.Entry, error) {
 	entries := make([]plugin.Entry, 0, len(root))
 	for name, attr := range root {
 		if attr.Mode().IsDir() {
-			entries = append(entries, NewDir(name, attr, v.contentcb, v.path+"/"+name, v.dirs))
+			entries = append(entries, NewDir(v, name, attr, v.contentcb, v.path+"/"+name, v.dirs))
 		} else {
-			entries = append(entries, NewFile(name, attr, v.contentcb, v.path+"/"+name))
+			entries = append(entries, NewFile(v, name, attr, v.contentcb, v.path+"/"+name))
 		}
 	}
 	return entries, nil

--- a/volume/dir_test.go
+++ b/volume/dir_test.go
@@ -17,13 +17,15 @@ func TestVolumeDir(t *testing.T) {
 		return nil, nil
 	}
 
+	root := plugin.NewRootEntry("/")
+
 	assert.NotNil(t, dmap[""]["path"])
-	vd := NewDir("path", dmap[""]["path"], contentcb, "/path", dmap)
+	vd := NewDir(&root, "path", dmap[""]["path"], contentcb, "/path", dmap)
 	attr := plugin.Attributes(vd)
 	assert.Equal(t, 0755|os.ModeDir, attr.Mode())
 
 	assert.NotNil(t, dmap[""]["path1"])
-	vd = NewDir("path", dmap[""]["path1"], contentcb, "/path1", dmap)
+	vd = NewDir(&root, "path", dmap[""]["path1"], contentcb, "/path1", dmap)
 	entries, err := vd.List(context.Background())
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(entries))
@@ -33,7 +35,7 @@ func TestVolumeDir(t *testing.T) {
 	}
 
 	assert.NotNil(t, dmap[""]["path2"])
-	vd = NewDir("path", dmap[""]["path2"], contentcb, "/path2", dmap)
+	vd = NewDir(&root, "path", dmap[""]["path2"], contentcb, "/path2", dmap)
 	entries, err = vd.List(context.Background())
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(entries))

--- a/volume/file.go
+++ b/volume/file.go
@@ -18,9 +18,9 @@ type File struct {
 }
 
 // NewFile creates a VolumeFile.
-func NewFile(name string, attr plugin.EntryAttributes, cb ContentCB, path string) *File {
+func NewFile(parent plugin.Entry, name string, attr plugin.EntryAttributes, cb ContentCB, path string) *File {
 	vf := &File{
-		EntryBase: plugin.NewEntry(name),
+		EntryBase: parent.NewEntry(name),
 		contentcb: cb,
 		path:      path,
 	}

--- a/volume/file_test.go
+++ b/volume/file_test.go
@@ -12,10 +12,12 @@ import (
 )
 
 func TestVolumeFile(t *testing.T) {
+	root := plugin.NewRootEntry("/")
+
 	now := time.Now()
 	initialAttr := plugin.EntryAttributes{}
 	initialAttr.SetCtime(now)
-	vf := NewFile("mine", initialAttr, func(ctx context.Context, path string) (plugin.SizedReader, error) {
+	vf := NewFile(&root, "mine", initialAttr, func(ctx context.Context, path string) (plugin.SizedReader, error) {
 		assert.Equal(t, "my path", path)
 		return strings.NewReader("hello"), nil
 	}, "my path")
@@ -36,7 +38,9 @@ func TestVolumeFile(t *testing.T) {
 }
 
 func TestVolumeFileErr(t *testing.T) {
-	vf := NewFile("mine", plugin.EntryAttributes{}, func(ctx context.Context, path string) (plugin.SizedReader, error) {
+	root := plugin.NewRootEntry("/")
+
+	vf := NewFile(&root, "mine", plugin.EntryAttributes{}, func(ctx context.Context, path string) (plugin.SizedReader, error) {
 		return nil, errors.New("fail")
 	}, "my path")
 


### PR DESCRIPTION
Allow caching to work on newly created entries. Also remove prefetching as mostly unnecessary and adding lots of hidden traffic.