### PR TITLE
Ensure new entries always have an ID

### DIFF
--- a/fuse/dir.go
+++ b/fuse/dir.go
@@ -55,15 +55,6 @@ func (d *dir) Lookup(ctx context.Context, req *fuse.LookupRequest, resp *fuse.Lo
 	if plugin.ListAction.IsSupportedOn(entry) {
 		childdir := newDir(d.entry.(plugin.Group), entry.(plugin.Group))
 		journal.Record(ctx, "FUSE: Found directory %v", childdir)
-		// Prefetch directory entries into the cache
-		go func() {
-			// Need to use a different context here because we still want the prefetch
-			// to happen even when the current context is cancelled.
-			jid := journal.PIDToID(int(req.Pid))
-			ctx := context.WithValue(context.Background(), journal.Key, jid)
-			_, err := childdir.children(ctx)
-			journal.Record(ctx, "FUSE: Prefetching children of %v complete: %v", childdir, err)
-		}()
 		return childdir, nil
 	}
 


### PR DESCRIPTION
For new entries created in a call to CachedList - which should be all of them - enable creating an ID as-needed by adding the parent ID to the context to be used by those cached operations. This should avoid any scenario where we can't determine a cache ID.

Also remove prefetching. It's mostly not needed and creates lots of implicit traffic that can
slow the rest of the experience. There are some scenarios where prefetching improved responsiveness, but it was equally likely to exceed rate limits on APIs and cause errors.

We could explore re-adding it with something like https://gobyexample.com/worker-pools (and maybe rate limiting) to limit concurrent requests so local responsiveness when not immediately using the prefetched data isn't impacted and to avoid running into rate limiting on APIs we use.