### PR TITLE
Increase duration of AWS session tokens that require MFA to 1 hour

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,8 @@ module github.com/puppetlabs/wash
 // Ensures we get the correct client version, tied to v18.09.3
 replace github.com/docker/docker => github.com/docker/engine v0.0.0-20190226002956-8c91e9672cc8
 
+replace github.com/aws/aws-sdk-go => github.com/MikaelSmith/aws-sdk-go v1.15.31-0.20190409174045-425882cd3d0c
+
 require (
 	bazil.org/fuse v0.0.0-20180421153158-65cc252bf669
 	cloud.google.com/go v0.34.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/InVisionApp/tabular v0.3.0 h1:4DGJoBZRTcgd/O+YgfG7/9bXAQy01tSJxrxWEuH
 github.com/InVisionApp/tabular v0.3.0/go.mod h1:/G6t7qe0ZULisB+FjMsB0Qu0mtJ2CZldq92nXWjfHGI=
 github.com/Microsoft/go-winio v0.4.12 h1:xAfWHN1IrQ0NJ9TBC0KBZoqLjzDTr1ML+4MywiUOryc=
 github.com/Microsoft/go-winio v0.4.12/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
+github.com/MikaelSmith/aws-sdk-go v1.15.31-0.20190409174045-425882cd3d0c h1:/Frpxm8rj23gcQHixm6ludozkTdXrJuSH5N8tidmEV8=
+github.com/MikaelSmith/aws-sdk-go v1.15.31-0.20190409174045-425882cd3d0c/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6 h1:G1bPvciwNyF7IUmKXNt9Ak3m6u9DE1rF+RmtIkBpVdA=

--- a/plugin/aws/profile.go
+++ b/plugin/aws/profile.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
@@ -29,6 +30,9 @@ func newProfile(ctx context.Context, name string) (*profile, error) {
 	sess, err := session.NewSessionWithOptions(session.Options{
 		Profile:                 name,
 		AssumeRoleTokenProvider: stscreds.StdinTokenProvider,
+		// TODO: make this configurable. Different IAM configs may allow different durations.
+		// Use the minimum IAM limit of 1 hour.
+		AssumeRoleTokenDuration: 1 * time.Hour,
 		SharedConfigState:       session.SharedConfigEnable,
 	})
 	if err != nil {


### PR DESCRIPTION
Reduces the frustration of re-entering your MFA token every 15 minutes. IAM allows configuring a limit on accounts from 1 to 12 hours. Chose 1 hour as the minimum limit so all accounts work. We should later make it configurable so those with longer limits can use them.

Explore https://github.com/posilva/go-mfa and https://github.com/AlexRudd/mfa later for additional improvements such as bulk role assumption and automatically generating tokens from the MFA key.

Remove the go.mod replace statement once https://github.com/aws/aws-sdk-go/pull/2554 is merged.

Signed-off-by: Michael Smith <michael.smith@puppet.com>