### PR TITLE
Add the size primary to `wash find`

### DIFF
--- a/cmd/find/sizePrimary.go
+++ b/cmd/find/sizePrimary.go
@@ -30,13 +30,13 @@ var sizeValueRegex = regexp.MustCompile(`^(\+|-)?((\d+)|(\d+[ckMGTP]))$`)
 
 // sizePrimary => -size (+|-)?((\d+)|(\d+[ckMGTP]))
 //
-// where c => character (byte), k => kibibyte, M => megabyte, G => gigabyte, T => terabyte, P => petabyte
+// where c => character (byte), k => kibibyte, M => mebibyte, G => gibibyte, T => tebibyte, P => pebibyte
 //
 // Example inputs:
 //   -size 2   (true if the entry's size in 512-byte blocks, rounded up, is 2)
 //   -size +2  (true if the entry's size in 512-byte blocks, rounded up, is greater than 2)
 //   -size -2  (true if the entry's size in 512-byte blocks, rounded up, is less than 2)
-//   -size +1k (true if the entry's size is greater than 1 kilobyte (1024 bytes))
+//   -size +1k (true if the entry's size is greater than 1 kibibyte (1024 bytes))
 //
 //nolint
 var sizePrimary = newAtom([]string{"-size"}, func(tokens []string) (Predicate, []string, error) {

--- a/cmd/find/sizePrimary.go
+++ b/cmd/find/sizePrimary.go
@@ -30,7 +30,7 @@ var sizeValueRegex = regexp.MustCompile(`^(\+|-)?((\d+)|(\d+[ckMGTP]))$`)
 
 // sizePrimary => -size (+|-)?((\d+)|(\d+[ckMGTP]))
 //
-// where c => character (byte), k => kilobyte, M => megabyte, G => gigabyte, T => terabyte, P => petabyte
+// where c => character (byte), k => kibibyte, M => megabyte, G => gigabyte, T => terabyte, P => petabyte
 //
 // Example inputs:
 //   -size 2   (true if the entry's size in 512-byte blocks, rounded up, is 2)

--- a/cmd/find/sizePrimary.go
+++ b/cmd/find/sizePrimary.go
@@ -63,19 +63,6 @@ var sizePrimary = newAtom([]string{"-size"}, func(tokens []string) (Predicate, [
 
 	p := func(e *apitypes.ListEntry) bool {
 		if !e.Attributes.HasSize() {
-			// TODO: If the user enters an expression like "-size 5 -o -true", then
-			// `wash find` will still include 'e' in its output even if 'e' does not have
-			// a size attribute. This leads to a weird UX in cases like `wash find /aws -size 5 -o true`
-			// b/c the output will contain things that don't have a `size` attribute
-			// (like EC2 instances). When we add the `state` attribute, then an expression
-			// like `wash find /aws -state running -o true` will include entries that don't
-			// have state, like S3 buckets and S3 objects.
-			//
-			// The more general issue here is how we handle entries that do not have the attributes
-			// required by the user's specified primaries when those primaries are or'ed
-			// with other primaries that could potentially return true for that entry. Do
-			// we ignore them? Do we still apply the predicate on them, even if that predicate
-			// may return true? We should figure this out soon.
 			return false
 		}
 		size := e.Attributes.Size()

--- a/cmd/find/sizePrimary.go
+++ b/cmd/find/sizePrimary.go
@@ -1,0 +1,112 @@
+package cmdfind
+
+import (
+	"fmt"
+	"math"
+	"regexp"
+	"strconv"
+	"strings"
+
+	apitypes "github.com/puppetlabs/wash/api/types"
+)
+
+// Use bytesOf instead of a hash so that we generate a more readable
+// panic message
+func bytesOf(unit byte) uint64 {
+	switch unit {
+	case 'c':
+		return 1
+	case 'k':
+		return 1024
+	case 'M':
+		return 1024 * 1024
+	case 'G':
+		return 1024 * 1024 * 1024
+	case 'T':
+		return 1024 * 1024 * 1024 * 1024
+	case 'P':
+		return 1024 * 1024 * 1024 * 1024 * 1024
+	default:
+		panic(fmt.Sprintf("cmdfind.bytesOf received an unexpected unit %v", unit))
+	}
+}
+
+var sizeValueRegex = regexp.MustCompile(`^(\+|-)?((\d+)|(\d+[ckMGTP]))$`)
+
+// sizePrimary => -size (+|-)?((\d+)|(\d+[ckMGTP]))
+//
+// where c => character (byte), k => kilobyte, M => megabyte, G => gigabyte, T => terabyte, P => petabyte
+//
+// Example inputs:
+//   -size 2   (true if the entry's size in 512-byte blocks, rounded up, is 2)
+//   -size +2  (true if the entry's size in 512-byte blocks, rounded up, is greater than 2)
+//   -size -2  (true if the entry's size in 512-byte blocks, rounded up, is less than 2)
+//   -size +1k (true if the entry's size is greater than 1 kilobyte (1024 bytes))
+//
+//nolint
+var sizePrimary = newAtom([]string{"-size"}, func(tokens []string) (Predicate, []string, error) {
+	tokens = tokens[1:]
+	if len(tokens) == 0 {
+		return nil, nil, fmt.Errorf("-size: requires additional arguments")
+	}
+	v := tokens[0]
+	if !sizeValueRegex.MatchString(v) {
+		return nil, nil, fmt.Errorf("-size: %v: illegal size value", v)
+	}
+
+	cmp := v[0]
+	if cmp == '+' || cmp == '-' {
+		v = strings.TrimPrefix(v, string(cmp))
+	} else {
+		cmp = '='
+	}
+
+	p := func(e *apitypes.ListEntry) bool {
+		if !e.Attributes.HasSize() {
+			// TODO: If the user enters an expression like "-size 5 -o -true", then
+			// `wash find` will still include 'e' in its output even if 'e' does not have
+			// a size attribute. This leads to a weird UX in cases like `wash find /aws -size 5 -o true`
+			// b/c the output will contain things that don't have a `size` attribute
+			// (like EC2 instances). When we add the `state` attribute, then an expression
+			// like `wash find /aws -state running -o true` will include entries that don't
+			// have state, like S3 buckets and S3 objects.
+			//
+			// The more general issue here is how we handle entries that do not have the attributes
+			// required by the user's specified primaries when those primaries are or'ed
+			// with other primaries that could potentially return true for that entry. Do
+			// we ignore them? Do we still apply the predicate on them, even if that predicate
+			// may return true? We should figure this out soon.
+			return false
+		}
+		size := e.Attributes.Size()
+
+		var parsedSize uint64
+		if n, err := strconv.ParseUint(v, 10, 32); err == nil {
+			// v (n) is an integer, so convert the size to the # of 512-byte blocks (rounded up).
+			size = uint64(math.Ceil(float64(size) / 512.0))
+			parsedSize = n
+		} else {
+			// v is followed by a scale indicator
+			endIx := len(v) - 1
+			unit := v[endIx]
+			n, err := strconv.ParseUint(v[0:endIx], 10, 32)
+			if err != nil {
+				// We should never hit this code-path because sizeValueRegex
+				// already verified that v[0:endIx] is an integer.
+				msg := fmt.Sprintf("errored parsing size %v, which is an expected integer: %v", v[0:endIx], err)
+				panic(msg)
+			}
+			parsedSize = n * bytesOf(unit)
+		}
+
+		switch cmp {
+		case '+':
+			return size > parsedSize
+		case '-':
+			return size < parsedSize
+		default:
+			return size == parsedSize
+		}
+	}
+	return p, tokens[1:], nil
+})

--- a/cmd/find/sizePrimary.go
+++ b/cmd/find/sizePrimary.go
@@ -9,25 +9,21 @@ import (
 	apitypes "github.com/puppetlabs/wash/api/types"
 )
 
-// Use bytesOf instead of a hash so that we generate a more readable
-// panic message
+var bytesMap = map[byte]uint64{
+	'c': 1,
+	'k': 1024,
+	'M': 1024 * 1024,
+	'G': 1024 * 1024 * 1024,
+	'T': 1024 * 1024 * 1024 * 1024,
+	'P': 1024 * 1024 * 1024 * 1024 * 1024,
+}
+
+// Use bytesOf to generate a more readable panic message
 func bytesOf(unit byte) uint64 {
-	switch unit {
-	case 'c':
-		return 1
-	case 'k':
-		return 1024
-	case 'M':
-		return 1024 * 1024
-	case 'G':
-		return 1024 * 1024 * 1024
-	case 'T':
-		return 1024 * 1024 * 1024 * 1024
-	case 'P':
-		return 1024 * 1024 * 1024 * 1024 * 1024
-	default:
-		panic(fmt.Sprintf("cmdfind.bytesOf received an unexpected unit %v", unit))
+	if b, ok := bytesMap[unit]; ok {
+		return b
 	}
+	panic(fmt.Sprintf("cmdfind.bytesOf received an unexpected unit %v", unit))
 }
 
 var sizeValueRegex = regexp.MustCompile(`^(\+|-)?((\d+)|(\d+[ckMGTP]))$`)

--- a/cmd/find/sizePrimary.go
+++ b/cmd/find/sizePrimary.go
@@ -5,7 +5,6 @@ import (
 	"math"
 	"regexp"
 	"strconv"
-	"strings"
 
 	apitypes "github.com/puppetlabs/wash/api/types"
 )
@@ -56,7 +55,7 @@ var sizePrimary = newAtom([]string{"-size"}, func(tokens []string) (Predicate, [
 
 	cmp := v[0]
 	if cmp == '+' || cmp == '-' {
-		v = strings.TrimPrefix(v, string(cmp))
+		v = v[1:]
 	} else {
 		cmp = '='
 	}

--- a/cmd/find/sizePrimary_test.go
+++ b/cmd/find/sizePrimary_test.go
@@ -35,6 +35,7 @@ func (suite *SizePrimaryTestSuite) TestSizePrimaryIllegalTimeValueError() {
 	illegalValues := []string{
 		"foo",
 		"+",
+		"+++++1",
 		"1kb",
 		"+1kb",
 	}

--- a/cmd/find/sizePrimary_test.go
+++ b/cmd/find/sizePrimary_test.go
@@ -1,0 +1,92 @@
+package cmdfind
+
+import (
+	"fmt"
+	"testing"
+
+	apitypes "github.com/puppetlabs/wash/api/types"
+	"github.com/stretchr/testify/suite"
+)
+
+type SizePrimaryTestSuite struct {
+	suite.Suite
+}
+
+func (suite *SizePrimaryTestSuite) TestBytesOf() {
+	testCases := map[byte]uint64{
+		'c': 1,
+		'k': 1024,
+		'M': 1024 * 1024,
+		'G': 1024 * 1024 * 1024,
+		'T': 1024 * 1024 * 1024 * 1024,
+		'P': 1024 * 1024 * 1024 * 1024 * 1024,
+	}
+	for input, expected := range testCases {
+		suite.Equal(expected, bytesOf(input))
+	}
+}
+
+func (suite *SizePrimaryTestSuite) TestSizePrimaryInsufficientArgsError() {
+	_, _, err := sizePrimary.parsePredicate([]string{"-size"})
+	suite.Equal("-size: requires additional arguments", err.Error())
+}
+
+func (suite *SizePrimaryTestSuite) TestSizePrimaryIllegalTimeValueError() {
+	illegalValues := []string{
+		"foo",
+		"+",
+		"1kb",
+		"+1kb",
+	}
+	for _, v := range illegalValues {
+		_, _, err := sizePrimary.parsePredicate([]string{"-size", v})
+		msg := fmt.Sprintf("-size: %v: illegal size value", v)
+		suite.Equal(msg, err.Error())
+	}
+}
+
+func (suite *SizePrimaryTestSuite) TestSizePrimaryValidInput() {
+	type testCase struct {
+		input string
+		// trueSize/falseSize represent entry sizes that satisfy/unsatisfy
+		// the predicate, respectively.
+		trueSize  uint64
+		falseSize uint64
+	}
+	testCases := []testCase{
+		// We set trueSize to 1.5 blocks in order to test rounding
+		testCase{"2", uint64(1.5 * 512), 512},
+		// +2 means p will return true if size > 2 blocks
+		testCase{"+2", 3 * 512, 1 * 512},
+		// -2 means p will return true if size < 2 blocks
+		testCase{"-2", 1 * 512, 2 * 512},
+		testCase{"1k", 1 * bytesOf('k'), 1 * bytesOf('c')},
+		testCase{"+1k", 2 * bytesOf('k'), 1 * bytesOf('k')},
+		testCase{"-1k", 1 * bytesOf('c'), 1 * bytesOf('k')},
+		// This case tests the multiplication by n, where here
+		// n = 2
+		testCase{"2k", 2 * bytesOf('k'), 1 * bytesOf('k')},
+	}
+	for _, testCase := range testCases {
+		inputStr := func() string {
+			return fmt.Sprintf("Input was '%v'", testCase.input)
+		}
+		p, tokens, err := sizePrimary.parsePredicate([]string{"-size", testCase.input})
+		if suite.NoError(err, inputStr()) {
+			suite.Equal([]string{}, tokens)
+			e := &apitypes.ListEntry{}
+			// Ensure p(e) is always false for an entry that doesn't have a size attribute
+			suite.False(p(e), inputStr())
+
+			e.Attributes.SetSize(testCase.trueSize)
+			suite.True(p(e), inputStr())
+
+			e.Attributes.SetSize(testCase.falseSize)
+			suite.False(p(e), inputStr())
+		}
+	}
+}
+
+func TestSizePrimary(t *testing.T) {
+	suite.Run(t, new(SizePrimaryTestSuite))
+}

--- a/cmd/find/sizePrimary_test.go
+++ b/cmd/find/sizePrimary_test.go
@@ -13,16 +13,18 @@ type SizePrimaryTestSuite struct {
 }
 
 func (suite *SizePrimaryTestSuite) TestBytesOf() {
-	testCases := map[byte]uint64{
-		'c': 1,
-		'k': 1024,
-		'M': 1024 * 1024,
-		'G': 1024 * 1024 * 1024,
-		'T': 1024 * 1024 * 1024 * 1024,
-		'P': 1024 * 1024 * 1024 * 1024 * 1024,
+	// Use array of bytes instead of a string to make it easier
+	// to add other, longer units in the future
+	testCases := []byte{
+		'c',
+		'k',
+		'M',
+		'G',
+		'T',
+		'P',
 	}
-	for input, expected := range testCases {
-		suite.Equal(expected, bytesOf(input))
+	for _, input := range testCases {
+		suite.Equal(bytesMap[input], bytesOf(input))
 	}
 }
 

--- a/cmd/find/timeAttrPrimary.go
+++ b/cmd/find/timeAttrPrimary.go
@@ -5,7 +5,6 @@ import (
 	"math"
 	"regexp"
 	"strconv"
-	"strings"
 	"time"
 
 	apitypes "github.com/puppetlabs/wash/api/types"
@@ -123,7 +122,7 @@ func newTimeAttrPrimary(name string) *atom {
 
 		cmp := v[0]
 		if cmp == '+' || cmp == '-' {
-			v = strings.TrimPrefix(v, string(cmp))
+			v = v[1:]
 		} else {
 			cmp = '='
 		}

--- a/cmd/find/timeAttrPrimary.go
+++ b/cmd/find/timeAttrPrimary.go
@@ -19,23 +19,21 @@ func SetStartTime(time time.Time) {
 	startTime = time
 }
 
+var durationsMap = map[byte]time.Duration{
+	's': time.Second,
+	'm': time.Minute,
+	'h': time.Hour,
+	'd': 24 * time.Hour,
+	'w': 7 * 24 * time.Hour,
+}
+
 // Use durationOf instead of a hash so that we generate a more readable
 // panic message
 func durationOf(unit byte) time.Duration {
-	switch unit {
-	case 's':
-		return time.Second
-	case 'm':
-		return time.Minute
-	case 'h':
-		return time.Hour
-	case 'd':
-		return 24 * time.Hour
-	case 'w':
-		return 7 * 24 * time.Hour
-	default:
-		panic(fmt.Sprintf("cmdfind.durationOf received an unexpected unit %v", unit))
+	if d, ok := durationsMap[unit]; ok {
+		return d
 	}
+	panic(fmt.Sprintf("cmdfind.durationOf received an unexpected unit %v", unit))
 }
 
 // We use getTimeAttrValue to retrieve the time attribute's value for performance

--- a/cmd/find/timeAttrPrimary_test.go
+++ b/cmd/find/timeAttrPrimary_test.go
@@ -22,15 +22,17 @@ func (suite *TimeAttrPrimaryTestSuite) TeardownTest() {
 }
 
 func (suite *TimeAttrPrimaryTestSuite) TestDurationOf() {
-	testCases := map[byte]time.Duration{
-		's': time.Second,
-		'm': time.Minute,
-		'h': time.Hour,
-		'd': 24 * time.Hour,
-		'w': 7 * 24 * time.Hour,
+	// Use array of bytes instead of a string to make it easier
+	// to add other, longer units in the future
+	testCases := []byte{
+		's',
+		'm',
+		'h',
+		'd',
+		'w',
 	}
-	for input, expected := range testCases {
-		suite.Equal(expected, durationOf(input))
+	for _, input := range testCases {
+		suite.Equal(durationsMap[input], durationOf(input))
 	}
 }
 

--- a/cmd/find/timeAttrPrimary_test.go
+++ b/cmd/find/timeAttrPrimary_test.go
@@ -98,8 +98,10 @@ func (suite *TimeAttrPrimaryTestSuite) TestTimeAttrPrimaryIllegalTimeValueError(
 	illegalValues := []string{
 		"foo",
 		"+",
+		"+++++1",
 		"1hr",
 		"+1hr",
+		"++++++1hr",
 		"1h30min",
 		"+1h30min",
 	}


### PR DESCRIPTION
The size primary was modeled off its counterpart in BSD's `find`
command.

Signed-off-by: Enis Inan <enis.inan@puppet.com>