### PR TITLE
Improve wash ls subcommand

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -15,16 +15,17 @@ import (
 	"github.com/puppetlabs/wash/config"
 )
 
-func lsCommand() *cobra.Command {
-	lsCmd := &cobra.Command{
-		Use:   "ls [file]",
-		Short: "Lists the resources at the indicated path.",
-		Args:  cobra.MaximumNArgs(1),
+func listCommand() *cobra.Command {
+	listCmd := &cobra.Command{
+		Use:     "list [file]",
+		Aliases: []string{"ls"},
+		Short:   "Lists the resources at the indicated path.",
+		Args:    cobra.MaximumNArgs(1),
 	}
 
-	lsCmd.RunE = toRunE(lsMain)
+	listCmd.RunE = toRunE(listMain)
 
-	return lsCmd
+	return listCmd
 }
 
 func formatListEntries(apiPath string, ls []apitypes.ListEntry) string {
@@ -62,7 +63,7 @@ func formatListEntries(apiPath string, ls []apitypes.ListEntry) string {
 	return cmdutil.FormatTable(headers, table)
 }
 
-func lsMain(cmd *cobra.Command, args []string) exitCode {
+func listMain(cmd *cobra.Command, args []string) exitCode {
 	var path string
 	if len(args) > 0 {
 		path = args[0]

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -49,7 +49,7 @@ func rootCommand() *cobra.Command {
 	rootCmd.AddCommand(versionCommand())
 	rootCmd.AddCommand(serverCommand())
 	rootCmd.AddCommand(metaCommand())
-	rootCmd.AddCommand(lsCommand())
+	rootCmd.AddCommand(listCommand())
 	rootCmd.AddCommand(execCommand())
 	rootCmd.AddCommand(psCommand())
 	rootCmd.AddCommand(findCommand())


### PR DESCRIPTION
Renames the `wash ls` command to `wash list` to make it more consistent with the API. Also includes `wash ls` as an alias to `wash list` to preserve familiarity with the `ls` command.

Fixes listing
- files
- the wash root directory
- wash plugin roots

Also simplifies code around listing the current directory, and introduces a foundation for listing non-resource paths.

Updates `wash list` to work for normal files and directories. Emits similar table content to that used for wash resources.

Resolves #204.