### PR TITLE
Require absolute paths for the Wash API

### DIFF
--- a/api/error.go
+++ b/api/error.go
@@ -131,7 +131,7 @@ func erroredActionResponse(path string, a plugin.Action, reason string) *errorRe
 
 func duplicateCNameResponse(e plugin.DuplicateCNameErr) *errorResponse {
 	fields := apitypes.ErrorFields{
-		"parent_path":                         e.ParentPath,
+		"parent_id":                           e.ParentID,
 		"first_child_name":                    e.FirstChildName,
 		"first_child_slash_replacement_char":  e.FirstChildSlashReplacementChar,
 		"second_child_name":                   e.SecondChildName,
@@ -146,4 +146,32 @@ func duplicateCNameResponse(e plugin.DuplicateCNameErr) *errorResponse {
 	)
 
 	return &errorResponse{http.StatusInternalServerError, body}
+}
+
+func relativePathResponse(path string) *errorResponse {
+	fields := apitypes.ErrorFields{
+		"path": path,
+	}
+
+	body := newErrorObj(
+		apitypes.RelativePath,
+		fmt.Sprintf("%v is a relative path. The Wash API only accepts absolute paths.", path),
+		fields,
+	)
+
+	return &errorResponse{http.StatusBadRequest, body}
+}
+
+func nonWashEntryResponse(path string) *errorResponse {
+	fields := apitypes.ErrorFields{
+		"path": path,
+	}
+
+	body := newErrorObj(
+		apitypes.NonWashEntry,
+		fmt.Sprintf("%v is not a Wash entry.", path),
+		fields,
+	)
+
+	return &errorResponse{http.StatusBadRequest, body}
 }

--- a/api/helpers.go
+++ b/api/helpers.go
@@ -73,17 +73,16 @@ func getEntryFromPath(ctx context.Context, path string) (plugin.Entry, *errorRes
 		// TODO: Handle these later by wrapping them into entries
 		return nil, nonWashEntryResponse(path)
 	}
-	path = trimmedPath
+	// Don't interpret trailing slash as a new segment, and ignore optional leading slash
+	path = strings.Trim(trimmedPath, "/")
 
 	// Get the registry from context (added by registry middleware).
 	registry := ctx.Value(pluginRegistryKey).(*plugin.Registry)
-	if path == "/" {
+	if path == "" {
 		// Return the registry
 		return registry, nil
 	}
 
-	// Don't interpret trailing slash as a new segment, and ignore optional leading slash
-	path = strings.Trim(path, "/")
 	// Split into plugin name and an optional list of segments.
 	segments := strings.Split(path, "/")
 	pluginName := segments[0]

--- a/api/helpers_test.go
+++ b/api/helpers_test.go
@@ -121,7 +121,12 @@ func (suite *HelpersTestSuite) TestGetEntryFromPath() {
 	_, err = getEntryFromPath(ctx, "/file")
 	suite.Error(nonWashEntryResponse("/file"), err)
 
-	entry, err := getEntryFromPath(ctx, mountpoint+"/")
+	entry, err := getEntryFromPath(ctx, mountpoint)
+	if suite.Nil(err) {
+		suite.Equal(reg.Name(), plugin.Name(entry))
+	}
+
+	entry, err = getEntryFromPath(ctx, mountpoint+"/")
 	if suite.Nil(err) {
 		suite.Equal(reg.Name(), plugin.Name(entry))
 	}

--- a/api/helpers_test.go
+++ b/api/helpers_test.go
@@ -78,7 +78,7 @@ func (suite *HelpersTestSuite) TestFindEntry() {
 	duplicateFoo := plugin.NewEntry("foo#bar")
 	group.entries = append(group.entries, &duplicateFoo)
 	expectedErr := plugin.DuplicateCNameErr{
-		ParentPath:                      plugin.Path(group),
+		ParentID:                        plugin.ID(group),
 		FirstChildName:                  foo.Name(),
 		FirstChildSlashReplacementChar:  '#',
 		SecondChildName:                 duplicateFoo.Name(),
@@ -112,31 +112,40 @@ func (suite *HelpersTestSuite) TestGetEntryFromPath() {
 	suite.NoError(reg.RegisterPlugin(plug))
 	ctx := context.WithValue(context.Background(), pluginRegistryKey, reg)
 
-	entry, err := getEntryFromPath(ctx, "/")
+	mountpoint := "/mountpoint"
+	ctx = context.WithValue(ctx, mountpointKey, mountpoint)
+
+	_, err := getEntryFromPath(ctx, "relative")
+	suite.Error(relativePathResponse("relative"), err)
+
+	_, err = getEntryFromPath(ctx, "/file")
+	suite.Error(nonWashEntryResponse("/file"), err)
+
+	entry, err := getEntryFromPath(ctx, mountpoint+"/")
 	if suite.Nil(err) {
 		suite.Equal(reg.Name(), plugin.Name(entry))
 	}
 
-	entry, err = getEntryFromPath(ctx, "/mine")
+	entry, err = getEntryFromPath(ctx, mountpoint+"/mine")
 	if suite.Nil(err) {
 		suite.Equal(plug.Name(), plugin.Name(entry))
 	}
 
-	_, err = getEntryFromPath(ctx, "/yours")
+	_, err = getEntryFromPath(ctx, mountpoint+"/yours")
 	suite.Error(err)
 
 	file := plugin.NewEntry("a file")
 	file.SetTestID("/mine/a file")
 	plug.On("List", mock.Anything).Return([]plugin.Entry{&file}, nil)
 
-	entry, err = getEntryFromPath(ctx, "/mine/a file")
+	entry, err = getEntryFromPath(ctx, mountpoint+"/mine/a file")
 	if suite.Nil(err) {
 		suite.Equal(file.Name(), plugin.Name(entry))
 	}
 	plug.AssertExpectations(suite.T())
 
 	plug.On("List", mock.Anything).Return([]plugin.Entry{&file}, nil)
-	_, err = getEntryFromPath(ctx, "/mine/a dir")
+	_, err = getEntryFromPath(ctx, mountpoint+"/mine/a dir")
 	suite.Error(err)
 	plug.AssertExpectations(suite.T())
 }

--- a/api/info.go
+++ b/api/info.go
@@ -21,6 +21,7 @@ var infoHandler handler = func(w http.ResponseWriter, r *http.Request, p params)
 	w.WriteHeader(http.StatusOK)
 	jsonEncoder := json.NewEncoder(w)
 	apiEntry := toAPIEntry(entry)
+	apiEntry.Path = path
 	if err := jsonEncoder.Encode(&apiEntry); err != nil {
 		journal.Record(ctx, "API: Info: marshalling %v errored: %v", path, err)
 		return unknownErrorResponse(fmt.Errorf("Could not marshal %v: %v", path, err))

--- a/api/list.go
+++ b/api/list.go
@@ -53,7 +53,12 @@ var listHandler handler = func(w http.ResponseWriter, r *http.Request, p params)
 
 	result := make([]apitypes.Entry, 0, len(entries))
 	for _, entry := range entries {
-		result = append(result, toAPIEntry(entry))
+		apiEntry := toAPIEntry(entry)
+		// Use += for efficiency
+		apiEntry.Path = path
+		apiEntry.Path += "/"
+		apiEntry.Path += apiEntry.CName
+		result = append(result, apiEntry)
 	}
 	journal.Record(ctx, "API: List %v %+v", path, result)
 

--- a/api/list.go
+++ b/api/list.go
@@ -54,10 +54,7 @@ var listHandler handler = func(w http.ResponseWriter, r *http.Request, p params)
 	result := make([]apitypes.Entry, 0, len(entries))
 	for _, entry := range entries {
 		apiEntry := toAPIEntry(entry)
-		// Use += for efficiency
-		apiEntry.Path = path
-		apiEntry.Path += "/"
-		apiEntry.Path += apiEntry.CName
+		apiEntry.Path = path + "/" + apiEntry.CName
 		result = append(result, apiEntry)
 	}
 	journal.Record(ctx, "API: List %v %+v", path, result)

--- a/api/types/error.go
+++ b/api/types/error.go
@@ -39,4 +39,6 @@ const (
 	BadRequest         = "puppetlabs.wash/bad-request"
 	ErroredAction      = "puppetlabs.wash/errored-action"
 	DuplicateCName     = "puppetlabs.wash/duplicate-cname"
+	RelativePath       = "puppetlabs.wash/relative-path"
+	NonWashEntry       = "puppetlabs.wash/non-wash-entry"
 )

--- a/cmd/clear.go
+++ b/cmd/clear.go
@@ -34,14 +34,8 @@ func clearMain(cmd *cobra.Command, args []string) exitCode {
 	}
 	verbose := viper.GetBool("verbose")
 
-	apiPath, err := client.APIKeyFromPath(path)
-	if err != nil {
-		cmdutil.ErrPrintf("%v\n", err)
-		return exitCode{1}
-	}
-
 	conn := client.ForUNIXSocket(config.Socket)
-	cleared, err := conn.Clear(apiPath)
+	cleared, err := conn.Clear(path)
 	if err != nil {
 		cmdutil.ErrPrintf("%v\n", err)
 		return exitCode{1}
@@ -52,7 +46,7 @@ func clearMain(cmd *cobra.Command, args []string) exitCode {
 			fmt.Println("Cleared", p)
 		}
 	} else {
-		fmt.Println("Cleared", apiPath)
+		fmt.Println("Cleared", path)
 	}
 
 	return exitCode{0}

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -75,15 +75,9 @@ func execMain(cmd *cobra.Command, args []string) exitCode {
 	command = args[1]
 	commandArgs = args[2:]
 
-	apiPath, err := client.APIKeyFromPath(path)
-	if err != nil {
-		cmdutil.ErrPrintf("%v\n", err)
-		return exitCode{1}
-	}
-
 	conn := client.ForUNIXSocket(config.Socket)
 
-	ch, err := conn.Exec(apiPath, command, commandArgs, apitypes.ExecOptions{})
+	ch, err := conn.Exec(path, command, commandArgs, apitypes.ExecOptions{})
 	if err != nil {
 		cmdutil.ErrPrintf("%v\n", err)
 		return exitCode{1}

--- a/cmd/find.go
+++ b/cmd/find.go
@@ -66,11 +66,14 @@ func findMain(cmd *cobra.Command, args []string) exitCode {
 		entries = append(entries, children...)
 	}
 
-	for _, entry := range entries {
+	for i, entry := range entries {
 		if p(&entry) {
-			// TODO: Include the cwd's directory in path (so that find
-			// prints out absolute paths).
-			fmt.Printf("%v\n", entry.Path)
+			entryPath := path
+			if len(entries) > 1 && i != 0 {
+				entryPath += "/"
+				entryPath += entry.CName
+			}
+			fmt.Printf("%v\n", entryPath)
 		}
 	}
 	return exitCode{0}

--- a/cmd/find.go
+++ b/cmd/find.go
@@ -49,21 +49,16 @@ func findMain(cmd *cobra.Command, args []string) exitCode {
 		return exitCode{1}
 	}
 
-	apiPath, err := client.APIKeyFromPath(path)
-	if err != nil {
-		cmdutil.ErrPrintf("%v\n", err)
-		return exitCode{1}
-	}
 	conn := client.ForUNIXSocket(config.Socket)
 
-	e, err := conn.Info(apiPath)
+	e, err := conn.Info(path)
 	if err != nil {
 		cmdutil.ErrPrintf("%v\n", err)
 		return exitCode{1}
 	}
 	entries := []apitypes.Entry{e}
 	if e.Supports(plugin.ListAction) {
-		children, err := conn.List(apiPath)
+		children, err := conn.List(path)
 		if err != nil {
 			cmdutil.ErrPrintf("%v\n", err)
 			return exitCode{1}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -55,7 +55,7 @@ func formatListEntries(apiPath string, ls []apitypes.Entry) string {
 		verbs := strings.Join(entry.Actions, ", ")
 
 		name := entry.CName
-		if len(ls) > 1 && entry.Path == apiPath {
+		if len(ls) > 1 && i == 0 {
 			// Represent the pwd as "."
 			name = "."
 		}
@@ -128,13 +128,23 @@ func listMain(cmd *cobra.Command, args []string) exitCode {
 		path = args[0]
 	}
 
-	apiPath, err := client.APIKeyFromPath(path)
+	err := listResource(path)
 	if err == nil {
-		err = listResource(apiPath)
-	} else {
-		err = listPath(path)
+		return exitCode{0}
+	}
+	// err != nil
+
+	apiErr, ok := err.(*apitypes.ErrorObj)
+	if !ok {
+		cmdutil.ErrPrintf("%v\n", err)
+		return exitCode{1}
+	}
+	if apiErr.Kind != apitypes.NonWashEntry {
+		cmdutil.ErrPrintf("%v\n", err)
+		return exitCode{1}
 	}
 
+	err = listPath(path)
 	if err != nil {
 		cmdutil.ErrPrintf("%v\n", err)
 		return exitCode{1}

--- a/cmd/meta.go
+++ b/cmd/meta.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/puppetlabs/wash/api/client"
-	"github.com/puppetlabs/wash/cmd/util"
+	cmdutil "github.com/puppetlabs/wash/cmd/util"
 	"github.com/puppetlabs/wash/config"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -44,15 +44,9 @@ func metaMain(cmd *cobra.Command, args []string) exitCode {
 		return exitCode{1}
 	}
 
-	apiPath, err := client.APIKeyFromPath(path)
-	if err != nil {
-		cmdutil.ErrPrintf("%v\n", err)
-		return exitCode{1}
-	}
-
 	conn := client.ForUNIXSocket(config.Socket)
 
-	metadata, err := conn.Metadata(apiPath)
+	metadata, err := conn.Metadata(path)
 	if err != nil {
 		cmdutil.ErrPrintf("%v\n", err)
 		return exitCode{1}

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"runtime/pprof"
 	"strings"
 	"syscall"
@@ -60,6 +61,12 @@ func serverMain(cmd *cobra.Command, args []string) exitCode {
 	logfile := viper.GetString("logfile")
 	externalPluginsPath := viper.GetString("external-plugins")
 
+	mountpoint, err := filepath.Abs(mountpoint)
+	if err != nil {
+		cmdutil.ErrPrintf("Could not compute the absolute path of the mountpoint %v: %v", mountpoint, err)
+		return exitCode{1}
+	}
+
 	logFH, err := loadLogger(loglevel, logfile)
 	if err != nil {
 		cmdutil.ErrPrintf("Failed to load the logger: %v\n", err)
@@ -90,7 +97,7 @@ func serverMain(cmd *cobra.Command, args []string) exitCode {
 
 	plugin.InitCache()
 
-	apiServerStopCh, apiServerStoppedCh, err := api.StartAPI(registry, config.Socket)
+	apiServerStopCh, apiServerStoppedCh, err := api.StartAPI(registry, mountpoint, config.Socket)
 	if err != nil {
 		log.Warn(err)
 		return exitCode{1}

--- a/fuse/core.go
+++ b/fuse/core.go
@@ -71,7 +71,7 @@ func newFuseNode(ftype string, parent plugin.Group, entry plugin.Entry) *fuseNod
 }
 
 func (f *fuseNode) String() string {
-	return plugin.Path(f.entry)
+	return plugin.ID(f.entry)
 }
 
 // Applies attributes where non-default, and sets defaults otherwise.
@@ -147,22 +147,6 @@ func (f *fuseNode) Attr(ctx context.Context, a *fuse.Attr) error {
 	f.applyAttr(a, &attr)
 	journal.Record(ctx, "FUSE: Attr finished %v", f)
 	log.Infof("FUSE: Attr[%v,jid=%v] %v %v", f.ftype, journal.GetID(ctx), f, a)
-	return nil
-}
-
-func (f *fuseNode) Listxattr(ctx context.Context, req *fuse.ListxattrRequest, resp *fuse.ListxattrResponse) error {
-	log.Infof("FUSE: Listxattr[%v,jid=%v] %v", f.ftype, journal.GetID(ctx), f)
-	resp.Append("wash.id")
-	return nil
-}
-
-func (f *fuseNode) Getxattr(ctx context.Context, req *fuse.GetxattrRequest, resp *fuse.GetxattrResponse) error {
-	log.Infof("FUSE: Getxattr[%v,jid=%v] %v", f.ftype, journal.GetID(ctx), f)
-	switch req.Name {
-	case "wash.id":
-		resp.Xattr = []byte(f.String())
-	}
-
 	return nil
 }
 

--- a/fuse/file.go
+++ b/fuse/file.go
@@ -19,8 +19,6 @@ type file struct {
 
 var _ fs.Node = (*file)(nil)
 var _ = fs.NodeOpener(&file{})
-var _ = fs.NodeGetxattrer(&file{})
-var _ = fs.NodeListxattrer(&file{})
 
 func newFile(p plugin.Group, e plugin.Entry) *file {
 	return &file{newFuseNode("f", p, e)}

--- a/plugin/cache.go
+++ b/plugin/cache.go
@@ -117,7 +117,7 @@ func CachedOp(ctx context.Context, opName string, entry Entry, ttl time.Duration
 // DuplicateCNameErr represents a duplicate cname error, which
 // occurs when at least two children have the same cname.
 type DuplicateCNameErr struct {
-	ParentPath                      string
+	ParentID                        string
 	FirstChildName                  string
 	FirstChildSlashReplacementChar  rune
 	SecondChildName                 string
@@ -127,14 +127,14 @@ type DuplicateCNameErr struct {
 
 func (c DuplicateCNameErr) Error() string {
 	pluginName := strings.SplitN(
-		strings.TrimLeft(c.ParentPath, "/"),
+		strings.TrimLeft(c.ParentID, "/"),
 		"/",
 		2,
 	)[0]
 
 	return fmt.Sprintf(
 		"error listing %v: children %v and %v have the same cname of %v. This means that either the %v plugin's API returns duplicate names, or that you need to use a different slash replacement character (see EntryBase#SetSlashReplacementCharar)",
-		c.ParentPath,
+		c.ParentID,
 		c.FirstChildName,
 		c.SecondChildName,
 		c.CName,
@@ -167,7 +167,7 @@ func CachedList(ctx context.Context, g Group) (map[string]Entry, error) {
 
 			if duplicateEntry, ok := searchedEntries[cname]; ok {
 				return nil, DuplicateCNameErr{
-					ParentPath:                      g.id(),
+					ParentID:                        g.id(),
 					FirstChildName:                  duplicateEntry.name(),
 					FirstChildSlashReplacementChar:  duplicateEntry.slashReplacementChar(),
 					SecondChildName:                 entry.name(),

--- a/plugin/cache_test.go
+++ b/plugin/cache_test.go
@@ -186,7 +186,7 @@ func (suite *CacheTestSuite) TestCachedOp() {
 
 func (suite *CacheTestSuite) TestDuplicateCNameErr() {
 	err := DuplicateCNameErr{
-		ParentPath:                      "/my_plugin/foo",
+		ParentID:                        "/my_plugin/foo",
 		FirstChildName:                  "foo/bar/",
 		FirstChildSlashReplacementChar:  '#',
 		SecondChildName:                 "foo#bar/",
@@ -282,7 +282,7 @@ func (suite *CacheTestSuite) TestCachedListCNameErrors() {
 	_, err := CachedList(ctx, entry)
 	if suite.Error(err) {
 		expectedErr := DuplicateCNameErr{
-			ParentPath:                      "/my_plugin/foo",
+			ParentID:                        "/my_plugin/foo",
 			FirstChildName:                  "foo/bar/",
 			FirstChildSlashReplacementChar:  '#',
 			SecondChildName:                 "foo#bar/",

--- a/plugin/helpers.go
+++ b/plugin/helpers.go
@@ -56,13 +56,13 @@ func CName(e Entry) string {
 	)
 }
 
-// Path returns the entry's path rooted at Wash's mountpoint. This is what
-// the API consumes. An entry's path is described as
+// ID returns the entry's ID, which is just its path rooted at Wash's mountpoint.
+// An entry's ID is described as
 //     /<plugin_name>/<group1_cname>/<group2_cname>/.../<entry_cname>
 //
 // NOTE: <plugin_name> is really <plugin_cname>. However since <plugin_name>
 // can never contain a '/', <plugin_cname> reduces to <plugin_name>.
-func Path(e Entry) string {
+func ID(e Entry) string {
 	return e.id()
 }
 

--- a/plugin/helpers_test.go
+++ b/plugin/helpers_test.go
@@ -37,11 +37,11 @@ func (suite *HelpersTestSuite) TestCName() {
 	suite.Equal("foo:bar:baz", CName(&e))
 }
 
-func (suite *HelpersTestSuite) TestPath() {
+func (suite *HelpersTestSuite) TestID() {
 	e := NewEntry("foo")
 	e.setID("/foo/bar")
 
-	suite.Equal(Path(&e), "/foo/bar")
+	suite.Equal(ID(&e), "/foo/bar")
 }
 
 type helpersTestsMockEntry struct {


### PR DESCRIPTION
This removes the dependency on xattr for determining the API key. It
also paves the way for the API to support regular files/directories
(i.e. non-Wash entries) in subsequent commits.

Signed-off-by: Enis Inan <enis.inan@puppet.com>

Contributions to this project require sign-off consistent with the [Developers Certificate of Origin](https://developercertificate.org). This can be as simple as using `git commit -s` on each commit.