### PR TITLE
Extend Wash API to support local files and directories

### DIFF
--- a/api/error.go
+++ b/api/error.go
@@ -161,17 +161,3 @@ func relativePathResponse(path string) *errorResponse {
 
 	return &errorResponse{http.StatusBadRequest, body}
 }
-
-func nonWashEntryResponse(path string) *errorResponse {
-	fields := apitypes.ErrorFields{
-		"path": path,
-	}
-
-	body := newErrorObj(
-		apitypes.NonWashEntry,
-		fmt.Sprintf("%v is not a Wash entry.", path),
-		fields,
-	)
-
-	return &errorResponse{http.StatusBadRequest, body}
-}

--- a/api/fs/core.go
+++ b/api/fs/core.go
@@ -4,8 +4,6 @@ package apifs
 
 import (
 	"os"
-	"syscall"
-	"time"
 
 	"github.com/puppetlabs/wash/plugin"
 )
@@ -17,15 +15,13 @@ type fsnode struct {
 }
 
 func newFSNode(finfo os.FileInfo, path string) *fsnode {
-	// TODO: Need to case this on platform since finfo.Sys()
-	// contains platform-specific data
-	statT := finfo.Sys().(*syscall.Stat_t)
+	// TODO: finfo.Sys() contains more detailed file attributes,
+	// but it's platform-specific. We should eventually use it for
+	// a more complete implementation of apifs.
 	attr := plugin.EntryAttributes{}
 	attr.
-		SetCtime(timespecToTime(statT.Ctimespec)).
-		SetAtime(timespecToTime(statT.Atimespec)).
-		SetMtime(timespecToTime(statT.Mtimespec)).
-		SetMode(os.FileMode(statT.Mode)).
+		SetMtime(finfo.ModTime()).
+		SetMode(finfo.Mode()).
 		SetSize(uint64(finfo.Size())).
 		SetMeta(plugin.ToMeta(finfo))
 
@@ -49,8 +45,4 @@ func NewEntry(path string) (plugin.Entry, error) {
 		return newDir(finfo, path), nil
 	}
 	return newFile(finfo, path), nil
-}
-
-func timespecToTime(t syscall.Timespec) time.Time {
-	return time.Unix(t.Sec, t.Nsec)
 }

--- a/api/fs/core.go
+++ b/api/fs/core.go
@@ -1,0 +1,56 @@
+// Package apifs is used by the Wash API to convert local files/directories
+// into Wash entries
+package apifs
+
+import (
+	"os"
+	"syscall"
+	"time"
+
+	"github.com/puppetlabs/wash/plugin"
+)
+
+// fsnode => filesystem node
+type fsnode struct {
+	plugin.EntryBase
+	path string
+}
+
+func newFSNode(finfo os.FileInfo, path string) *fsnode {
+	// TODO: Need to case this on platform since finfo.Sys()
+	// contains platform-specific data
+	statT := finfo.Sys().(*syscall.Stat_t)
+	attr := plugin.EntryAttributes{}
+	attr.
+		SetCtime(timespecToTime(statT.Ctimespec)).
+		SetAtime(timespecToTime(statT.Atimespec)).
+		SetMtime(timespecToTime(statT.Mtimespec)).
+		SetMode(os.FileMode(statT.Mode)).
+		SetSize(uint64(finfo.Size())).
+		SetMeta(plugin.ToMeta(finfo))
+
+	n := &fsnode{
+		EntryBase: plugin.NewEntry(finfo.Name()),
+		path:      path,
+	}
+	n.DisableDefaultCaching()
+	n.SetAttributes(attr)
+	return n
+}
+
+// NewEntry constructs a new Wash entry from the given FS
+// path
+func NewEntry(path string) (plugin.Entry, error) {
+	finfo, err := os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+	if finfo.IsDir() {
+		return newDir(finfo, path), nil
+	}
+	return newFile(finfo, path), nil
+}
+
+func timespecToTime(t syscall.Timespec) time.Time {
+	return time.Unix(t.Sec, t.Nsec)
+}

--- a/api/fs/dir.go
+++ b/api/fs/dir.go
@@ -1,0 +1,36 @@
+package apifs
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	"github.com/puppetlabs/wash/plugin"
+)
+
+type dir struct {
+	*fsnode
+}
+
+func newDir(finfo os.FileInfo, path string) *dir {
+	return &dir{
+		newFSNode(finfo, path),
+	}
+}
+
+func (d *dir) List(ctx context.Context) ([]plugin.Entry, error) {
+	matches, err := filepath.Glob(filepath.Join(d.path, "*"))
+	if err != nil {
+		return nil, err
+	}
+
+	entries := make([]plugin.Entry, len(matches))
+	for i, match := range matches {
+		entry, err := NewEntry(match)
+		if err != nil {
+			return nil, err
+		}
+		entries[i] = entry
+	}
+	return entries, nil
+}

--- a/api/fs/file.go
+++ b/api/fs/file.go
@@ -1,0 +1,28 @@
+package apifs
+
+import (
+	"bytes"
+	"context"
+	"io/ioutil"
+	"os"
+
+	"github.com/puppetlabs/wash/plugin"
+)
+
+type file struct {
+	*fsnode
+}
+
+func newFile(finfo os.FileInfo, path string) *file {
+	return &file{
+		newFSNode(finfo, path),
+	}
+}
+
+func (f *file) Open(ctx context.Context) (plugin.SizedReader, error) {
+	content, err := ioutil.ReadFile(f.path)
+	if err != nil {
+		return nil, err
+	}
+	return bytes.NewReader(content), nil
+}

--- a/api/helpers.go
+++ b/api/helpers.go
@@ -73,6 +73,12 @@ func getEntryFromPath(ctx context.Context, path string) (plugin.Entry, *errorRes
 	trimmedPath := strings.TrimPrefix(path, mountpoint)
 	if trimmedPath == path {
 		// Local file/directory, so convert it to a Wash entry
+		//
+		// TODO: The code here means that the Wash server cannot be
+		// mounted on a remote machine. This is not an immediate issue,
+		// but it does mean that we'll need to re-evaluate this code once
+		// we get to the point where supporting remote Wash servers is
+		// desirable.
 		e, err := apifs.NewEntry(path)
 		if err != nil {
 			if os.IsNotExist(err) {

--- a/api/helpers_test.go
+++ b/api/helpers_test.go
@@ -118,8 +118,7 @@ func (suite *HelpersTestSuite) TestGetEntryFromPath() {
 	_, err := getEntryFromPath(ctx, "relative")
 	suite.Error(relativePathResponse("relative"), err)
 
-	_, err = getEntryFromPath(ctx, "/file")
-	suite.Error(nonWashEntryResponse("/file"), err)
+	// TODO: Add tests for non-Wash entries (i.e. for apifs)
 
 	entry, err := getEntryFromPath(ctx, mountpoint)
 	if suite.Nil(err) {

--- a/api/types/error.go
+++ b/api/types/error.go
@@ -40,5 +40,4 @@ const (
 	ErroredAction      = "puppetlabs.wash/errored-action"
 	DuplicateCName     = "puppetlabs.wash/duplicate-cname"
 	RelativePath       = "puppetlabs.wash/relative-path"
-	NonWashEntry       = "puppetlabs.wash/non-wash-entry"
 )

--- a/cmd/tail.go
+++ b/cmd/tail.go
@@ -56,10 +56,6 @@ func tailStream(conn client.DomainSocketClient, agg chan line, path string) io.C
 	stream, err := conn.Stream(path)
 	if err != nil {
 		if errObj, ok := err.(*apitypes.ErrorObj); ok {
-			if errObj.Kind == apitypes.NonWashEntry {
-				// Not a resource
-				return nil
-			}
 			if errObj.Kind == apitypes.UnsupportedAction {
 				// The resource exists but does not support the streaming action
 				return nil

--- a/plugin/cache.go
+++ b/plugin/cache.go
@@ -149,10 +149,6 @@ func (c DuplicateCNameErr) Error() string {
 // querying a specific entry.
 func CachedList(ctx context.Context, g Group) (map[string]Entry, error) {
 	cachedEntries, err := cachedDefaultOp(ctx, ListOp, g, func() (interface{}, error) {
-		if g.id() == "" {
-			panic("cannot List an entry that you just created")
-		}
-
 		// Including the entry's ID allows plugin authors to use any Cached* methods defined on the
 		// children after their creation. This is necessary when the child's Cached* methods are used
 		// to calculate its attributes. Note that the child's ID is set in cachedOp.
@@ -240,6 +236,10 @@ func cachedOp(ctx context.Context, opName string, entry Entry, ttl time.Duration
 		}
 	}
 
+	if ttl < 0 {
+		return op()
+	}
+
 	if entry.id() == "" {
 		// Try to set the ID based on parent ID
 		if obj := ctx.Value(parentID); obj != nil {
@@ -248,10 +248,6 @@ func cachedOp(ctx context.Context, opName string, entry Entry, ttl time.Duration
 		} else {
 			panic(fmt.Sprintf("Cached op %v on %v had no cache ID and context did not include parent ID", opName, entry.name()))
 		}
-	}
-
-	if ttl < 0 {
-		return op()
 	}
 
 	return cache.GetOrUpdate(opName, entry.id(), ttl, false, op)

--- a/plugin/cache_test.go
+++ b/plugin/cache_test.go
@@ -219,13 +219,8 @@ func (suite *CacheTestSuite) testCachedDefaultOp(
 
 	entry := newCacheTestsMockEntry("mock")
 
-	// Test that cachedDefaultOp panics if entry.id() == "" if not passed
-	// a suitable context.
-	suite.Panics(panicFunc, "entry.id() returned an empty ID")
-
 	// Test that cachedDefaultOp does _not_ call cache#GetOrUpdate for an
 	// entry that's turned off caching
-	entry.SetTestID("id")
 	entry.On(opName, mock.Anything).Return(opValue, nil)
 	entry.DisableCachingFor(op)
 	v, err := cachedDefaultOp(ctx, entry)
@@ -233,6 +228,11 @@ func (suite *CacheTestSuite) testCachedDefaultOp(
 		suite.Equal(mungedOpValue, v)
 	}
 	suite.cache.AssertNotCalled(suite.T(), "GetOrUpdate")
+
+	// Test that cachedDefaultOp panics if entry.id() == "" if not passed
+	// a suitable context.
+	suite.Panics(panicFunc, "entry.id() returned an empty ID")
+	entry.SetTestID("id")
 
 	// Test that cachedDefaultOp does call cache#GetOrUpdate for an
 	// entry that's enabled caching, and that it passes-in the

--- a/plugin/helpers.go
+++ b/plugin/helpers.go
@@ -63,6 +63,10 @@ func CName(e Entry) string {
 // NOTE: <plugin_name> is really <plugin_cname>. However since <plugin_name>
 // can never contain a '/', <plugin_cname> reduces to <plugin_name>.
 func ID(e Entry) string {
+	if e.id() == "" {
+		msg := fmt.Sprintf("plugin.ID: entry %v (cname %v) has no ID", e.name(), CName(e))
+		panic(msg)
+	}
 	return e.id()
 }
 

--- a/plugin/helpers_test.go
+++ b/plugin/helpers_test.go
@@ -38,9 +38,13 @@ func (suite *HelpersTestSuite) TestCName() {
 }
 
 func (suite *HelpersTestSuite) TestID() {
-	e := NewEntry("foo")
-	e.setID("/foo/bar")
+	e := NewEntry("foo/bar")
 
+	suite.Panics(
+		func() { ID(&e) },
+		"plugin.ID: entry foo (cname foo#bar) has no ID",
+	)
+	e.setID("/foo/bar")
 	suite.Equal(ID(&e), "/foo/bar")
 }
 


### PR DESCRIPTION
This commit adds the apifs package, which is used by the API to convert
local files/directories into Wash entries. This means that custom commands
built on the API are no longer required to special-case on them.

Signed-off-by: Enis Inan <enis.inan@puppet.com>

Contributions to this project require sign-off consistent with the [Developers Certificate of Origin](https://developercertificate.org). This can be as simple as using `git commit -s` on each commit.