### PR TITLE
Prettify error messages

### DIFF
--- a/api/error.go
+++ b/api/error.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 
@@ -44,8 +45,15 @@ type errorResponse struct {
 	body       *apitypes.ErrorObj
 }
 
+// Used when formatting to write an HTTP response, so serialize as JSON.
 func (e *errorResponse) Error() string {
-	return e.body.Error()
+	jsonBytes, err := json.Marshal(e.body)
+	if err != nil {
+		// We should never hit this code-path, but better safe than sorry
+		return fmt.Sprintf("Kind: %v, Msg: %v, Fields: %v", e.body.Kind, e.body.Msg, e.body.Fields)
+	}
+
+	return string(jsonBytes)
 }
 
 // Below are all of Wash's API error responses

--- a/api/types/error.go
+++ b/api/types/error.go
@@ -2,7 +2,6 @@
 package apitypes
 
 import (
-	"encoding/json"
 	"fmt"
 )
 
@@ -20,13 +19,7 @@ type ErrorObj struct {
 }
 
 func (e *ErrorObj) Error() string {
-	jsonBytes, err := json.Marshal(e)
-	if err != nil {
-		// We should never hit this code-path, but better safe than sorry
-		return fmt.Sprintf("Kind: %v, Msg: %v, Fields: %v", e.Kind, e.Msg, e.Fields)
-	}
-
-	return string(jsonBytes)
+	return fmt.Sprintf("%v: %v", e.Kind, e.Msg)
 }
 
 // Define error kinds returned by the API


### PR DESCRIPTION
Make error messages more readable by formatting them client-side.
Previously they would print out the serialized JSON, which is difficult
to read.

Signed-off-by: Michael Smith <michael.smith@puppet.com>