### PR TITLE
Stream logs from VMs

### DIFF
--- a/api/exec.go
+++ b/api/exec.go
@@ -29,19 +29,15 @@ func sendPacket(ctx context.Context, w *json.Encoder, p *apitypes.ExecPacket) {
 	}
 }
 
-var outputStreamNames = [2]string{apitypes.Stdout, apitypes.Stderr}
-
 func streamOutput(ctx context.Context, w *json.Encoder, outputCh <-chan plugin.ExecOutputChunk) {
 	if outputCh == nil {
 		return
 	}
 
 	for chunk := range outputCh {
-		stream := outputStreamNames[chunk.StreamID]
-
-		packet := apitypes.ExecPacket{TypeField: stream, Timestamp: chunk.Timestamp}
+		packet := apitypes.ExecPacket{TypeField: chunk.StreamID, Timestamp: chunk.Timestamp}
 		if err := chunk.Err; err != nil {
-			packet.Err = newStreamingErrorObj(stream, err.Error())
+			packet.Err = newStreamingErrorObj(chunk.StreamID, err.Error())
 		} else {
 			packet.Data = chunk.Data
 		}

--- a/api/types/exec.go
+++ b/api/types/exec.go
@@ -1,6 +1,7 @@
 package apitypes
 
 import (
+	"github.com/puppetlabs/wash/plugin"
 	"time"
 )
 
@@ -30,14 +31,11 @@ type ExecBody struct {
 	Opts ExecOptions `json:"opts"`
 }
 
-// ExecPacketType identifies the packet type.
-type ExecPacketType = string
-
-// Enumerates packet types.
+// Enumerates packet types used by the API.
 const (
-	Stdout   ExecPacketType = "stdout"
-	Stderr   ExecPacketType = "stderr"
-	Exitcode ExecPacketType = "exitcode"
+	Stdout   plugin.ExecPacketType = plugin.Stdout
+	Stderr   plugin.ExecPacketType = plugin.Stderr
+	Exitcode plugin.ExecPacketType = "exitcode"
 )
 
 // ExecPacket is a single packet of results from an exec.
@@ -46,8 +44,8 @@ const (
 //
 // swagger:response
 type ExecPacket struct {
-	TypeField ExecPacketType `json:"type"`
-	Timestamp time.Time      `json:"timestamp"`
-	Data      interface{}    `json:"data"`
-	Err       *ErrorObj      `json:"error"`
+	TypeField plugin.ExecPacketType `json:"type"`
+	Timestamp time.Time             `json:"timestamp"`
+	Data      interface{}           `json:"data"`
+	Err       *ErrorObj             `json:"error"`
 }

--- a/plugin/aws/s3Object.go
+++ b/plugin/aws/s3Object.go
@@ -95,7 +95,7 @@ func (o *s3Object) Open(ctx context.Context) (plugin.SizedReader, error) {
 	return &s3ObjectReader{o: o}, nil
 }
 
-func (o *s3Object) Stream(context.Context) (io.Reader, error) {
+func (o *s3Object) Stream(context.Context) (io.ReadCloser, error) {
 	return o.fetchContent(0)
 }
 

--- a/plugin/cleanupReader.go
+++ b/plugin/cleanupReader.go
@@ -1,0 +1,16 @@
+package plugin
+
+import "io"
+
+// CleanupReader is a wrapper for an io.ReadCloser that performs cleanup when closed.
+type CleanupReader struct {
+	io.ReadCloser
+	Cleanup func()
+}
+
+// Close closes the reader it wraps, then calls the Cleanup function and returns any errors.
+func (c CleanupReader) Close() error {
+	err := c.ReadCloser.Close()
+	c.Cleanup()
+	return err
+}

--- a/plugin/cleanupReader_test.go
+++ b/plugin/cleanupReader_test.go
@@ -1,0 +1,35 @@
+package plugin
+
+import (
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCleanupReader(t *testing.T) {
+	called := false
+	cleanup := func() {
+		called = true
+	}
+
+	r, w := io.Pipe()
+	defer w.Close()
+	rdr := CleanupReader{ReadCloser: r, Cleanup: cleanup}
+	go func() {
+		_, err := w.Write([]byte("hello"))
+		assert.NoError(t, err)
+	}()
+
+	buf := make([]byte, 5)
+	n, err := rdr.Read(buf)
+	assert.NoError(t, err)
+	assert.Equal(t, 5, n)
+	assert.Equal(t, "hello", string(buf))
+	assert.False(t, called)
+
+	rdr.Close()
+	assert.True(t, called)
+	_, err = w.Write([]byte("goodbye"))
+	assert.Error(t, err)
+}

--- a/plugin/docker/container-log.go
+++ b/plugin/docker/container-log.go
@@ -52,7 +52,7 @@ func (clf *containerLogFile) Open(ctx context.Context) (plugin.SizedReader, erro
 	return bytes.NewReader(buf.Bytes()), nil
 }
 
-func (clf *containerLogFile) Stream(ctx context.Context) (io.Reader, error) {
+func (clf *containerLogFile) Stream(ctx context.Context) (io.ReadCloser, error) {
 	opts := types.ContainerLogsOptions{ShowStdout: true, ShowStderr: true, Follow: true, Tail: "10"}
 	rdr, err := clf.client.ContainerLogs(ctx, clf.containerName, opts)
 	if err != nil {

--- a/plugin/externalPluginEntry.go
+++ b/plugin/externalPluginEntry.go
@@ -179,7 +179,7 @@ func (s *stdoutStreamer) Close() error {
 }
 
 // Stream streams the entry's content
-func (e *externalPluginEntry) Stream(ctx context.Context) (io.Reader, error) {
+func (e *externalPluginEntry) Stream(ctx context.Context) (io.ReadCloser, error) {
 	cmd, stdoutR, stderrR, err := CreateCommand(
 		e.script.Path(),
 		"stream",

--- a/plugin/kubernetes/pod.go
+++ b/plugin/kubernetes/pod.go
@@ -113,7 +113,7 @@ func (p *pod) Open(ctx context.Context) (plugin.SizedReader, error) {
 	return bytes.NewReader(pdInfo.logContent), nil
 }
 
-func (p *pod) Stream(ctx context.Context) (io.Reader, error) {
+func (p *pod) Stream(ctx context.Context) (io.ReadCloser, error) {
 	var tailLines int64 = 10
 	req := p.client.CoreV1().Pods(p.ns).GetLogs(p.Name(), &corev1.PodLogOptions{Follow: true, TailLines: &tailLines})
 	return req.Stream()

--- a/plugin/kubernetes/pod.go
+++ b/plugin/kubernetes/pod.go
@@ -147,7 +147,33 @@ func (p *pod) Exec(ctx context.Context, cmd string, args []string, opts plugin.E
 	outputCh, stdout, stderr := plugin.CreateExecOutputStreams(ctx)
 	exitcode := 0
 	go func() {
-		streamOpts := remotecommand.StreamOptions{Stdout: stdout, Stderr: stderr, Stdin: opts.Stdin}
+		stdin := opts.Stdin
+		if opts.Tty {
+			// If using a Tty, create an input stream that allows us to send Ctrl-C to end execution;
+			// when a Tty is allocated commands expect user input and will respond to control signals.
+			// Otherwise close input now to ensure commands that depend on EOF execute correctly.
+			r, w := io.Pipe()
+			if stdin != nil {
+				stdin = io.MultiReader(stdin, r)
+			} else {
+				stdin = r
+			}
+
+			go func() {
+				// Close the response on context cancellation. Copying will block until there's more to
+				// read from the exec output. For an action with no more output it may never return.
+				// Asynchronously watch for context cancellation, and when it happens close the response
+				// so the parent goroutine can complete. We expect all contexts to complete eventually.
+				<-ctx.Done()
+
+				// Append Ctrl-C to input to signal end of execution.
+				_, err := w.Write([]byte{0x03})
+				activity.Record(ctx, "Sent ETX on context termination: %v", err)
+				w.Close()
+			}()
+		}
+
+		streamOpts := remotecommand.StreamOptions{Stdout: stdout, Stderr: stderr, Stdin: stdin, Tty: opts.Tty}
 		err = executor.Stream(streamOpts)
 		activity.Record(ctx, "Exec on %v complete: %v", p.Name(), err)
 		if exerr, ok := err.(k8exec.ExitError); ok {

--- a/plugin/outputStream.go
+++ b/plugin/outputStream.go
@@ -6,18 +6,11 @@ import (
 	"time"
 )
 
-const (
-	// StdoutID represents Stdout
-	StdoutID = iota
-	// StderrID represents Stderr
-	StderrID
-)
-
 // OutputStream represents stdout/stderr.
 type OutputStream struct {
 	ctx        context.Context
 	sentCtxErr bool
-	id         int8
+	id         ExecPacketType
 	ch         chan ExecOutputChunk
 	closer     *multiCloser
 }
@@ -91,8 +84,8 @@ func CreateExecOutputStreams(ctx context.Context) (<-chan ExecOutputChunk, *Outp
 	outputCh := make(chan ExecOutputChunk)
 	closer := &multiCloser{ch: outputCh, countdown: 2}
 
-	stdout := &OutputStream{ctx: ctx, id: StdoutID, ch: outputCh, closer: closer}
-	stderr := &OutputStream{ctx: ctx, id: StderrID, ch: outputCh, closer: closer}
+	stdout := &OutputStream{ctx: ctx, id: Stdout, ch: outputCh, closer: closer}
+	stderr := &OutputStream{ctx: ctx, id: Stderr, ch: outputCh, closer: closer}
 
 	return outputCh, stdout, stderr
 }

--- a/plugin/types.go
+++ b/plugin/types.go
@@ -63,9 +63,25 @@ type Root interface {
 }
 
 // ExecOptions is a struct we can add new features to that must be serializable to JSON.
-// Examples of potential features: user, privileged, tty, map of environment variables, string of stdin, timeout.
+// Examples of potential features: user, privileged, map of environment variables, timeout.
 type ExecOptions struct {
+	// Stdin can be used to pass a stream of input to write to stdin when executing the command.
 	Stdin io.Reader
+
+	// Tty instructs the executor to allocate a TTY (pseudo-terminal), which lets Wash communicate
+	// with the running process via its Stdin. The TTY is used to send a process termination signal
+	// (Ctrl+C) via Stdin when the passed-in Exec context is cancelled.
+	//
+	// NOTE TO PLUGIN AUTHORS: The Tty option is only relevant for executors that do not have an API
+	// endpoint to stop a running command (e.g. Docker, Kubernetes). If your executor does have an
+	// API endpoint to stop a running command, then ignore the Tty option. Note that the reason we
+	// make Tty an option instead of having the relevant executors always attach a TTY is because
+	// attaching a TTY can change the behavior of the command that's being executed.
+	//
+	// NOTE TO CALLERS: The Tty option is useful for executing your own stream-like commands (e.g.
+	// tail -f), because it ensures that there are no orphaned processes after the request is
+	// cancelled/finished.
+	Tty bool
 }
 
 // ExecOutputChunk is a struct containing a chunk of the Exec'ed cmd's output.

--- a/plugin/types.go
+++ b/plugin/types.go
@@ -93,7 +93,7 @@ type Execable interface {
 // Streamable is an entry that returns a stream of updates.
 type Streamable interface {
 	Entry
-	Stream(context.Context) (io.Reader, error)
+	Stream(context.Context) (io.ReadCloser, error)
 }
 
 // SizedReader returns a ReaderAt that can report its Size.

--- a/plugin/types.go
+++ b/plugin/types.go
@@ -77,6 +77,9 @@ type ExecOutputChunk struct {
 	Err       error
 }
 
+// StreamTypes provides the name of the corresponding StreamID.
+var StreamTypes = []string{"Stdout", "Stderr"}
+
 // ExecResult is a struct that contains the result of invoking Execable#exec.
 // Any of these fields can be nil. The OutputCh will be closed when execution completes.
 type ExecResult struct {

--- a/plugin/types.go
+++ b/plugin/types.go
@@ -84,17 +84,22 @@ type ExecOptions struct {
 	Tty bool
 }
 
+// ExecPacketType identifies the packet type.
+type ExecPacketType = string
+
+// Enumerates packet types.
+const (
+	Stdout ExecPacketType = "stdout"
+	Stderr ExecPacketType = "stderr"
+)
+
 // ExecOutputChunk is a struct containing a chunk of the Exec'ed cmd's output.
-// For StreamID, 0 = stdout and 1 = stderr.
 type ExecOutputChunk struct {
-	StreamID  int8
+	StreamID  ExecPacketType
 	Timestamp time.Time
 	Data      string
 	Err       error
 }
-
-// StreamTypes provides the name of the corresponding StreamID.
-var StreamTypes = []string{"Stdout", "Stderr"}
 
 // ExecResult is a struct that contains the result of invoking Execable#exec.
 // Any of these fields can be nil. The OutputCh will be closed when execution completes.

--- a/volume/core.go
+++ b/volume/core.go
@@ -8,6 +8,7 @@ package volume
 
 import (
 	"context"
+	"io"
 	"sort"
 	"time"
 
@@ -25,7 +26,8 @@ type Interface interface {
 	VolumeList(context.Context) (DirMap, error)
 	// Accepts a path and returns the content associated with that path.
 	VolumeOpen(context.Context, string) (plugin.SizedReader, error)
-	// TODO: add VolumeStream
+	// Accepts a path and streams updates to the content associated with that path.
+	VolumeStream(context.Context, string) (io.ReadCloser, error)
 }
 
 // A Dir is a map of files in a directory to their attributes.
@@ -51,7 +53,7 @@ func List(ctx context.Context, impl Interface, path string) ([]plugin.Entry, err
 		if attr.Mode().IsDir() {
 			entries = append(entries, newDir(name, attr, impl, path+"/"+name))
 		} else {
-			entries = append(entries, newFile(name, attr, impl.VolumeOpen, path+"/"+name))
+			entries = append(entries, newFile(name, attr, impl, path+"/"+name))
 		}
 	}
 	// Sort entries so they have a deterministic order.

--- a/volume/dir_test.go
+++ b/volume/dir_test.go
@@ -2,6 +2,7 @@ package volume
 
 import (
 	"context"
+	"io"
 	"os"
 	"strings"
 	"testing"
@@ -11,16 +12,20 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type mockEntry struct {
+type mockDirEntry struct {
 	plugin.EntryBase
 	dmap DirMap
 }
 
-func (m *mockEntry) VolumeList(context.Context) (DirMap, error) {
+func (m *mockDirEntry) VolumeList(context.Context) (DirMap, error) {
 	return m.dmap, nil
 }
 
-func (m *mockEntry) VolumeOpen(context.Context, string) (plugin.SizedReader, error) {
+func (m *mockDirEntry) VolumeOpen(context.Context, string) (plugin.SizedReader, error) {
+	return nil, nil
+}
+
+func (m *mockDirEntry) VolumeStream(context.Context, string) (io.ReadCloser, error) {
 	return nil, nil
 }
 
@@ -29,7 +34,7 @@ func TestVolumeDir(t *testing.T) {
 	assert.Nil(t, err)
 
 	plugin.SetTestCache(datastore.NewMemCache())
-	entry := mockEntry{EntryBase: plugin.NewEntry("mine"), dmap: dmap}
+	entry := mockDirEntry{EntryBase: plugin.NewEntry("mine"), dmap: dmap}
 	entry.SetTestID("/mine")
 
 	assert.NotNil(t, dmap[""]["path"])

--- a/volume/file.go
+++ b/volume/file.go
@@ -2,26 +2,24 @@ package volume
 
 import (
 	"context"
+	"io"
 	"time"
 
 	"github.com/puppetlabs/wash/plugin"
 )
 
-// contentCB accepts a path and returns the content associated with that path.
-type contentCB = func(context.Context, string) (plugin.SizedReader, error)
-
 // file represents a file in a volume that has content we can access.
 type file struct {
 	plugin.EntryBase
-	contentcb contentCB
-	path      string
+	impl Interface
+	path string
 }
 
 // newFile creates a VolumeFile.
-func newFile(name string, attr plugin.EntryAttributes, cb contentCB, path string) *file {
+func newFile(name string, attr plugin.EntryAttributes, impl Interface, path string) *file {
 	vf := &file{
 		EntryBase: plugin.NewEntry(name),
-		contentcb: cb,
+		impl:      impl,
 		path:      path,
 	}
 	vf.SetAttributes(attr)
@@ -32,5 +30,9 @@ func newFile(name string, attr plugin.EntryAttributes, cb contentCB, path string
 
 // Open returns the content of the file as a SizedReader.
 func (v *file) Open(ctx context.Context) (plugin.SizedReader, error) {
-	return v.contentcb(ctx, v.path)
+	return v.impl.VolumeOpen(ctx, v.path)
+}
+
+func (v *file) Stream(ctx context.Context) (io.ReadCloser, error) {
+	return v.impl.VolumeStream(ctx, v.path)
 }

--- a/volume/file_test.go
+++ b/volume/file_test.go
@@ -3,6 +3,8 @@ package volume
 import (
 	"context"
 	"errors"
+	"io"
+	"io/ioutil"
 	"strings"
 	"testing"
 	"time"
@@ -11,19 +13,43 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+type mockFileEntry struct {
+	plugin.EntryBase
+	content string
+	err     error
+}
+
+func (m *mockFileEntry) VolumeList(context.Context) (DirMap, error) {
+	return nil, nil
+}
+
+func (m *mockFileEntry) VolumeOpen(context.Context, string) (plugin.SizedReader, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return strings.NewReader(m.content), nil
+}
+
+func (m *mockFileEntry) VolumeStream(context.Context, string) (io.ReadCloser, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return ioutil.NopCloser(strings.NewReader(m.content)), nil
+}
+
 func TestVolumeFile(t *testing.T) {
 	now := time.Now()
 	initialAttr := plugin.EntryAttributes{}
 	initialAttr.SetCtime(now)
-	vf := newFile("mine", initialAttr, func(ctx context.Context, path string) (plugin.SizedReader, error) {
-		assert.Equal(t, "my path", path)
-		return strings.NewReader("hello"), nil
-	}, "my path")
+
+	impl := &mockFileEntry{EntryBase: plugin.NewEntry("parent"), content: "hello"}
+	vf := newFile("mine", initialAttr, impl, "my path")
 
 	attr := plugin.Attributes(vf)
 	expectedAttr := plugin.EntryAttributes{}
 	expectedAttr.SetCtime(now)
 	assert.Equal(t, expectedAttr, attr)
+
 	rdr, err := vf.Open(context.Background())
 	assert.Nil(t, err)
 	if assert.NotNil(t, rdr) {
@@ -33,14 +59,26 @@ func TestVolumeFile(t *testing.T) {
 		assert.Equal(t, int64(n), rdr.Size())
 		assert.Equal(t, "hello", string(buf))
 	}
+
+	rdr2, err := vf.Stream(context.Background())
+	assert.Nil(t, err)
+	if assert.NotNil(t, rdr2) {
+		buf, err := ioutil.ReadAll(rdr2)
+		if assert.NoError(t, err) {
+			assert.Equal(t, "hello", string(buf))
+		}
+	}
 }
 
 func TestVolumeFileErr(t *testing.T) {
-	vf := newFile("mine", plugin.EntryAttributes{}, func(ctx context.Context, path string) (plugin.SizedReader, error) {
-		return nil, errors.New("fail")
-	}, "my path")
+	impl := &mockFileEntry{EntryBase: plugin.NewEntry("parent"), err: errors.New("fail")}
+	vf := newFile("mine", plugin.EntryAttributes{}, impl, "my path")
 
 	rdr, err := vf.Open(context.Background())
 	assert.Nil(t, rdr)
+	assert.Equal(t, errors.New("fail"), err)
+
+	rdr2, err := vf.Stream(context.Background())
+	assert.Nil(t, rdr2)
 	assert.Equal(t, errors.New("fail"), err)
 }

--- a/volume/fs.go
+++ b/volume/fs.go
@@ -90,7 +90,7 @@ func (d *FS) VolumeOpen(ctx context.Context, path string) (plugin.SizedReader, e
 // VolumeStream satisfies the Interface required by List to stream file contents.
 func (d *FS) VolumeStream(ctx context.Context, path string) (io.ReadCloser, error) {
 	activity.Record(ctx, "Streaming %v on %v", path, plugin.ID(d.executor))
-	result, err := d.executor.Exec(ctx, "tail", []string{"-f", path}, plugin.ExecOptions{})
+	result, err := d.executor.Exec(ctx, "tail", []string{"-f", path}, plugin.ExecOptions{Tty: true})
 	if err != nil {
 		activity.Record(ctx, "Exec error in VolumeRead: %v", err)
 		return nil, err

--- a/volume/fs.go
+++ b/volume/fs.go
@@ -42,11 +42,11 @@ func exec(ctx context.Context, executor plugin.Execable, cmdline []string) (*byt
 	for chunk := range result.OutputCh {
 		if chunk.Err != nil {
 			errs = append(errs, chunk.Err)
-		} else if chunk.StreamID == 0 {
-			activity.Record(ctx, "Stdout: %v", chunk.Data)
-			fmt.Fprint(&buf, chunk.Data)
 		} else {
-			activity.Record(ctx, "Stderr: %v", chunk.Data)
+			activity.Record(ctx, "%v: %v", chunk.StreamID, chunk.Data)
+			if chunk.StreamID == plugin.Stdout {
+				fmt.Fprint(&buf, chunk.Data)
+			}
 		}
 	}
 
@@ -107,7 +107,7 @@ func (d *FS) VolumeStream(ctx context.Context, path string) (io.ReadCloser, erro
 				continue
 			}
 
-			activity.Record(ctx, "%v: %v", plugin.StreamTypes[chunk.StreamID], chunk.Data)
+			activity.Record(ctx, "%v: %v", chunk.StreamID, chunk.Data)
 			if len(errs) == 0 {
 				if _, err := w.Write([]byte(chunk.Data)); err != nil {
 					activity.Record(ctx, "Error copying exec result: %v", err)

--- a/volume/fs_test.go
+++ b/volume/fs_test.go
@@ -42,7 +42,7 @@ func createResult(data string) plugin.ExecResult {
 		OutputCh:   outputch,
 		ExitCodeCB: func() (int, error) { return 0, nil },
 	}
-	outputch <- plugin.ExecOutputChunk{Data: data}
+	outputch <- plugin.ExecOutputChunk{StreamID: plugin.Stdout, Data: data}
 	close(outputch)
 	return execResult
 }


### PR DESCRIPTION
Add Stream support to the volume package. Add Tty support to Exec on Docker and Kubernetes to support correctly cleaning up processes after terminating streaming.

Resolves #227.