### PR TITLE
Move parser suite test helpers to a separate package

### DIFF
--- a/cmd/internal/find/parser/parseExpression_test.go
+++ b/cmd/internal/find/parser/parseExpression_test.go
@@ -4,6 +4,7 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/puppetlabs/wash/cmd/internal/find/parser/parsertest"
 	"github.com/puppetlabs/wash/cmd/internal/find/parser/predicate"
 	"github.com/puppetlabs/wash/cmd/internal/find/types"
 	"github.com/stretchr/testify/suite"
@@ -14,18 +15,18 @@ import (
 // the parseExpression function. They're meant to test parser errors, each of
 // the operators, and whether operator precedence is enforced.
 type ParseExpressionTestSuite struct {
-	predicate.ParserTestSuite
+	parsertest.Suite
 }
 
-func (s *ParseExpressionTestSuite) NPETC(input string, errMsg string) predicate.ParserTestCase {
-	return s.ParserTestSuite.NPETC(input, regexp.QuoteMeta(errMsg), false)
+func (s *ParseExpressionTestSuite) NPETC(input string, errMsg string) parsertest.Case {
+	return s.Suite.NPETC(input, regexp.QuoteMeta(errMsg), false)
 }
 
-func (s *ParseExpressionTestSuite) NPTC(input string, expected bool) predicate.ParserTestCase {
+func (s *ParseExpressionTestSuite) NPTC(input string, expected bool) parsertest.Case {
 	if expected {
-		return s.ParserTestSuite.NPTC(input, "", types.Entry{})
+		return s.Suite.NPTC(input, "", types.Entry{})
 	}
-	return s.ParserTestSuite.NPNTC(input, "", types.Entry{})
+	return s.Suite.NPNTC(input, "", types.Entry{})
 }
 
 func (s *ParseExpressionTestSuite) TestParseExpressionEmptyTokens() {

--- a/cmd/internal/find/parser/parsertest/suite.go
+++ b/cmd/internal/find/parser/parsertest/suite.go
@@ -1,21 +1,23 @@
-package predicate
+package parsertest
 
 import (
-	"github.com/puppetlabs/wash/cmd/internal/find/parser/errz"
-	"github.com/stretchr/testify/suite"
 	"fmt"
 	"regexp"
 	"strings"
+
+	"github.com/puppetlabs/wash/cmd/internal/find/parser/errz"
+	"github.com/puppetlabs/wash/cmd/internal/find/parser/predicate"
+	"github.com/stretchr/testify/suite"
 )
 
-// ParserTestSuite represents a type that tests predicate parsers
-type ParserTestSuite struct {
+// Suite represents a type that tests predicate parsers
+type Suite struct {
 	suite.Suite
-	Parser Parser
+	Parser predicate.Parser
 }
 
-// ParserTestCase represents a parser test case
-type ParserTestCase struct {
+// Case represents a parser test case
+type Case struct {
 	Input           string
 	RemInput        string
 	SatisfyingValue interface{}
@@ -23,27 +25,27 @@ type ParserTestCase struct {
 	IsMatchError    bool
 }
 
-// NPTC => NewParserTestCase. Saves some typing
-func (suite *ParserTestSuite) NPTC(input string, remInput string, trueValue interface{}) ParserTestCase {
-	return ParserTestCase{
-		Input: input,
-		RemInput: remInput,
+// NPTC => NewCase. Saves some typing
+func (suite *Suite) NPTC(input string, remInput string, trueValue interface{}) Case {
+	return Case{
+		Input:           input,
+		RemInput:        remInput,
 		SatisfyingValue: trueValue,
 	}
 }
 
 // NPNTC => NewParserNegativeTestCase. Saves some typing
-func (suite *ParserTestSuite) NPNTC(input string, remInput string, falseValue interface{}) ParserTestCase {
-	return ParserTestCase{
-		Input: input,
-		RemInput: remInput,
+func (suite *Suite) NPNTC(input string, remInput string, falseValue interface{}) Case {
+	return Case{
+		Input:           input,
+		RemInput:        remInput,
 		SatisfyingValue: falseV{falseValue},
 	}
 }
 
 // NPETC => NewParserErrorTestCase
-func (suite *ParserTestSuite) NPETC(input string, errRegex string, isMatchError bool) ParserTestCase {
-	return ParserTestCase{
+func (suite *Suite) NPETC(input string, errRegex string, isMatchError bool) Case {
+	return Case{
 		Input:        input,
 		ErrRegex:     regexp.MustCompile(errRegex),
 		IsMatchError: isMatchError,
@@ -51,7 +53,7 @@ func (suite *ParserTestSuite) NPETC(input string, errRegex string, isMatchError 
 }
 
 // RunTestCases runs the given test cases.
-func (suite *ParserTestSuite) RunTestCases(cases ...ParserTestCase) {
+func (suite *Suite) RunTestCases(cases ...Case) {
 	var input string
 	defer func() {
 		if r := recover(); r != nil {
@@ -84,7 +86,7 @@ func (suite *ParserTestSuite) RunTestCases(cases ...ParserTestCase) {
 }
 
 // ToTks => ToTokens. Saves some typing
-func (suite *ParserTestSuite) ToTks(s string) []string {
+func (suite *Suite) ToTks(s string) []string {
 	var tokens = []string{}
 	if s != "" {
 		tokens = strings.Split(s, " ")
@@ -97,4 +99,3 @@ func (suite *ParserTestSuite) ToTks(s string) []string {
 type falseV struct {
 	v interface{}
 }
-

--- a/cmd/internal/find/primary/meta/arrayPredicate_test.go
+++ b/cmd/internal/find/primary/meta/arrayPredicate_test.go
@@ -5,12 +5,13 @@ import (
 	"time"
 
 	"github.com/puppetlabs/wash/cmd/internal/find/params"
+	"github.com/puppetlabs/wash/cmd/internal/find/parser/parsertest"
 	"github.com/puppetlabs/wash/cmd/internal/find/parser/predicate"
 	"github.com/stretchr/testify/suite"
 )
 
 type ArrayPredicateTestSuite struct {
-	predicate.ParserTestSuite
+	parsertest.Suite
 }
 
 func (s *ArrayPredicateTestSuite) SetupTest() {

--- a/cmd/internal/find/primary/meta/emptyPredicate_test.go
+++ b/cmd/internal/find/primary/meta/emptyPredicate_test.go
@@ -3,12 +3,13 @@ package meta
 import (
 	"testing"
 
-	"github.com/stretchr/testify/suite"
+	"github.com/puppetlabs/wash/cmd/internal/find/parser/parsertest"
 	"github.com/puppetlabs/wash/cmd/internal/find/parser/predicate"
+	"github.com/stretchr/testify/suite"
 )
 
 type EmptyPredicateTestSuite struct {
-	predicate.ParserTestSuite
+	parsertest.Suite
 }
 
 func (s *EmptyPredicateTestSuite) TestErrors() {

--- a/cmd/internal/find/primary/meta/numericPredicate_test.go
+++ b/cmd/internal/find/primary/meta/numericPredicate_test.go
@@ -3,13 +3,14 @@ package meta
 import (
 	"testing"
 
-	"github.com/puppetlabs/wash/cmd/internal/find/primary/numeric"
+	"github.com/puppetlabs/wash/cmd/internal/find/parser/parsertest"
 	"github.com/puppetlabs/wash/cmd/internal/find/parser/predicate"
+	"github.com/puppetlabs/wash/cmd/internal/find/primary/numeric"
 	"github.com/stretchr/testify/suite"
 )
 
 type NumericPredicateTestSuite struct {
-	predicate.ParserTestSuite
+	parsertest.Suite
 }
 
 func (s *NumericPredicateTestSuite) TestErrors() {

--- a/cmd/internal/find/primary/meta/objectPredicate_test.go
+++ b/cmd/internal/find/primary/meta/objectPredicate_test.go
@@ -3,12 +3,13 @@ package meta
 import (
 	"testing"
 
-	"github.com/stretchr/testify/suite"
+	"github.com/puppetlabs/wash/cmd/internal/find/parser/parsertest"
 	"github.com/puppetlabs/wash/cmd/internal/find/parser/predicate"
+	"github.com/stretchr/testify/suite"
 )
 
 type ObjectPredicateTestSuite struct {
-	predicate.ParserTestSuite
+	parsertest.Suite
 }
 
 func (s *ObjectPredicateTestSuite) TestKeyRegex() {

--- a/cmd/internal/find/primary/meta/predicate_test.go
+++ b/cmd/internal/find/primary/meta/predicate_test.go
@@ -5,12 +5,13 @@ import (
 	"time"
 
 	"github.com/puppetlabs/wash/cmd/internal/find/params"
+	"github.com/puppetlabs/wash/cmd/internal/find/parser/parsertest"
 	"github.com/puppetlabs/wash/cmd/internal/find/parser/predicate"
 	"github.com/stretchr/testify/suite"
 )
 
 type PredicateTestSuite struct {
-	predicate.ParserTestSuite
+	parsertest.Suite
 }
 
 func (s *PredicateTestSuite) SetupTest() {

--- a/cmd/internal/find/primary/meta/primitivePredicate_test.go
+++ b/cmd/internal/find/primary/meta/primitivePredicate_test.go
@@ -5,13 +5,14 @@ import (
 	"time"
 
 	"github.com/puppetlabs/wash/cmd/internal/find/params"
-	"github.com/puppetlabs/wash/cmd/internal/find/primary/numeric"
+	"github.com/puppetlabs/wash/cmd/internal/find/parser/parsertest"
 	"github.com/puppetlabs/wash/cmd/internal/find/parser/predicate"
+	"github.com/puppetlabs/wash/cmd/internal/find/primary/numeric"
 	"github.com/stretchr/testify/suite"
 )
 
 type PrimitivePredicateTestSuite struct {
-	predicate.ParserTestSuite
+	parsertest.Suite
 }
 
 func (s *PrimitivePredicateTestSuite) SetupTest() {

--- a/cmd/internal/find/primary/meta/stringPredicate_test.go
+++ b/cmd/internal/find/primary/meta/stringPredicate_test.go
@@ -3,12 +3,13 @@ package meta
 import (
 	"testing"
 
-	"github.com/stretchr/testify/suite"
+	"github.com/puppetlabs/wash/cmd/internal/find/parser/parsertest"
 	"github.com/puppetlabs/wash/cmd/internal/find/parser/predicate"
+	"github.com/stretchr/testify/suite"
 )
 
 type StringPredicateTestSuite struct {
-	predicate.ParserTestSuite
+	parsertest.Suite
 }
 
 func (s *StringPredicateTestSuite) TestErrors() {

--- a/cmd/internal/find/primary/meta/timePredicate_test.go
+++ b/cmd/internal/find/primary/meta/timePredicate_test.go
@@ -5,13 +5,14 @@ import (
 	"time"
 
 	"github.com/puppetlabs/wash/cmd/internal/find/params"
-	"github.com/puppetlabs/wash/cmd/internal/find/primary/numeric"
+	"github.com/puppetlabs/wash/cmd/internal/find/parser/parsertest"
 	"github.com/puppetlabs/wash/cmd/internal/find/parser/predicate"
+	"github.com/puppetlabs/wash/cmd/internal/find/primary/numeric"
 	"github.com/stretchr/testify/suite"
 )
 
 type TimePredicateTestSuite struct {
-	predicate.ParserTestSuite
+	parsertest.Suite
 }
 
 func (s *TimePredicateTestSuite) SetupTest() {


### PR DESCRIPTION
When parserTestSuite was added, it introduced importing the `testing`
package (via testify) outside of a test context. That caused the
`test.v` flag to be defined, so initializing the cache in normal
operations (running `wash server`) failed.

Move the parser suite test helpers to their own package that's only used
during testing to avoid this problem.

Signed-off-by: Michael Smith <michael.smith@puppet.com>