### PR TITLE
Fix stage condition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ jobs:
     script: golangci-lint run -v
   - stage: deploy
     name: Deploy to GitHub Releases
-    if: branch = master AND type = push
+    if: tag IS present
     env: LINKFLAGS="-w -s -X github.com/puppetlabs/wash/cmd.version=${TRAVIS_TAG}" CGO_ENABLED=0
     script:
     - GOOS=darwin GOARCH=amd64 go build -ldflags="$LINKFLAGS"


### PR DESCRIPTION
When tagging a release, the build is triggered for branch=<tag>, not
branch=master. Our previous conditional for the deploy stage expected
branch=master so it didn't run for the release. Update the stage to run
whenever a tag is present.

Signed-off-by: Michael Smith <michael.smith@puppet.com>