### PR TITLE
Support predicate expressions in the `meta` primary

### DIFF
--- a/cmd/internal/find/parser/expression/parser.go
+++ b/cmd/internal/find/parser/expression/parser.go
@@ -64,7 +64,7 @@ func NewParser(predicateParser predicate.Parser) *Parser {
 		}
 	}
 	p.atom = &predicate.CompositeParser{
-		ErrMsg: "expected an atom",
+		MatchErrMsg: "expected an atom",
 		Parsers: []predicate.Parser{
 			notOpParser(p),
 			parensOpParser(p),

--- a/cmd/internal/find/parser/expression/parser.go
+++ b/cmd/internal/find/parser/expression/parser.go
@@ -183,15 +183,22 @@ func (parser *Parser) Parse(tokens []string) (predicate.Predicate, []string, err
 	}
 	if _, ok := parser.stack.Peek().(*BinaryOp); ok {
 		// This codepath is possible via something like "p1 -and" or "p1 -and <unknown_token>"
-		if err != nil {
-			// We have "p1 -and <unknown_token>"
-			return nil, nil, err
+		if err == nil {
+			// We have "p1 -and"
+			return nil, nil, fmt.Errorf(
+				"%v: no expression after %v",
+				parser.stack.mostRecentOpToken,
+				parser.stack.mostRecentOpToken,
+			)
 		}
-		return nil, nil, fmt.Errorf(
-			"%v: no expression after %v",
-			parser.stack.mostRecentOpToken,
-			parser.stack.mostRecentOpToken,
-		)
+		// We have "p1 -and <unknown_token>". Pop the binary op off the stack and include
+		// it as part of the remaining tokens. This is useful in case our expression is inside
+		// another expression, where the top-level expression handles combining our parsed
+		// predicate p with whatever's parsed by the "<unknown_token>" bit. For example, it
+		// ensures that the top-level `wash find` parser correctly parses something like
+		// "-m .key foo -o -m .key bar" as "Meta(.key, foo) -o Meta(.key, bar)".
+		parser.stack.Pop()
+		tokens = append([]string{parser.stack.mostRecentOpToken}, tokens...)
 	}
 	// Call s.evaluate() to handle cases like "p1 -and p2"
 	parser.stack.evaluate()

--- a/cmd/internal/find/parser/parseExpression_test.go
+++ b/cmd/internal/find/parser/parseExpression_test.go
@@ -129,6 +129,9 @@ func (s *ParseExpressionTestSuite) TestParseExpressionComplexErrors() {
 	s.RunTestCases(
 		s.NPETC("( -true ) -a )", "): no beginning '('"),
 		s.NPETC("-true -a -foo", "-foo: unknown primary or operator"),
+		// Make sure meta primary expressions are parsed independently of
+		// the top-level `wash find` expression
+		s.NPETC("-m .key (", "-m: (: missing closing ')'"),
 	)
 }
 

--- a/cmd/internal/find/parser/parseExpression_test.go
+++ b/cmd/internal/find/parser/parseExpression_test.go
@@ -69,16 +69,23 @@ func (s *ParseExpressionTestSuite) TestParseExpressionBinOpParseErrors() {
 
 func (s *ParseExpressionTestSuite) TestParseExpressionAndOpEval() {
 	s.RunTestCases(
+		s.NPTC("-false -a -false", false),
+		s.NPTC("-false -false", false),
+		s.NPTC("-false -a -true", false),
+		s.NPTC("-false -true", false),
 		s.NPTC("-true -a -false", false),
 		s.NPTC("-true -false", false),
+		s.NPTC("-true -a -true", true),
 		s.NPTC("-true -true", true),
 	)
 }
 
 func (s *ParseExpressionTestSuite) TestParseExpressionOrOpEval() {
 	s.RunTestCases(
-		s.NPTC("-true -o -false", true),
+		s.NPTC("-false -o -false", false),
 		s.NPTC("-false -o -true", true),
+		s.NPTC("-true -o -false", true),
+		s.NPTC("-true -o -true", true),
 	)
 }
 

--- a/cmd/internal/find/parser/predicate/parser.go
+++ b/cmd/internal/find/parser/predicate/parser.go
@@ -10,7 +10,7 @@ type Parser interface {
 // CompositeParser represents a parser composed of multiple predicate
 // parsers.
 type CompositeParser struct {
-	ErrMsg string
+	MatchErrMsg string
 	Parsers []Parser
 }
 
@@ -24,7 +24,7 @@ func (cp CompositeParser) Parse(tokens []string) (Predicate, []string, error) {
 // ParseAndReturnParserID attempts to parse a predicate from the given tokens. It loops
 // through each of cp's parsers, returning the result of the first parser that matches
 // the input, and the matching parser's ID. If no parser matches the input, then Parse
-// returns a MatchError containing cp.ErrMsg
+// returns a MatchError containing cp.MatchErrMsg
 func (cp CompositeParser) ParseAndReturnParserID(tokens []string) (Predicate, []string, int, error) {
 	for i, parser := range cp.Parsers {
 		p, tokens, err := parser.Parse(tokens)
@@ -38,7 +38,7 @@ func (cp CompositeParser) ParseAndReturnParserID(tokens []string) (Predicate, []
 		}
 	}
 	// None of the parsers matched the input, so return a MatchError
-	return nil, nil, -1, errz.NewMatchError(cp.ErrMsg)		
+	return nil, nil, -1, errz.NewMatchError(cp.MatchErrMsg)		
 }
 
 // ToParser converts the given parse function to a predicate.Parser object

--- a/cmd/internal/find/primary/meta.go
+++ b/cmd/internal/find/primary/meta.go
@@ -3,40 +3,52 @@ package primary
 import "github.com/puppetlabs/wash/cmd/internal/find/primary/meta"
 
 /*
-metaPrimary        => (-meta|-m) ObjectPredicate
-ObjectPredicate    => EmptyPredicate | ‘.’ Key Predicate
-EmptyPredicate     => -empty
-Key                => [ ^.[ ] ]+ (i.e. one or more cs that aren't ".", "[", or "]")
+metaPrimary         => (-meta|-m) Expression
 
-Predicate          => ObjectPredicate     |
-                      ArrayPredicate      |
-                      PrimitivePredicate
+Expression          => EmptyPredicate | KeySequence PredicateExpression
+EmptyPredicate      => -empty
 
-ArrayPredicate     => EmptyPredicate      |
-                      ‘[' ? ‘]’ Predicate |
-                      ‘[' * ‘]’ Predicate |
-                      ‘[' N ‘]’ Predicate |
+KeySequence         => '.' Key Tail
+Key                 => [ ^.[ ] ]+ (i.e. one or more cs that aren't ".", "[", or "]")
+Tail                => '.' Key Tail   |
+                       ‘[' ? ‘]’ Tail |
+                       '[' * ']' Tail |
+                       '[' N ']' Tail |
+                       ""
 
-PrimitivePredicate => NullPredicate       |
-                      ExistsPredicate     |
-                      BooleanPredicate    |
-                      NumericPredicate    |
-                      TimePredicate       |
-                      StringPredicate
+PredicateExpression => (See the comments of expression.Parser#Parse)
 
-NullPredicate      => -null
-ExistsPredicate    => -exists
-BooleanPredicate   => -true | -false
+Predicate           => ObjectPredicate     |
+                       ArrayPredicate      |
+                       PrimitivePredicate
 
-NumericPredicate   => (+|-)? Number
-Number             => N | '{' N '}' | numeric.SizeRegex
+ObjectPredicate     => EmptyPredicate | ‘.’ Key Predicate
 
-TimePredicate      => (+|-)? Duration
-Duration           => numeric.DurationRegex | '{' numeric.DurationRegex '}'
+ArrayPredicate      => EmptyPredicate      |
+                       ‘[' ? ‘]’ Predicate |
+                       ‘[' * ‘]’ Predicate |
+                       ‘[' N ‘]’ Predicate |
 
-StringPredicate    => [^-].*
+PrimitivePredicate  => NullPredicate       |
+                       ExistsPredicate     |
+                       BooleanPredicate    |
+                       NumericPredicate    |
+                       TimePredicate       |
+                       StringPredicate
 
-N                  => \d+ (i.e. some number > 0)
+NullPredicate       => -null
+ExistsPredicate     => -exists
+BooleanPredicate    => -true | -false
+
+NumericPredicate    => (+|-)? Number
+Number              => N | '{' N '}' | numeric.SizeRegex
+
+TimePredicate       => (+|-)? Duration
+Duration            => numeric.DurationRegex | '{' numeric.DurationRegex '}'
+
+StringPredicate     => [^-].*
+
+N                   => \d+ (i.e. some number > 0)
 */
 //nolint
 var metaPrimary = Parser.newPrimary([]string{"-meta", "-m"}, meta.Parse)

--- a/cmd/internal/find/primary/meta/arrayPredicate.go
+++ b/cmd/internal/find/primary/meta/arrayPredicate.go
@@ -18,10 +18,11 @@ func parseArrayPredicate(tokens []string) (predicate.Predicate, []string, error)
 		return p, tokens, err
 	}
 	// EmptyPredicate did not match
+	parsePredicate := predicate.ToParser(parsePredicate)
 	return parseArrayP(
 		tokens,
-		predicate.ToParser(parsePredicate),
-		predicate.ToParser(parsePredicate),
+		parsePredicate,
+		parsePredicate,
 	)
 }
 

--- a/cmd/internal/find/primary/meta/arrayPredicate.go
+++ b/cmd/internal/find/primary/meta/arrayPredicate.go
@@ -6,17 +6,27 @@ import (
 	"strings"
 
 	"github.com/puppetlabs/wash/cmd/internal/find/parser/errz"
+	"github.com/puppetlabs/wash/cmd/internal/find/parser/predicate"
 )
 
 // ArrayPredicate => EmptyPredicate      |
 //                   ‘[' ? ‘]’ Predicate |
 //                   ‘[' * ‘]’ Predicate |
 //                   ‘[' N ‘]’ Predicate |
-func parseArrayPredicate(tokens []string) (Predicate, []string, error) {
+func parseArrayPredicate(tokens []string) (predicate.Predicate, []string, error) {
 	if p, tokens, err := parseEmptyPredicate(tokens); err == nil {
 		return p, tokens, err
 	}
 	// EmptyPredicate did not match
+	return parseArrayP(
+		tokens,
+		predicate.ToParser(parsePredicate),
+		predicate.ToParser(parsePredicate),
+	)
+}
+
+// This helper's used by parseArrayPredicate and parseArrayExpression
+func parseArrayP(tokens []string, baseCaseParser, keySequenceParser predicate.Parser) (predicate.Predicate, []string, error) {
 	if len(tokens) == 0 {
 		return nil, nil, errz.NewMatchError("expected an opening '['")
 	}
@@ -28,8 +38,11 @@ func parseArrayPredicate(tokens []string) (Predicate, []string, error) {
 	if err != nil {
 		return nil, nil, err
 	}
+
+	var p predicate.Predicate
 	if len(token) == 0 {
 		tokens = tokens[1:]
+		p, tokens, err = baseCaseParser.Parse(tokens)
 	} else {
 		// token may be part of a key sequence (e.g. something like
 		// [?].key2 or [?][?])
@@ -40,8 +53,9 @@ func parseArrayPredicate(tokens []string) (Predicate, []string, error) {
 			return nil, nil, fmt.Errorf("expected a '.' or '[' after ']' but got %v instead", token)
 		}
 		tokens[0] = token
+		p, tokens, err = keySequenceParser.Parse(tokens)
 	}
-	p, tokens, err := parsePredicate(tokens)
+
 	if err != nil {
 		if errz.IsMatchError(err) {
 			parsedToken := rawToken[0 : len(rawToken)-len(token)]
@@ -101,12 +115,16 @@ func parseArrayPredicateType(token string) (arrayPredicateType, string, error) {
 	return ptype, token[endIx+1:], nil
 }
 
-func arrayP(ptype arrayPredicateType, p Predicate) Predicate {
+func arrayP(ptype arrayPredicateType, p predicate.Predicate) predicate.Predicate {
+	arryP := &arrayPredicate{
+		ptype: ptype,
+		p: p,
+	}
 	switch ptype.t {
 	case 's':
-		return toArrayP(func(vs []interface{}) bool {
+		arryP.genericPredicate = toArrayP(func(vs []interface{}) bool {
 			for _, v := range vs {
-				if p(v) {
+				if p.IsSatisfiedBy(v) {
 					return true
 				}
 			}
@@ -115,9 +133,9 @@ func arrayP(ptype arrayPredicateType, p Predicate) Predicate {
 			return false
 		})
 	case 'a':
-		return toArrayP(func(vs []interface{}) bool {
+		arryP.genericPredicate = toArrayP(func(vs []interface{}) bool {
 			for _, v := range vs {
-				if !p(v) {
+				if !p.IsSatisfiedBy(v) {
 					return false
 				}
 			}
@@ -126,26 +144,54 @@ func arrayP(ptype arrayPredicateType, p Predicate) Predicate {
 		})
 	case 'n':
 		n := ptype.n
-		return toArrayP(func(vs []interface{}) bool {
+		arryP.genericPredicate = toArrayP(func(vs []interface{}) bool {
 			if n >= uint(len(vs)) {
 				return false
 			}
-			return p(vs[n])
+			return p.IsSatisfiedBy(vs[n])
 		})
 	default:
 		msg := fmt.Sprintf("meta.arrayP called with an unkown ptype %v", ptype.t)
 		panic(msg)
 	}
+	return arryP
 }
 
 // toArrayP is a helper for arrayP that's meant to reduce
 // the boilerplate type validation.
-func toArrayP(p func([]interface{}) bool) Predicate {
-	return func(v interface{}) bool {
+func toArrayP(p func([]interface{}) bool) genericPredicate {
+	return genericPredicate(func(v interface{}) bool {
 		arrayV, ok := v.([]interface{})
 		if !ok {
 			return false
 		}
 		return p(arrayV)
+	})
+}
+
+type arrayPredicate struct {
+	genericPredicate
+	ptype arrayPredicateType
+	p predicate.Predicate
+}
+
+func (arryP *arrayPredicate) Negate() predicate.Predicate {
+	switch t := arryP.ptype.t; t {
+	case 's':
+		// Not("Some element satisfies p") => "All elements satisfy Not(p)"
+		ptype := arrayPredicateType{}
+		ptype.t = 'a'
+		return arrayP(ptype, arryP.p.Negate())
+	case 'a':
+		// Not("All elements satisfy p") => "Some element satisfies Not(p)"
+		ptype := arrayPredicateType{}
+		ptype.t = 's'
+		return arrayP(ptype, arryP.p.Negate())
+	case 'n':
+		// Not("Nth element satisfies p") => "Nth element satisfies Not(p)"
+		return arrayP(arryP.ptype, arryP.p.Negate())
+	default:
+		msg := fmt.Sprintf("meta.arrayPredicate contains an unknown ptype %v", t)
+		panic(msg)
 	}
 }

--- a/cmd/internal/find/primary/meta/emptyPredicate.go
+++ b/cmd/internal/find/primary/meta/emptyPredicate.go
@@ -2,23 +2,45 @@ package meta
 
 import (
 	"github.com/puppetlabs/wash/cmd/internal/find/parser/errz"
+	"github.com/puppetlabs/wash/cmd/internal/find/parser/predicate"
 )
 
 // emptyPredicate => -empty
-func parseEmptyPredicate(tokens []string) (Predicate, []string, error) {
+func parseEmptyPredicate(tokens []string) (predicate.Predicate, []string, error) {
 	if len(tokens) == 0 || tokens[0] != "-empty" {
 		return nil, nil, errz.NewMatchError("expected '-empty'")
 	}
-	return emptyP, tokens[1:], nil
+	return emptyP(false), tokens[1:], nil
 }
 
-func emptyP(v interface{}) bool {
-	switch t := v.(type) {
-	case map[string]interface{}:
-		return len(t) == 0
-	case []interface{}:
-		return len(t) == 0
-	default:
-		return false
+func emptyP(negated bool) predicate.Predicate {
+	return &emptyPredicate{
+		genericPredicate: func(v interface{}) bool {
+			switch t := v.(type) {
+			case map[string]interface{}:
+				if negated {
+					return len(t) > 0
+				}
+				return len(t) == 0
+			case []interface{}:
+				if negated {
+					return len(t) > 0
+				}
+				return len(t) == 0
+			default:
+				return false
+			}	
+		},
+		negated: negated,
 	}
 }
+
+type emptyPredicate struct {
+	genericPredicate
+	negated bool
+}
+
+func (p *emptyPredicate) Negate() predicate.Predicate {
+	return emptyP(!p.negated)
+} 
+

--- a/cmd/internal/find/primary/meta/emptyPredicate_test.go
+++ b/cmd/internal/find/primary/meta/emptyPredicate_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/puppetlabs/wash/cmd/internal/find/parser/parsertest"
+	"github.com/puppetlabs/wash/cmd/internal/find/parser/predicate"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -25,25 +26,41 @@ func (s *EmptyPredicateTestSuite) TestValidInput() {
 }
 
 func (s *EmptyPredicateTestSuite) TestEmptyPInvalidType() {
-	s.False(emptyP("foo"))
+	p := emptyP(false)
+	s.False(p.IsSatisfiedBy("foo"))
+	s.False(p.Negate().IsSatisfiedBy("foo"))
 }
 
 func (s *EmptyPredicateTestSuite) TestEmptyPObject() {
 	mp := make(map[string]interface{})
-	s.True(emptyP(mp))
+	p := emptyP(false)
+	
+	// Test empty map
+	s.True(p.IsSatisfiedBy(mp))
+	s.False(p.Negate().IsSatisfiedBy(mp))
+
+	// Test nonempty map
 	mp["foo"] = 1
-	s.False(emptyP(mp))
+	s.False(p.IsSatisfiedBy(mp))
+	s.True(p.Negate().IsSatisfiedBy(mp))
 }
 
 func (s *EmptyPredicateTestSuite) TestEmptyPArray() {
 	a := []interface{}{}
-	s.True(emptyP(a))
+	p := emptyP(false)
+
+	// Test empty array
+	s.True(p.IsSatisfiedBy(a))
+	s.False(p.Negate().IsSatisfiedBy(a))
+
+	// Test nonempty array
 	a = append(a, 1)
-	s.False(emptyP(a))
+	s.False(p.IsSatisfiedBy(a))
+	s.True(p.Negate().IsSatisfiedBy(a))
 }
 
 func TestEmptyPredicate(t *testing.T) {
 	s := new(EmptyPredicateTestSuite)
-	s.Parser = predicateParser(parseEmptyPredicate)
+	s.Parser = predicate.ToParser(parseEmptyPredicate)
 	suite.Run(t, s)
 }

--- a/cmd/internal/find/primary/meta/expression.go
+++ b/cmd/internal/find/primary/meta/expression.go
@@ -1,0 +1,106 @@
+package meta
+
+import (
+	"fmt"
+
+	"github.com/puppetlabs/wash/cmd/internal/find/parser/errz"
+	"github.com/puppetlabs/wash/cmd/internal/find/parser/predicate"
+)
+
+// The functionality here is tested in primary/meta_test.go
+
+// Expression => EmptyPredicate | KeySequence PredicateExpression
+//
+// To simplify the parsing logic, we will change this to
+//     Expression       => EmptyPredicate | ObjectExpression
+//     ObjectExpression => '.' Key (PredicateExpression | OAExpression)
+//     OAExpression     => ObjectExpression |
+//                         ArrayExpression
+//     ArrayExpression  => ‘[' ? ‘]’ (PredicateExpression | OAExpression) |
+//                         ‘[' * ‘]’ (PredicateExpression | OAExpression) |
+//                         ‘[' N ‘]’ (PredicateExpression | OAExpression) |
+// 
+// For ObjectExpression/ArrayExpression, assume their parsers are given a tokens
+// array that's something like [<token>, <rest>...]. Then, if <token> does not
+// contain a key sequence, <rest> will be parsed as a PredicateExpression. Otherwise,
+// let <token> = <head>:<tail>, where <head> is the "'.' Key" part in ObjectExpression,
+// or the "'[' ? ']'" part in ArrayExpression. Then, [<tail>, <rest>...] will be parsed
+// as an OAExpression.
+//
+// NOTE: The rules in ^ are necessary so that something like
+//     -meta .key1 .key2 -true -a .key3 -false
+// is parsed as "the value of the 'key1' key in the entry's metadata is an object with 'key2'
+// set to true AND is an object with 'key3' set to false". Otherwise, if we constructed the
+// grammar as something like:
+//     ObjectExpression => '.' Key Expr
+//     Expr             => ObjectExpression    |
+//                         ArrayExpression     |
+//                         PredicateExpression
+//     ArrayExpression  => '[' ? ']' Expr | ...
+//
+// (to mirror the symmetry of ObjectPredicate/ArrayPredicate), then our example would instead
+// be parsed as "the value of the 'key1.key2' key in the entry's metadata is set to true AND it
+// is an object with 'key3' set to false". We could get our example to parse correctly with the
+// above grammar via something like "-meta .key1 \( .key2 -true -a .key3 -false \)", but that is
+// annoying and unnecessary clutter.
+//    
+// Thus, the rules for PredicateExpression/OAExpression allow one to cleanly combine object/array
+// predicates on entry metadata values without having to use a parentheses. 
+func parseExpression(tokens []string) (predicate.Predicate, []string, error) {
+	if p, tokens, err := parseEmptyPredicate(tokens); err == nil {
+		return p, tokens, err
+	}
+	p, tokens, err := parseObjectExpression(tokens)
+	if err != nil {
+		if errz.IsMatchError(err) {
+			// We expect an ObjectExpression, so treat any match errors
+			// as syntax errors.
+			err = fmt.Errorf(err.Error())
+		}
+		return nil, nil, err
+	}
+	return p, tokens, nil
+}
+
+func parseObjectExpression(tokens []string) (predicate.Predicate, []string, error) {
+	return parseObjectP(
+		tokens,
+		predicate.ToParser(parsePredicateExpression),
+		predicate.ToParser(parseOAExpression),
+	)
+}
+
+func parseOAExpression(tokens []string) (predicate.Predicate, []string, error) {
+	cp := &predicate.CompositeParser{
+		// This error message should never be used. The following comment explains why.
+		MatchErrMsg: "",
+		Parsers: []predicate.Parser{
+			predicate.ToParser(parseObjectExpression),
+			predicate.ToParser(parseArrayExpression),
+		},
+	}
+	p, tokens, err := cp.Parse(tokens)
+	if err != nil {
+		if errz.IsMatchError(err) {
+			// We should never hit this code-path because parseOAExpression
+			// will only be called by parseObjectExpression/parseArrayExpression
+			// when either method receives a key sequence. Key sequences will always
+			// match parseObjectExpression/parseArrayExpression.
+			msg := fmt.Sprintf(
+				"meta.parseOAExpression: predicate.CompositeParser#Parse returned a match error on a key sequence. Input: %v",
+				tokens,
+			)
+			panic(msg)
+		}
+		return nil, nil, err
+	}
+	return p, tokens, nil
+}
+
+func parseArrayExpression(tokens []string) (predicate.Predicate, []string, error) {
+	return parseArrayP(
+		tokens,
+		predicate.ToParser(parsePredicateExpression),
+		predicate.ToParser(parseOAExpression),
+	)
+}

--- a/cmd/internal/find/primary/meta/objectPredicate.go
+++ b/cmd/internal/find/primary/meta/objectPredicate.go
@@ -24,10 +24,11 @@ func parseObjectPredicate(tokens []string) (predicate.Predicate, []string, error
 		return p, tokens, err
 	}
 	// EmptyPredicate did not match, so try '.' Key Predicate
+	parsePredicate := predicate.ToParser(parsePredicate)
 	return parseObjectP(
 		tokens,
-		predicate.ToParser(parsePredicate),
-		predicate.ToParser(parsePredicate),
+		parsePredicate,
+		parsePredicate,
 	)
 }
 

--- a/cmd/internal/find/primary/meta/parse.go
+++ b/cmd/internal/find/primary/meta/parse.go
@@ -5,14 +5,16 @@ import (
 	"github.com/puppetlabs/wash/cmd/internal/find/types"
 )
 
+// The functionality here is tested in primary/meta_test.go
+
 // Parse is the meta primary's parse function.
 func Parse(tokens []string) (types.EntryPredicate, []string, error) {
-	p, tokens, err := parseObjectPredicate(tokens)
+	p, tokens, err := parseExpression(tokens)
 	if err != nil {
 		return nil, nil, err
 	}
 	return func(e types.Entry) bool {
 		mp := map[string]interface{}(e.Attributes.Meta())
-		return p(mp)
+		return p.IsSatisfiedBy(mp)
 	}, tokens, nil
 }

--- a/cmd/internal/find/primary/meta/predicate.go
+++ b/cmd/internal/find/primary/meta/predicate.go
@@ -4,61 +4,59 @@ import (
 	"github.com/puppetlabs/wash/cmd/internal/find/parser/predicate"
 )
 
-// Predicate represents a meta primary predicate.
-type Predicate func(interface{}) bool
-
-// And returns p1 && p2
-func (p1 Predicate) And(p2 predicate.Predicate) predicate.Predicate {
-	return Predicate(func(v interface{}) bool {
-		return p1(v) && (p2.(Predicate))(v)
-	})
-}
-
-// Or returns p1 || p2
-func (p1 Predicate) Or(p2 predicate.Predicate) predicate.Predicate {
-	return Predicate(func(v interface{}) bool {
-		return p1(v) || (p2.(Predicate))(v)
-	})
-}
-
-// Negate returns Not(p1)
-func (p1 Predicate) Negate() predicate.Predicate {
-	return Predicate(func(v interface{}) bool {
-		return !p1(v)
-	})
-}
-
-// IsSatisfiedBy returns true if v satisfies the predicate, false otherwise
-func (p1 Predicate) IsSatisfiedBy(v interface{}) bool {
-	return p1(v)
-}
-
 /*
 Predicate => ObjectPredicate |
              ArrayPredicate  |
              PrimitivePredicate
 */
-func parsePredicate(tokens []string) (Predicate, []string, error) {
+func parsePredicate(tokens []string) (predicate.Predicate, []string, error) {
 	cp := &predicate.CompositeParser{
-		ErrMsg: "expected either a primitive, object, or array predicate",
+		MatchErrMsg: "expected either a primitive, object, or array predicate",
 		Parsers: []predicate.Parser{
-			predicateParser(parseObjectPredicate),
-			predicateParser(parseArrayPredicate),
-			predicateParser(parsePrimitivePredicate),
+			predicate.ToParser(parseObjectPredicate),
+			predicate.ToParser(parseArrayPredicate),
+			predicate.ToParser(parsePrimitivePredicate),
 		},
 	}
-	p, tokens, err := cp.Parse(tokens)
-	if err != nil {
-		return nil, nil, err
-	}
-	return p.(Predicate), tokens, err
+	return cp.Parse(tokens)
 }
 
+// genericPredicate represents a `meta` primary predicate "base" class.
+// Child classes should only override the Negate method. Here's why:
+//   * Some `meta` primary predicates perform type validation, returning
+//     false for a mis-typed value. genericPredicate#Negate is a strict
+//     negation, so it will return true for a mis-typed value. This is bad.
+//
+//   * Some of the more complicated predicates require additional negation
+//     semantics. For example, ObjectPredicate returns false if the key does
+//     not exist. A negated ObjectPredicate should also return false for this
+//     case.
+//
+// Both of these issues are resolved if the child class overrides Negate.
+type genericPredicate func(interface{}) bool
 
-type predicateParser func(tokens []string) (Predicate, []string, error)
-
-// Parse parses a meta primary predicate from the given input.
-func (parser predicateParser) Parse(tokens []string) (predicate.Predicate, []string, error) {
-	return parser(tokens)
+// And returns p1 && p2
+func (p1 genericPredicate) And(p2 predicate.Predicate) predicate.Predicate {
+	return genericPredicate(func(v interface{}) bool {
+		return p1(v) && p2.IsSatisfiedBy(v)
+	})
 }
 
+// Or returns p1 || p2
+func (p1 genericPredicate) Or(p2 predicate.Predicate) predicate.Predicate {
+	return genericPredicate(func(v interface{}) bool {
+		return p1(v) || p2.IsSatisfiedBy(v)
+	})
+}
+
+// Negate returns Not(p1)
+func (p1 genericPredicate) Negate() predicate.Predicate {
+	return genericPredicate(func(v interface{}) bool {
+		return !p1(v)
+	})
+}
+
+// IsSatisfiedBy returns true if v satisfies the predicate, false otherwise
+func (p1 genericPredicate) IsSatisfiedBy(v interface{}) bool {
+	return p1(v)
+}

--- a/cmd/internal/find/primary/meta/predicateExpression.go
+++ b/cmd/internal/find/primary/meta/predicateExpression.go
@@ -21,7 +21,7 @@ func parsePredicateExpression(tokens []string) (predicate.Predicate, []string, e
 			return nil, nil, err
 		}
 		if p == nil {
-			// possible via something like "-size + 1" or "-true -a -size + 1"
+			// possible via something like "-size + 1"
 			return nil, nil, fmt.Errorf("unknown predicate %v", tkErr.Token)
 		}
 	}

--- a/cmd/internal/find/primary/meta/predicateExpression.go
+++ b/cmd/internal/find/primary/meta/predicateExpression.go
@@ -1,0 +1,31 @@
+package meta
+
+import (
+	"fmt"
+
+	"github.com/puppetlabs/wash/cmd/internal/find/parser/expression"
+	"github.com/puppetlabs/wash/cmd/internal/find/parser/predicate"
+)
+
+// PredicateExpression => (See the comments of expression.Parser#Parse)
+func parsePredicateExpression(tokens []string) (predicate.Predicate, []string, error) {
+	if len(tokens) == 0 {
+		return nil, nil, fmt.Errorf("expected a predicate expression")
+	}
+	parser := expression.NewParser(predicate.ToParser(parsePredicate))
+	p, tks, err := parser.Parse(tokens)
+	if err != nil {
+		tkErr, ok := err.(expression.UnknownTokenError)
+		if !ok {
+			// We have a syntax error
+			return nil, nil, err
+		}
+		if p == nil {
+			// possible via something like "-size + 1" or "-true -a -size + 1"
+			return nil, nil, fmt.Errorf("unknown predicate %v", tkErr.Token)
+		}
+	}
+	// If err != nil here, then err is an UnknownTokenError. An UnknownTokenError
+	// means we've finished parsing the `meta` primary's predicate expression.
+	return p, tks, nil
+}

--- a/cmd/internal/find/primary/meta/predicateExpression_test.go
+++ b/cmd/internal/find/primary/meta/predicateExpression_test.go
@@ -120,16 +120,23 @@ func (s *PredicateExpressionTestSuite) TestBinOpParseErrors() {
 
 func (s *PredicateExpressionTestSuite) TestAndOpEval() {
 	s.RunTestCases(
+		s.NPOETC("-false -a -false -primary", "-primary", false),
+		s.NPOETC("-false -false -primary", "-primary", false),
+		s.NPOETC("-false -a -true -primary", "-primary", false),
+		s.NPOETC("-false -true -primary", "-primary", false),
 		s.NPOETC("-true -a -false -primary", "-primary", false),
 		s.NPOETC("-true -false -primary", "-primary", false),
+		s.NPOETC("-true -a -true -primary", "-primary", true),
 		s.NPOETC("-true -true -primary", "-primary", true),
 	)
 }
 
 func (s *PredicateExpressionTestSuite) TestOrOpEval() {
 	s.RunTestCases(
-		s.NPOETC("-true -o -false -primary", "-primary", true),
-		s.NPOETC("-false -o -true -primary", "-primary", true),
+		s.NPTC("-false -o -false -primary", "-primary", false),
+		s.NPTC("-false -o -true -primary", "-primary", true),
+		s.NPTC("-true -o -false -primary", "-primary", true),
+		s.NPTC("-true -o -true -primary", "-primary", true),
 	)
 }
 

--- a/cmd/internal/find/primary/meta/predicateExpression_test.go
+++ b/cmd/internal/find/primary/meta/predicateExpression_test.go
@@ -182,7 +182,6 @@ func (s *PredicateExpressionTestSuite) TestParensEval() {
 func (s *PredicateExpressionTestSuite) TestComplexErrors() {
 	s.RunTestCases(
 		s.NPETC("( -true ) -a )", "): no beginning '('"),
-		s.NPETC("-true -a -foo", "unknown predicate -foo"),
 		s.NPETC(".key -a -foo", "expected a predicate after key"),
 	)
 }

--- a/cmd/internal/find/primary/meta/predicateExpression_test.go
+++ b/cmd/internal/find/primary/meta/predicateExpression_test.go
@@ -1,0 +1,219 @@
+package meta
+
+import (
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/puppetlabs/wash/cmd/internal/find/params"
+	"github.com/puppetlabs/wash/cmd/internal/find/parser/parsertest"
+	"github.com/puppetlabs/wash/cmd/internal/find/parser/predicate"
+	"github.com/stretchr/testify/suite"
+)
+
+// The predicates are tested separately in their *Predicate.go files, so they
+// will not be tested here. Instead, the tests here serve as "integration tests" for
+// the parsePredicateExpression function. They're meant to test parser errors, each of
+// the operators, and whether operator precedence is enforced. 
+
+type PredicateExpressionTestSuite struct {
+	parsertest.Suite
+}
+
+func (s *PredicateExpressionTestSuite) NPETC(input string, errRegex string) parsertest.Case {
+	return s.Suite.NPETC(input, regexp.QuoteMeta(errRegex), false)
+}
+
+// NPOETC => NewParserOpEvalTestCase. input should only contain Boolean predicates (-true/-false).
+// The Boolean predicates are meant to represent individual predicates that evaluate to -true/-false,
+// respectively. Thus, NPOETC("-false -o -false", "", false) is read as "Test that if p1 returns false,
+// and p2 returns false, then p1 -o p2 returns false". It is _not_ meant to be confused with
+// NPTC("-false -o -false", "", false), which is read as "Test that the parsed predicate returns true if
+// v is false OR is false". In other words, in NPTC, "-false" is a Boolean predicate while in NPOETC,
+// "-false" represents _any_ predicate p (object/array/primitive/...) that returns false. NPOETC is useful
+// to make binary op/parens op tests more expressive.
+func (s *PredicateExpressionTestSuite) NPOETC(input string, remInput string, expectedValue bool) parsertest.Case {
+	// -false/-true will still be parsed as Boolean predicates. Using "true" as the satisfying value in
+	// both cases ensures that -false/-true represent an arbitrary predicate p that returns false/true,
+	// respectively (since -false(true) == false, -true(true) == true).
+	if expectedValue {
+		return s.NPTC(input, remInput, true)
+	}
+	return s.NPNTC(input, remInput, true)
+}
+
+func (s *PredicateExpressionTestSuite) SetupTest() {
+	params.StartTime = time.Now()
+}
+
+func (s *PredicateExpressionTestSuite) TeardownTest() {
+	params.StartTime = time.Time{}
+}
+
+func (s *PredicateExpressionTestSuite) TestEmptyExpression() {
+	s.RunTestCases(
+		s.NPETC("", "expected a predicate expression"),
+		s.NPETC("-primary", "unknown predicate -primary"),
+	)
+}
+
+func (s *PredicateExpressionTestSuite) TestNotOpParseErrors() {
+	s.RunTestCases(
+		// Test error when "-not" is supplied without an expression
+		s.NPETC("-not", "-not: no following expression"),
+		// Test error when "-not" is mixed with parentheses
+		s.NPETC("-not )", "): no beginning '('"),
+		s.NPETC("( -not )", "-not: no following expression"),
+		// Test error when "-not" is supplied w/ a malformed predicate
+		s.NPETC("-not .", "expected a key sequence after '.'"),
+		// Test error when "-not" is followed by a binary operator
+		s.NPETC("-not -a", "-not: no following expression"),
+	)
+}
+
+func (s *PredicateExpressionTestSuite) TestNotOpEval() {
+	s.RunTestCases(
+		s.NPTC("-not -true -primary", "-primary", false),
+		s.NPTC("-not -not -true -primary", "-primary", true),
+		s.NPTC("-not -not -not -true -primary", "-primary", false),
+		// Ensure that "-not <predicate>" and "-not -not <predicate>" always
+		// return false for mis-typed values. It is important to thoroughly
+		// test this behavior because it can be very confusing for users to
+		// debug if something goes wrong with the negation.
+		//
+		// Start with array predicates
+		s.NPNTC("-not [?] -true -primary", "-primary", "foo"),
+		s.NPNTC("-not -not [?] -true -primary", "-primary", "foo"),
+		// empty predicate
+		s.NPNTC("-not -empty -primary", "-primary", "foo"),
+		s.NPNTC("-not -not -empty -primary", "-primary", "foo"),
+		// numeric predicate
+		s.NPNTC("-not +1 -primary", "-primary", "2"),
+		s.NPNTC("-not -not -1 -primary", "-primary", "0"),
+		// object predicate
+		s.NPNTC("-not .key -true -primary", "-primary", "foo"),
+		s.NPNTC("-not -not .key -true -primary", "-primary", "foo"),
+		// boolean predicate
+		s.NPNTC("-not -true -primary", "-primary", "false"),
+		s.NPNTC("-not -not -true -primary", "-primary", "true"),
+		// string predicate	
+		s.NPNTC("-not f -primary", "-primary", 'g'),
+		s.NPNTC("-not -not f -primary", "-primary", 'f'),
+		// time predicate
+		s.NPNTC("-not +1h -primary", "-primary", "not a time"),
+		s.NPNTC("-not -not +1h -primary", "-primary", "not a time"),
+	)
+}
+
+func (s *PredicateExpressionTestSuite) TestBinOpParseErrors() {
+	s.RunTestCases(
+		// Tests for -and
+		s.NPETC("-a", "-a: no expression before -a"),
+		s.NPETC("-true -a", "-a: no expression after -a"),
+		s.NPETC("-true -a -a", "-a: no expression after -a"),
+		// Tests for -or
+		s.NPETC("-o", "-o: no expression before -o"),
+		s.NPETC("-true -o", "-o: no expression after -o"),
+		s.NPETC("-true -o -o", "-o: no expression after -o"),
+	)
+}
+
+func (s *PredicateExpressionTestSuite) TestAndOpEval() {
+	s.RunTestCases(
+		s.NPOETC("-true -a -false -primary", "-primary", false),
+		s.NPOETC("-true -false -primary", "-primary", false),
+		s.NPOETC("-true -true -primary", "-primary", true),
+	)
+}
+
+func (s *PredicateExpressionTestSuite) TestOrOpEval() {
+	s.RunTestCases(
+		s.NPOETC("-true -o -false -primary", "-primary", true),
+		s.NPOETC("-false -o -true -primary", "-primary", true),
+	)
+}
+
+func (s *PredicateExpressionTestSuite) TestBinOpPrecedence() {
+	s.RunTestCases(
+		// Should be parsed as (-true -o (-true -a -false)), which evaluates to true.
+		// Without precedence, this would be parsed as ((-true -o -true) -a false) which
+		// evaluates to false.
+		s.NPOETC("-true -o -true -a -false -primary", "-primary", true),
+	)
+}
+
+func (s *PredicateExpressionTestSuite) TestParensErrors() {
+	s.RunTestCases(
+		// Test the simple error cases
+		s.NPETC(")", "): no beginning '('"),
+		s.NPETC("(", "(: missing closing ')'"),
+		s.NPETC("( )", "(): empty inner expression"),
+		// Test some more complicated error cases
+		s.NPETC("( -true ) )", "): no beginning '('"),
+		s.NPETC("( -true ) ( ) -true", "(): empty inner expression"),
+		s.NPETC("( -true ( -false )", "(: missing closing ')'"),
+		s.NPETC("( ( ( -true ) ) ) )", "): no beginning '('"),
+		s.NPETC("( -a )", "-a: no expression before -a"),
+		s.NPETC("( ( ( -true ) -a", "(: missing closing ')'"),
+		s.NPETC("( ( ( -true ) -a ) )", "-a: no expression after -a"),
+	)
+}
+
+func (s *PredicateExpressionTestSuite) TestParensEval() {
+	s.RunTestCases(
+		// Note that w/o the parentheses, this would be parsed as "(-true -o (-true -a -false))"
+		// which would evaluate to true.
+		s.NPOETC("( -true -o -true ) -a -false -primary", "-primary", false),
+		s.NPOETC("-not ( -true -o -false ) -primary", "-primary", false),
+		s.NPOETC("( -true ) -a ( -false ) -primary", "-primary", false),
+		s.NPOETC("( -true ( -false ) -o ( ( -false -true ) ) ) -primary", "-primary", false),
+		s.NPOETC("( ( ( -true ) ) ) -primary", "-primary", true),
+		s.NPOETC("( ( -true ) -a -false ) -primary", "-primary", false),
+	)
+}
+
+func (s *PredicateExpressionTestSuite) TestComplexErrors() {
+	s.RunTestCases(
+		s.NPETC("( -true ) -a )", "): no beginning '('"),
+		s.NPETC("-true -a -foo", "unknown predicate -foo"),
+		s.NPETC(".key -a -foo", "expected a predicate after key"),
+	)
+}
+
+func (s *PredicateExpressionTestSuite) TestComplexOpEval() {
+	s.RunTestCases(
+		s.NPOETC("( -true -o -true ) -false -primary", "-primary", false),
+		// Should be parsed as (-true -a -false) -o -true which evaluates to true.
+		s.NPOETC("-true -false -o -true -primary", "-primary", true),
+		s.NPOETC("-false -o -true -false -primary", "-primary", false),
+		s.NPOETC("( -true -true ) -o -false -primary", "-primary", true),
+	)
+}
+
+func (s *PredicateExpressionTestSuite) TestPredicateExpressions() {
+	s.RunTestCases(
+		// Parsed as "> 3 AND > 5"
+		s.NPTC("+3 -a +5 -primary", "-primary", float64(6)),
+		s.NPNTC("+3 -a +5 -primary", "-primary", float64(4)),
+		// Parsed as "(> 3 AND > 5) OR == 1"
+		s.NPTC("( +3 -a +5 ) -o 1 -primary", "-primary", float64(6)),
+		s.NPNTC("+3 -a +5 -primary", "-primary", float64(4)),
+		s.NPTC("( +3 -a +5 ) -o 1 -primary", "-primary", float64(1)),
+		// Parsed as "NOT(> 3) OR > 5" which reduces to "<= 3 OR > 5"
+		s.NPTC("-not +3 -o +5 -primary", "-primary", float64(3)),
+		s.NPTC("-not +3 -o +5 -primary", "-primary", float64(1)),
+		s.NPTC("-not +3 -o +5 -primary", "-primary", float64(6)),
+		// Parsed as "true OR empty object/array"
+		s.NPTC("-true -o -empty -primary", "-primary", true),
+		s.NPTC("-true -o -empty -primary", "-primary", []interface{}{}),
+		// Parsed as "true AND empty object/array" (should always return false)
+		s.NPNTC("-true -a -empty -primary", "-primary", true),
+		s.NPNTC("-true -a -empty -primary", "-primary", []interface{}{}),
+	)
+}
+
+func TestPredicateExpression(t *testing.T) {
+	s := new(PredicateExpressionTestSuite)
+	s.Parser = predicate.ToParser(parsePredicateExpression)
+	suite.Run(t, s)
+}

--- a/cmd/internal/find/primary/meta/predicate_test.go
+++ b/cmd/internal/find/primary/meta/predicate_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/puppetlabs/wash/cmd/internal/find/params"
 	"github.com/puppetlabs/wash/cmd/internal/find/parser/parsertest"
+	"github.com/puppetlabs/wash/cmd/internal/find/parser/predicate"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -29,6 +30,16 @@ func (s *PredicateTestSuite) TestErrors() {
 		s.NPETC(".", "expected a key sequence after '.'", false),
 		s.NPETC("[", `expected a closing '\]'`, false),
 		s.NPETC("--15", "positive", false),
+		// These cases ensure that parsePredicate does not parse any expression operators.
+		// Otherwise, parsePredicateExpression may not work correctly.
+		s.NPETC("-a", ".*primitive.*", true),
+		s.NPETC("-and", ".*primitive.*", true),
+		s.NPETC("-o", ".*primitive.*", true),
+		s.NPETC("-or", ".*primitive.*", true),
+		s.NPETC("!", ".*primitive.*", true),
+		s.NPETC("-not", ".*primitive.*", true),
+		s.NPETC("(", ".*primitive.*", true),
+		s.NPETC(")", ".*primitive.*", true),
 	)
 }
 
@@ -47,6 +58,6 @@ func (s *PredicateTestSuite) TestValidInput() {
 
 func TestPredicate(t *testing.T) {
 	s := new(PredicateTestSuite)
-	s.Parser = predicateParser(parsePredicate)
+	s.Parser = predicate.ToParser(parsePredicate)
 	suite.Run(t, s)
 }

--- a/cmd/internal/find/primary/meta/primitivePredicate_test.go
+++ b/cmd/internal/find/primary/meta/primitivePredicate_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/puppetlabs/wash/cmd/internal/find/params"
 	"github.com/puppetlabs/wash/cmd/internal/find/parser/parsertest"
+	"github.com/puppetlabs/wash/cmd/internal/find/parser/predicate"
 	"github.com/puppetlabs/wash/cmd/internal/find/primary/numeric"
 	"github.com/stretchr/testify/suite"
 )
@@ -61,19 +62,29 @@ func (s *PrimitivePredicateTestSuite) TestExistsP() {
 }
 
 func (s *PrimitivePredicateTestSuite) TestTrueP() {
-	s.False(trueP("foo"))
-	s.False(trueP(false))
-	s.True(trueP(true))
+	s.False(trueP.IsSatisfiedBy("foo"))
+	s.False(trueP.Negate().IsSatisfiedBy("foo"))
+
+	s.False(trueP.IsSatisfiedBy(false))
+	s.True(trueP.Negate().IsSatisfiedBy(false))
+
+	s.True(trueP.IsSatisfiedBy(true))
+	s.False(trueP.Negate().IsSatisfiedBy(true))
 }
 
 func (s *PrimitivePredicateTestSuite) TestFalseP() {
-	s.False(falseP("foo"))
-	s.False(falseP(true))
-	s.True(falseP(false))
+	s.False(falseP.IsSatisfiedBy("foo"))
+	s.False(falseP.Negate().IsSatisfiedBy("foo"))
+
+	s.False(falseP.IsSatisfiedBy(true))
+	s.True(falseP.Negate().IsSatisfiedBy(true))
+
+	s.True(falseP.IsSatisfiedBy(false))
+	s.False(falseP.Negate().IsSatisfiedBy(false))
 }
 
 func TestPrimitivePredicate(t *testing.T) {
 	s := new(PrimitivePredicateTestSuite)
-	s.Parser = predicateParser(parsePrimitivePredicate)
+	s.Parser = predicate.ToParser(parsePrimitivePredicate)
 	suite.Run(t, s)
 }

--- a/cmd/internal/find/primary/meta/timePredicate.go
+++ b/cmd/internal/find/primary/meta/timePredicate.go
@@ -68,7 +68,7 @@ func timeP(subFromStartTime bool, p numeric.Predicate) predicate.Predicate {
 			}
 			return p(diff)
 		},
-		subFromStartTime: true,
+		subFromStartTime: subFromStartTime,
 		p: p,
 	}
 }

--- a/cmd/internal/find/primary/meta/timePredicate.go
+++ b/cmd/internal/find/primary/meta/timePredicate.go
@@ -5,13 +5,14 @@ import (
 
 	"github.com/puppetlabs/wash/cmd/internal/find/params"
 	"github.com/puppetlabs/wash/cmd/internal/find/parser/errz"
+	"github.com/puppetlabs/wash/cmd/internal/find/parser/predicate"
 	"github.com/puppetlabs/wash/cmd/internal/find/primary/numeric"
 	"github.com/puppetlabs/wash/munge"
 )
 
 // TimePredicate => (+|-)? Duration
 // Duration      => numeric.DurationRegex | '{' numeric.DurationRegex '}'
-func parseTimePredicate(tokens []string) (Predicate, []string, error) {
+func parseTimePredicate(tokens []string) (predicate.Predicate, []string, error) {
 	if params.StartTime.IsZero() {
 		panic("meta.parseTimePredicate called without setting params.StartTime")
 	}
@@ -19,7 +20,7 @@ func parseTimePredicate(tokens []string) (Predicate, []string, error) {
 		return nil, nil, errz.NewMatchError("expected a +, -, or a digit")
 	}
 	token := tokens[0]
-	numericP, parserID, err := numeric.ParsePredicate(
+	p, parserID, err := numeric.ParsePredicate(
 		token,
 		numeric.ParseDuration,
 		numeric.Bracket(numeric.ParseDuration),
@@ -39,28 +40,45 @@ func parseTimePredicate(tokens []string) (Predicate, []string, error) {
 		// 'StartTime - timeV'.
 		subFromStartTime = false
 	}
-	p := func(v interface{}) bool {
-		timeV, err := munge.ToTime(v)
-		if err != nil {
-			return false
-		}
-		var diff int64
-		if subFromStartTime {
-			diff = int64(params.StartTime.Sub(timeV))
-		} else {
-			diff = int64(timeV.Sub(params.StartTime))
-		}
-		if diff < 0 {
-			// Time predicates query either the past or the future, but not both.
-			// For example, +1h means "more than one hour ago", which queries the
-			// past. diff < 0 there means timeV is from the future, so the query
-			// doesn't make sense. Similarly, +{1h} means "more than one hour from now",
-			// which queries the future. diff < 0 there means timeV is from the past,
-			// so the query doesn't make sense. Thus, diff < 0 is a time-mismatch.
-			// Time-mismatches always return false.
-			return false
-		}
-		return numericP(diff)
+	return timeP(subFromStartTime, p), tokens[1:], nil
+}
+
+func timeP(subFromStartTime bool, p numeric.Predicate) predicate.Predicate {
+	return &timePredicate{
+		genericPredicate: func(v interface{}) bool {
+			timeV, err := munge.ToTime(v)
+			if err != nil {
+				return false
+			}
+			var diff int64
+			if subFromStartTime {
+				diff = int64(params.StartTime.Sub(timeV))
+			} else {
+				diff = int64(timeV.Sub(params.StartTime))
+			}
+			if diff < 0 {
+				// Time predicates query either the past or the future, but not both.
+				// For example, +1h means "more than one hour ago", which queries the
+				// past. diff < 0 there means timeV is from the future, so the query
+				// doesn't make sense. Similarly, +{1h} means "more than one hour from now",
+				// which queries the future. diff < 0 there means timeV is from the past,
+				// so the query doesn't make sense. Thus, diff < 0 is a time-mismatch.
+				// Time-mismatches always return false.
+				return false
+			}
+			return p(diff)
+		},
+		subFromStartTime: true,
+		p: p,
 	}
-	return p, tokens[1:], nil
+}
+
+type timePredicate struct {
+	genericPredicate
+	subFromStartTime bool
+	p numeric.Predicate
+}
+
+func (tp *timePredicate) Negate() predicate.Predicate {
+	return timeP(tp.subFromStartTime, tp.p.Negate().(numeric.Predicate))
 }

--- a/cmd/internal/find/primary/meta/timePredicate_test.go
+++ b/cmd/internal/find/primary/meta/timePredicate_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/puppetlabs/wash/cmd/internal/find/params"
 	"github.com/puppetlabs/wash/cmd/internal/find/parser/parsertest"
+	"github.com/puppetlabs/wash/cmd/internal/find/parser/predicate"
 	"github.com/puppetlabs/wash/cmd/internal/find/primary/numeric"
 	"github.com/stretchr/testify/suite"
 )
@@ -56,6 +57,34 @@ func (s *TimePredicateTestSuite) TestValidInputFalseValues() {
 	)
 }
 
+func (s *TimePredicateTestSuite) TestTimeP_Negation_NotATime() {
+	d := 5 * numeric.DurationOf('h')
+	tp := timeP(true, func(n int64) bool {
+		return n > d 
+	})
+	s.False(tp.Negate().IsSatisfiedBy("not_a_valid_time_value"))
+}
+
+func (s *TimePredicateTestSuite) TestTimeP_Negation_TimeMismatch() {
+	d := 5 * numeric.DurationOf('h')
+	// This is a query to the past
+	tp := timeP(true, func(n int64) bool {
+		return n > d 
+	})
+	/// Negating tp still preserves time mismatches. 
+	s.False(tp.Negate().IsSatisfiedBy(addTST(d+1)))
+	s.False(tp.Negate().IsSatisfiedBy(addTST(d-1)))
+}
+
+func (s *TimePredicateTestSuite) TestTimeP_Negation() {
+	d := 5 * numeric.DurationOf('h')
+	tp := timeP(true, func(n int64) bool {
+		return n > d 
+	})
+	s.False(tp.Negate().IsSatisfiedBy(addTST(-(d+1))))
+	s.True(tp.Negate().IsSatisfiedBy(addTST(-(d-1))))
+}
+
 // addTST => addToStartTime. Saves some typing. Note that v
 // is an int64 duration.
 func addTST(v int64) time.Time {
@@ -64,6 +93,6 @@ func addTST(v int64) time.Time {
 
 func TestTimePredicate(t *testing.T) {
 	s := new(TimePredicateTestSuite)
-	s.Parser = predicateParser(parseTimePredicate)
+	s.Parser = predicate.ToParser(parseTimePredicate)
 	suite.Run(t, s)
 }

--- a/cmd/internal/find/primary/meta/timePredicate_test.go
+++ b/cmd/internal/find/primary/meta/timePredicate_test.go
@@ -67,13 +67,22 @@ func (s *TimePredicateTestSuite) TestTimeP_Negation_NotATime() {
 
 func (s *TimePredicateTestSuite) TestTimeP_Negation_TimeMismatch() {
 	d := 5 * numeric.DurationOf('h')
-	// This is a query to the past
+	// These tests check that negating a timePredicate will still return
+	// false for time mismatches.
+
+	// Test past queries
 	tp := timeP(true, func(n int64) bool {
-		return n > d 
+		return n > d
 	})
-	/// Negating tp still preserves time mismatches. 
 	s.False(tp.Negate().IsSatisfiedBy(addTST(d+1)))
 	s.False(tp.Negate().IsSatisfiedBy(addTST(d-1)))
+
+	// Test future queries
+	tp = timeP(false, func(n int64) bool {
+		return n > d 
+	})
+	s.False(tp.Negate().IsSatisfiedBy(addTST(-(d+1))))
+	s.False(tp.Negate().IsSatisfiedBy(addTST(-(d-1))))
 }
 
 func (s *TimePredicateTestSuite) TestTimeP_Negation() {

--- a/cmd/internal/find/primary/parser.go
+++ b/cmd/internal/find/primary/parser.go
@@ -11,7 +11,7 @@ import (
 // Parser parses `wash find` primaries.
 var Parser = &parser{
 	CompositeParser: &predicate.CompositeParser{
-		ErrMsg: "unknown primary",
+		MatchErrMsg: "unknown primary",
 	},
 	primaries: make(map[string]*primary),
 }

--- a/cmd/internal/find/primary/testdata/metadata.json
+++ b/cmd/internal/find/primary/testdata/metadata.json
@@ -1,0 +1,150 @@
+{
+    "AmiLaunchIndex": 0,
+    "Architecture": "x86_64",
+    "BlockDeviceMappings": [
+      {
+        "DeviceName": "/dev/sda1",
+        "Ebs": {
+          "AttachTime": "2018-08-07T13:55:25Z",
+          "DeleteOnTermination": true,
+          "Status": "attached",
+          "VolumeId": "vol-0f6a9b57391d099bb"
+        }
+      }
+    ],
+    "CapacityReservationId": null,
+    "CapacityReservationSpecification": {
+      "CapacityReservationPreference": "open",
+      "CapacityReservationTarget": null
+    },
+    "ClientToken": "",
+    "CpuOptions": {
+      "CoreCount": 4,
+      "ThreadsPerCore": 1
+    },
+    "CreationTime": "2018-08-07T13:55:25Z",
+    "EbsOptimized": false,
+    "ElasticGpuAssociations": null,
+    "ElasticInferenceAcceleratorAssociations": null,
+    "EnaSupport": true,
+    "HibernationOptions": {
+      "Configured": false
+    },
+    "Hypervisor": "xen",
+    "IamInstanceProfile": null,
+    "ImageId": "ami-0ead4c08015751a37",
+    "InstanceId": "i-06b4f0f14864915e5",
+    "InstanceLifecycle": null,
+    "InstanceType": "t2.xlarge",
+    "KernelId": null,
+    "KeyName": "mike.smith.SE",
+    "LastModifiedTime": "2018-10-01T17:37:05Z",
+    "LaunchTime": "2018-10-01T17:37:05Z",
+    "Licenses": null,
+    "Monitoring": {
+      "State": "disabled"
+    },
+    "NetworkInterfaces": [
+      {
+        "Association": {
+          "IpOwnerId": "amazon",
+          "PublicDnsName": "ec2-18-236-186-96.us-west-2.compute.amazonaws.com",
+          "PublicIp": "18.236.186.96"
+        },
+        "Attachment": {
+          "AttachTime": "2018-08-07T13:55:24Z",
+          "AttachmentId": "eni-attach-00a1ac6ea935316a6",
+          "DeleteOnTermination": true,
+          "DeviceIndex": 0,
+          "Status": "attached"
+        },
+        "Description": "Primary network interface",
+        "Groups": [
+          {
+            "GroupId": "sg-0a6a56ccb175928e7",
+            "GroupName": "launch-wizard-102"
+          }
+        ],
+        "Ipv6Addresses": null,
+        "MacAddress": "02:a8:74:70:c4:2e",
+        "NetworkInterfaceId": "eni-04c6eeea9efa025be",
+        "OwnerId": "482693910459",
+        "PrivateDnsName": "ip-10-0-124-233.us-west-2.compute.internal",
+        "PrivateIpAddress": "10.0.124.233",
+        "PrivateIpAddresses": [
+          {
+            "Association": {
+              "IpOwnerId": "amazon",
+              "PublicDnsName": "ec2-18-236-186-96.us-west-2.compute.amazonaws.com",
+              "PublicIp": "18.236.186.96"
+            },
+            "Primary": true,
+            "PrivateDnsName": "ip-10-0-124-233.us-west-2.compute.internal",
+            "PrivateIpAddress": "10.0.124.233"
+          }
+        ],
+        "SourceDestCheck": true,
+        "Status": "in-use",
+        "SubnetId": "subnet-05e99aa622e12192c",
+        "VpcId": "vpc-0eb70f7f626d3db83"
+      }
+    ],
+    "Placement": {
+      "Affinity": null,
+      "AvailabilityZone": "us-west-2a",
+      "GroupName": "",
+      "HostId": null,
+      "PartitionNumber": null,
+      "SpreadDomain": null,
+      "Tenancy": "default"
+    },
+    "Platform": "windows",
+    "PrivateDnsName": "ip-10-0-124-233.us-west-2.compute.internal",
+    "PrivateIpAddress": "10.0.124.233",
+    "ProductCodes": null,
+    "PublicDnsName": "ec2-18-236-186-96.us-west-2.compute.amazonaws.com",
+    "PublicIpAddress": "18.236.186.96",
+    "RamdiskId": null,
+    "RootDeviceName": "/dev/sda1",
+    "RootDeviceType": "ebs",
+    "SecurityGroups": [
+      {
+        "GroupId": "sg-0a6a56ccb175928e7",
+        "GroupName": "launch-wizard-102"
+      }
+    ],
+    "SourceDestCheck": true,
+    "SpotInstanceRequestId": null,
+    "SriovNetSupport": null,
+    "State": {
+      "Code": 16,
+      "Name": "running"
+    },
+    "StateReason": null,
+    "StateTransitionReason": "",
+    "SubnetId": "subnet-05e99aa622e12192c",
+    "Tags": [
+      {
+        "Key": "department",
+        "Value": "SE"
+      },
+      {
+        "Key": "project",
+        "Value": "SE Demo"
+      },
+      {
+        "Key": "created_by",
+        "Value": "Mike Smith"
+      },
+      {
+        "Key": "lifetime",
+        "Value": "52w"
+      },
+      {
+        "Key": "termination_date",
+        "Value": "2017-08-06T13:55:25.680464+00:00"
+      }
+    ],
+    "VirtualizationType": "hvm",
+    "VpcId": "vpc-0eb70f7f626d3db83"
+  }


### PR DESCRIPTION
This commit adds support for predicate expressions to the `meta`
primary. Predicate expressions allow users to create more expressive
and powerful predicates. For example, the changes here reduce the
AWS reaper case from the verbose “-m .Tags[?].key termination_date -a -m .Tags[?].value +{1h}”
to the more expressive “-m .Tags[?] .key termination_date -a .value +{1h}”.
See the test cases in primary/meta_test.go for more examples.

Signed-off-by: Enis Inan <enis.inan@puppet.com>

Contributions to this project require sign-off consistent with the [Developers Certificate of Origin](https://developercertificate.org). This can be as simple as using `git commit -s` on each commit.