### PR TITLE
Add screencast to website and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 `wash` helps you deal with all your remote or cloud-native infrastructure using the UNIX-y patterns and tools you already know and love!
 
-_TBD: Screencast_
+[![asciicast](https://asciinema.org/a/245046.svg)](https://asciinema.org/a/245046?cols=120&rows=30)
 
 Exploring, understanding, and inspecting modern infrastructure should be simple and straightforward. Whether it's containers, VMs, network devices, IoT stuff, or anything in between...they all have different ways of enumerating what you have, getting a stream of output, running commands, etc. Every vendor has its own tools and APIs that expose these features, each one different, each one bespoke. Thus, they are difficult to compose together to solve higher-level problems. And that's no fun at all!
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<meta name="generator" content="Hugo 0.55.2" />
+	<meta name="generator" content="Hugo 0.55.5" />
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
@@ -37,7 +37,7 @@
 
 <p><code>wash</code> helps you deal with all your remote or cloud-native infrastructure using the UNIX-y patterns and tools you already know and love.</p>
 
-<p><em>TBD: Screencast</em></p>
+<script id="asciicast-245046" src="https://asciinema.org/a/245046.js" async></script>
 
 <p><code>wash</code> aims to:</p>
 

--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -7,7 +7,7 @@ draft= false
 
 `wash` helps you deal with all your remote or cloud-native infrastructure using the UNIX-y patterns and tools you already know and love.
 
-_TBD: Screencast_
+<script id="asciicast-245046" src="https://asciinema.org/a/245046.js" async></script>
 
 `wash` aims to:
 


### PR DESCRIPTION
Screencast generated with asciinema in a 100x20 frame to best fit the
website and README previow. README links to a larger version that looks
better as a full-size video.

Resolves #238.

Signed-off-by: Michael Smith <michael.smith@puppet.com>