### PR TITLE
 Default to maxdepth 1 if the meta primary is set 

### DIFF
--- a/cmd/internal/find/parser/parse.go
+++ b/cmd/internal/find/parser/parse.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"github.com/puppetlabs/wash/cmd/internal/find/primary"
 	"github.com/puppetlabs/wash/cmd/internal/find/types"
 )
 
@@ -24,6 +25,7 @@ func Parse(args []string) (Result, error) {
 	if err != nil {
 		return r, err
 	}
+	primary.Parser.Options = &r.Options
 	r.Predicate, err = parseExpression(args)
 	return r, err
 }

--- a/cmd/internal/find/parser/parseOptions.go
+++ b/cmd/internal/find/parser/parseOptions.go
@@ -42,6 +42,9 @@ func parseOptions(args []string) (types.Options, []string, error) {
 	}
 	fs.Visit(func(f *flag.Flag) {
 		o.MarkAsSet(f.Name)
+		if f.Name == types.MaxdepthFlag && o.Maxdepth < 0 {
+			o.Maxdepth = types.DefaultMaxdepth
+		}
 	})
 
 	// Calculate the remaining args

--- a/cmd/internal/find/parser/parseOptions.go
+++ b/cmd/internal/find/parser/parseOptions.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"flag"
 	"github.com/puppetlabs/wash/cmd/internal/find/parser/expression"
 	"github.com/puppetlabs/wash/cmd/internal/find/primary"
 	"github.com/puppetlabs/wash/cmd/internal/find/types"
@@ -39,6 +40,9 @@ func parseOptions(args []string) (types.Options, []string, error) {
 	if err != nil {
 		return o, nil, err
 	}
+	fs.Visit(func(f *flag.Flag) {
+		o.MarkAsSet(f.Name)
+	})
 
 	// Calculate the remaining args
 	if endIx == len(args) {

--- a/cmd/internal/find/parser/parseOptions_test.go
+++ b/cmd/internal/find/parser/parseOptions_test.go
@@ -91,6 +91,7 @@ func (suite *ParseOptionsTestSuite) TestParseOptionInvalidOption() {
 func (suite *ParseOptionsTestSuite) TestParseOptionsValidOptions() {
 	o := types.NewOptions()
 	o.Mindepth = 5
+	o.MarkAsSet(types.MindepthFlag)
 	suite.runTestCases(
 		nPOTC("-mindepth 5", o, ""),
 		nPOTC("-mindepth 5 --", o, "--"),

--- a/cmd/internal/find/parser/parseOptions_test.go
+++ b/cmd/internal/find/parser/parseOptions_test.go
@@ -101,6 +101,14 @@ func (suite *ParseOptionsTestSuite) TestParseOptionsValidOptions() {
 	)
 }
 
+func (suite *ParseOptionsTestSuite) TestParseOptionsNegativeMaxdepth() {
+	o := types.NewOptions()
+	o.MarkAsSet(types.MaxdepthFlag)
+	suite.runTestCases(
+		nPOTC("-maxdepth -1", o, ""),
+	)
+}
+
 func TestParseOptions(t *testing.T) {
 	suite.Run(t, new(ParseOptionsTestSuite))
 }

--- a/cmd/internal/find/parser/parse_test.go
+++ b/cmd/internal/find/parser/parse_test.go
@@ -42,7 +42,7 @@ func (suite *ParseTestSuite) TestPrimariesCanSetOptions() {
 	r, err := Parse([]string{"-meta", ".key", "-true"})
 	if suite.NoError(err) {
 		expectedOpts := types.NewOptions()
-		expectedOpts.Maxdepth = uint(1)
+		expectedOpts.Maxdepth = int(1)
 		suite.Equal(expectedOpts, r.Options)
 	}
 
@@ -50,7 +50,7 @@ func (suite *ParseTestSuite) TestPrimariesCanSetOptions() {
 	r, err = Parse([]string{"-maxdepth", "10", "-meta", ".key", "-true"})
 	if suite.NoError(err) {
 		expectedOpts := types.NewOptions()
-		expectedOpts.Maxdepth = uint(10)
+		expectedOpts.Maxdepth = int(10)
 		expectedOpts.MarkAsSet(types.MaxdepthFlag)
 		suite.Equal(expectedOpts, r.Options)
 	}

--- a/cmd/internal/find/parser/parse_test.go
+++ b/cmd/internal/find/parser/parse_test.go
@@ -7,30 +7,53 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
+// parsePath, parseOption, and parseExpression are tested separately.
+// The tests here are meant to make sure that they integrate well
+// together.
+
 type ParseTestSuite struct {
 	suite.Suite
 }
 
-// parsePath + parseExpression are tested separately, so TestParse()
-// can just make sure that they integrate well together.
-func (suite *ParseTestSuite) TestParse() {
-	// Happy case
+func (suite *ParseTestSuite) TestParseOptionsError() {
+	_, err := Parse([]string{"foo", "-unknown"})
+	suite.Regexp("flag.*unknown", err)
+}
+
+func (suite *ParseTestSuite) TestParseExpressionError() {
+	_, err := Parse([]string{"foo", "-true", "-a", "-blah"})
+	suite.Regexp("-blah.*primary", err)
+}
+
+func (suite *ParseTestSuite) TestValidInput() {
 	r, err := Parse([]string{"foo", "-depth", "-true"})
 	if suite.NoError(err) {
 		suite.Equal("foo", r.Path)
 		expectedOpts := types.NewOptions()
+		expectedOpts.MarkAsSet(types.DepthFlag)
 		expectedOpts.Depth = true
 		suite.Equal(expectedOpts, r.Options)
 		suite.Equal(true, r.Predicate(types.Entry{}))
 	}
+}
 
-	// Test a parse error on the options
-	r, err = Parse([]string{"foo", "-unknown"})
-	suite.Regexp("flag.*unknown", err)
+func (suite *ParseTestSuite) TestPrimariesCanSetOptions() {
+	// Test when an option is not set
+	r, err := Parse([]string{"-meta", ".key", "-true"})
+	if suite.NoError(err) {
+		expectedOpts := types.NewOptions()
+		expectedOpts.Maxdepth = uint(1)
+		suite.Equal(expectedOpts, r.Options)
+	}
 
-	// Test a parse error on the expression
-	r, err = Parse([]string{"foo", "-true", "-a", "-blah"})
-	suite.Regexp("-blah.*primary", err)
+	// Test when an option is set
+	r, err = Parse([]string{"-maxdepth", "10", "-meta", ".key", "-true"})
+	if suite.NoError(err) {
+		expectedOpts := types.NewOptions()
+		expectedOpts.Maxdepth = uint(10)
+		expectedOpts.MarkAsSet(types.MaxdepthFlag)
+		suite.Equal(expectedOpts, r.Options)
+	}
 }
 
 func TestParse(t *testing.T) {

--- a/cmd/internal/find/primary/action.go
+++ b/cmd/internal/find/primary/action.go
@@ -10,23 +10,26 @@ import (
 
 // actionPrimary => <action>
 //nolint
-var actionPrimary = Parser.newPrimary([]string{"-action"}, func(tokens []string) (types.EntryPredicate, []string, error) {
-	if len(tokens) == 0 {
-		return nil, nil, fmt.Errorf("requires additional arguments")
-	}
-	validActions := plugin.Actions()
-	action, ok := validActions[tokens[0]]
-	if !ok {
-		// User's querying an invalid action, so return an error.
-		validActionsArray := make([]string, 0, len(validActions))
-		for actionName := range validActions {
-			validActionsArray = append(validActionsArray, actionName)
+var actionPrimary = Parser.add(&primary{
+	tokens: []string{"-action"},
+	parseFunc: func(tokens []string) (types.EntryPredicate, []string, error) {
+		if len(tokens) == 0 {
+			return nil, nil, fmt.Errorf("requires additional arguments")
 		}
-		validActionsStr := strings.Join(validActionsArray, ", ")
-		return nil, nil, fmt.Errorf("%v is an invalid action. Valid actions are %v", tokens[0], validActionsStr)
-	}
-	p := func(e types.Entry) bool {
-		return e.Supports(action)
-	}
-	return p, tokens[1:], nil
+		validActions := plugin.Actions()
+		action, ok := validActions[tokens[0]]
+		if !ok {
+			// User's querying an invalid action, so return an error.
+			validActionsArray := make([]string, 0, len(validActions))
+			for actionName := range validActions {
+				validActionsArray = append(validActionsArray, actionName)
+			}
+			validActionsStr := strings.Join(validActionsArray, ", ")
+			return nil, nil, fmt.Errorf("%v is an invalid action. Valid actions are %v", tokens[0], validActionsStr)
+		}
+		p := func(e types.Entry) bool {
+			return e.Supports(action)
+		}
+		return p, tokens[1:], nil
+	},
 })

--- a/cmd/internal/find/primary/action_test.go
+++ b/cmd/internal/find/primary/action_test.go
@@ -1,7 +1,6 @@
 package primary
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/puppetlabs/wash/cmd/internal/find/types"
@@ -9,50 +8,29 @@ import (
 )
 
 type ActionPrimaryTestSuite struct {
-	suite.Suite
+	primaryTestSuite
 }
 
-func (suite *ActionPrimaryTestSuite) TestActionPrimaryInsufficientArgsError() {
-	_, _, err := actionPrimary.parse([]string{"-action"})
-	suite.Equal("-action: requires additional arguments", err.Error())
+func (s *ActionPrimaryTestSuite) TestErrors() {
+	s.RunTestCases(
+		s.NPETC("", "requires additional arguments"),
+		s.NPETC("foo", "foo is an invalid action. Valid actions are.*list"),
+	)
 }
 
-func (suite *ActionPrimaryTestSuite) TestActionPrimaryInvalidActionError() {
-	_, _, err := actionPrimary.parse([]string{"-action", "foo"})
-	suite.Regexp("foo is an invalid action. Valid actions are.*list", err)
-}
-
-func (suite *ActionPrimaryTestSuite) TestActionPrimaryValidInput() {
-	type testCase struct {
-		input string
-		// trueActions/falseActions represent entry actions that satisfy/unsatisfy
-		// the predicate, respectively.
-		trueActions  []string
-		falseActions []string
-	}
-	testCases := []testCase{
-		testCase{"list", []string{"list"}, []string{"exec"}},
-		// Test multiple supported actions
-		testCase{"list", []string{"read","stream","list"}, []string{"read", "stream"}},
-	}
-	for _, testCase := range testCases {
-		inputStr := func() string {
-			return fmt.Sprintf("Input was '%v'", testCase.input)
-		}
-		p, tokens, err := actionPrimary.parse([]string{"-action", testCase.input})
-		if suite.NoError(err, inputStr()) {
-			suite.Equal([]string{}, tokens)
-			e := types.Entry{}
-			
-			e.Actions = testCase.trueActions
-			suite.True(p(e), inputStr())
-
-			e.Actions = testCase.falseActions
-			suite.False(p(e), inputStr())
-		}
-	}
+func (s *ActionPrimaryTestSuite) TestValidInput() {
+	s.RTC("list", "", []string{"list"}, []string{"exec"})
+	// Test multiple supported actions
+	s.RTC("list", "", []string{"read", "stream", "list"}, []string{"read", "stream"})
 }
 
 func TestActionPrimary(t *testing.T) {
-	suite.Run(t, new(ActionPrimaryTestSuite))
+	s := new(ActionPrimaryTestSuite)
+	s.Parser = actionPrimary
+	s.ConstructEntry = func(v interface{}) types.Entry {
+		e := types.Entry{}
+		e.Actions = v.([]string)
+		return e
+	}
+	suite.Run(t, s)
 }

--- a/cmd/internal/find/primary/boolean.go
+++ b/cmd/internal/find/primary/boolean.go
@@ -8,10 +8,13 @@ import (
 
 //nolint
 func newBooleanPrimary(val bool) *primary {
-	return Parser.newPrimary([]string{fmt.Sprintf("-%v", val)}, func(tokens []string) (types.EntryPredicate, []string, error) {
-		return func(e types.Entry) bool {
-			return val
-		}, tokens, nil
+	return Parser.add(&primary{
+		tokens: []string{fmt.Sprintf("-%v", val)},
+		parseFunc: func(tokens []string) (types.EntryPredicate, []string, error) {
+			return func(e types.Entry) bool {
+				return val
+			}, tokens, nil
+		},
 	})
 }
 

--- a/cmd/internal/find/primary/meta.go
+++ b/cmd/internal/find/primary/meta.go
@@ -1,6 +1,9 @@
 package primary
 
 import (
+    "fmt"
+    "os"
+
     "github.com/puppetlabs/wash/cmd/internal/find/types"
     "github.com/puppetlabs/wash/cmd/internal/find/primary/meta"
 )
@@ -71,9 +74,10 @@ var metaPrimary = Parser.add(&primary{
             // because those entries don't have tags and, even if they did, they'd likely be under a
             // different key (e.g. like "Labels" for Docker containers). Thus to avoid the unnecessary
             // recursion, we default maxdepth to 1 if the flag was not set by the user. Note that users
-            // who want to recurse down into subdirectories can just specify the maxdepth option, which
+            // who want to recurse down into subdirectories can just set maxdepth to -1. The recursion
             // is useful when running `wash find` inside a directory whose entries and subdirectory entries
             // all have the same `meta` schema (e.g. like in an S3 bucket).
+            fmt.Fprintln(os.Stderr, "The meta primary is being used. Setting maxdepth to 1...")
             opts.Maxdepth = 1
         }
     },

--- a/cmd/internal/find/primary/meta.go
+++ b/cmd/internal/find/primary/meta.go
@@ -53,4 +53,7 @@ StringPredicate     => [^-].*
 N                   => \d+ (i.e. some number > 0)
 */
 //nolint
-var metaPrimary = Parser.newPrimary([]string{"-meta", "-m"}, meta.Parse)
+var metaPrimary = Parser.add(&primary{
+    tokens: []string{"-meta", "-m"},
+    parseFunc: meta.Parse,
+})

--- a/cmd/internal/find/primary/meta.go
+++ b/cmd/internal/find/primary/meta.go
@@ -1,6 +1,9 @@
 package primary
 
-import "github.com/puppetlabs/wash/cmd/internal/find/primary/meta"
+import (
+    "github.com/puppetlabs/wash/cmd/internal/find/types"
+    "github.com/puppetlabs/wash/cmd/internal/find/primary/meta"
+)
 
 /*
 metaPrimary         => (-meta|-m) Expression
@@ -56,4 +59,22 @@ N                   => \d+ (i.e. some number > 0)
 var metaPrimary = Parser.add(&primary{
     tokens: []string{"-meta", "-m"},
     parseFunc: meta.Parse,
+    optionsSetter: func(opts *types.Options) {
+        if !opts.IsSet(types.MaxdepthFlag) {
+            // The `meta` primary's a specialized filter. It should only be used
+            // if a user needs to filter on something that isn't in plugin.EntryAttributes
+            // (e.g. like an EC2 instance tag, a Docker container's image, etc.). Thus, it
+            // wouldn't make sense for `wash find` to recurse when someone's using the `meta`
+            // primary since it is likely that siblings or children will have a different meta
+            // schema. For example, if we're filtering EC2 instances based on a tag, then `wash find`
+            // shouldn't recurse down into the EC2 instance's console output + metadata.json files
+            // because those entries don't have tags and, even if they did, they'd likely be under a
+            // different key (e.g. like "Labels" for Docker containers). Thus to avoid the unnecessary
+            // recursion, we default maxdepth to 1 if the flag was not set by the user. Note that users
+            // who want to recurse down into subdirectories can just specify the maxdepth option, which
+            // is useful when running `wash find` inside a directory whose entries and subdirectory entries
+            // all have the same `meta` schema (e.g. like in an S3 bucket).
+            opts.Maxdepth = 1
+        }
+    },
 })

--- a/cmd/internal/find/primary/meta_test.go
+++ b/cmd/internal/find/primary/meta_test.go
@@ -94,14 +94,14 @@ func (s *MetaPrimaryTestSuite) TestOptionsSetter() {
 	// Test that if maxdepth is not set, then the options setter
 	// sets it to 1.
 	metaPrimary.optionsSetter(&opts)
-	s.Equal(uint(1), opts.Maxdepth)
+	s.Equal(int(1), opts.Maxdepth)
 
 	// Test that if maxdepth is set, then the options setter
 	// leaves it alone.
 	opts.Maxdepth = 10
 	opts.MarkAsSet(types.MaxdepthFlag)
 	metaPrimary.optionsSetter(&opts)
-	s.Equal(uint(10), opts.Maxdepth)
+	s.Equal(int(10), opts.Maxdepth)
 }
 
 func TestMetaPrimary(t *testing.T) {

--- a/cmd/internal/find/primary/meta_test.go
+++ b/cmd/internal/find/primary/meta_test.go
@@ -88,6 +88,22 @@ func (s *MetaPrimaryTestSuite) TestMetaPrimaryValidInputNegation() {
 	)
 }
 
+func (s *MetaPrimaryTestSuite) TestOptionsSetter() {
+	opts := types.NewOptions()
+
+	// Test that if maxdepth is not set, then the options setter
+	// sets it to 1.
+	metaPrimary.optionsSetter(&opts)
+	s.Equal(uint(1), opts.Maxdepth)
+
+	// Test that if maxdepth is set, then the options setter
+	// leaves it alone.
+	opts.Maxdepth = 10
+	opts.MarkAsSet(types.MaxdepthFlag)
+	metaPrimary.optionsSetter(&opts)
+	s.Equal(uint(10), opts.Maxdepth)
+}
+
 func TestMetaPrimary(t *testing.T) {
 	s := new(MetaPrimaryTestSuite)
 	rawMeta, err := ioutil.ReadFile("testdata/metadata.json")

--- a/cmd/internal/find/primary/meta_test.go
+++ b/cmd/internal/find/primary/meta_test.go
@@ -7,85 +7,84 @@ import (
 	"testing"
 
 	"github.com/puppetlabs/wash/cmd/internal/find/types"
-	"github.com/puppetlabs/wash/cmd/internal/find/parser/parsertest"
 	"github.com/stretchr/testify/suite"
 )
 
 type MetaPrimaryTestSuite struct {
-	parsertest.Suite
+	primaryTestSuite
 	e types.Entry
 }
 
 func (s *MetaPrimaryTestSuite) TestMetaPrimaryErrors() {
 	s.RunTestCases(
-		s.NPETC("-m", "expected a key sequence", false),
-		s.NPETC("-m foo", "key sequences must begin with a '.'", false),
-		s.NPETC("-m .", "expected a key sequence after '.'", false),
-		s.NPETC("-m .[", "expected a key sequence after '.'", false),
-		s.NPETC("-m .key", "expected a predicate expression", false),
-		s.NPETC("-m .key +{", "expected.*closing.*}", false),
-		s.NPETC("-m .key]", `expected an opening '\['`, false),
-		s.NPETC("-m .key[", `expected a closing '\]'`, false),
+		s.NPETC("", "expected a key sequence"),
+		s.NPETC("foo", "key sequences must begin with a '.'"),
+		s.NPETC(".", "expected a key sequence after '.'"),
+		s.NPETC(".[", "expected a key sequence after '.'"),
+		s.NPETC(".key", "expected a predicate expression"),
+		s.NPETC(".key +{", "expected.*closing.*}"),
+		s.NPETC(".key]", `expected an opening '\['`),
+		s.NPETC(".key[", `expected a closing '\]'`),
 		// Test some inner predicate expression parser errors
-		s.NPETC("-m .key1 .key2 (", `\(: missing closing '\)'`, false),
-		s.NPETC("-m .key1 .key2 ( -foo", "unknown predicate -foo", false),
-		s.NPETC("-m .key1 [?] (", `\(: missing closing '\)'`, false),
-		s.NPETC("-m .key1 [?] ( -foo", "unknown predicate -foo", false),
+		s.NPETC(".key1 .key2 (", `\(: missing closing '\)'`),
+		s.NPETC(".key1 .key2 ( -foo", "unknown predicate -foo"),
+		s.NPETC(".key1 [?] (", `\(: missing closing '\)'`),
+		s.NPETC(".key1 [?] ( -foo", "unknown predicate -foo"),
 	)
 }
 
 func (s *MetaPrimaryTestSuite) TestMetaPrimaryValidInputTruePredicates() {
 	s.RunTestCases(
-		s.NPTC("-m .architecture x86_64 -primary", "-primary", s.e),
-		s.NPTC("-m .blockDeviceMappings[?] .deviceName /dev/sda1 -primary", "-primary", s.e),
-		s.NPTC("-m .cpuOptions.coreCount 4 -primary", "-primary", s.e),
-		s.NPTC("-m .tags[?] .key termination_date -a .value +1h -primary", "-primary", s.e),
-		s.NPTC("-m .tags[?] .key foo -o .key department -primary", "-primary", s.e),
-		s.NPTC("-m .elasticGpuAssociations -null -primary", "-primary", s.e),
-		s.NPTC("-m .networkInterfaces[?] .association.ipOwnerID amazon -a .privateIpAddresses[?] .association.ipOwnerID amazon -primary", "-primary", s.e),
+		s.NPTC(".architecture x86_64 -primary", "-primary", s.e),
+		s.NPTC(".blockDeviceMappings[?] .deviceName /dev/sda1 -primary", "-primary", s.e),
+		s.NPTC(".cpuOptions.coreCount 4 -primary", "-primary", s.e),
+		s.NPTC(".tags[?] .key termination_date -a .value +1h -primary", "-primary", s.e),
+		s.NPTC(".tags[?] .key foo -o .key department -primary", "-primary", s.e),
+		s.NPTC(".elasticGpuAssociations -null -primary", "-primary", s.e),
+		s.NPTC(".networkInterfaces[?] .association.ipOwnerID amazon -a .privateIpAddresses[?] .association.ipOwnerID amazon -primary", "-primary", s.e),
 		// Test some inner predicate expressions
-		s.NPTC("-m .tags[?] .key ( foo -o department ) -primary", "-primary", s.e),
-		s.NPTC("-m .blockDeviceMappings[?] .ebs ( .attachTime +1h -a .status attached ) -primary", "-primary", s.e),
-		s.NPTC("-m .cpuOptions ( .coreCount ( ( -1 -a +5 ) -o 4 ) ) .threadsPerCore 1 -primary", "-primary", s.e),
+		s.NPTC(".tags[?] .key ( foo -o department ) -primary", "-primary", s.e),
+		s.NPTC(".blockDeviceMappings[?] .ebs ( .attachTime +1h -a .status attached ) -primary", "-primary", s.e),
+		s.NPTC(".cpuOptions ( .coreCount ( ( -1 -a +5 ) -o 4 ) ) .threadsPerCore 1 -primary", "-primary", s.e),
 	)
 }
 
 func (s *MetaPrimaryTestSuite) TestMetaPrimaryValidInputFalsePredicates() {
 	s.RunTestCases(
 		// Should fail b/c arch key does not exist
-		s.NPNTC("-m .arch x86_64 -primary", "-primary", s.e),
+		s.NPNTC(".arch x86_64 -primary", "-primary", s.e),
 		// Should fail b/c architecture is a string, not a number
-		s.NPNTC("-m .architecture +10 -primary", "-primary", s.e),
+		s.NPNTC(".architecture +10 -primary", "-primary", s.e),
 		// Should fail b/c the termination_date tag's value is in the past while
 		// +{1h} queries the future. 
-		s.NPNTC("-m .tags[?] .key termination_date -a .value +{1h} -primary", "-primary", s.e),
+		s.NPNTC(".tags[?] .key termination_date -a .value +{1h} -primary", "-primary", s.e),
 		// Should fail b/c the tags array has elements whose ".key" value is _not_ termination_date.
 		// Informally, this means that this EC2 instance has more than one tag.
-		s.NPNTC("-m .tags[*] .key termination_date -primary", "-primary", s.e),
+		s.NPNTC(".tags[*] .key termination_date -primary", "-primary", s.e),
 		// Should fail b/c architecture cannot be both a number and a string
-		s.NPNTC("-m .architecture +10 -a x86_64 -primary", "-primary", s.e),
+		s.NPNTC(".architecture +10 -a x86_64 -primary", "-primary", s.e),
 	)
 }
 
 func (s *MetaPrimaryTestSuite) TestMetaPrimaryValidInputNegation() {
 	s.RunTestCases(
-		s.NPNTC("-m .architecture ! x86_64 -primary", "-primary", s.e),
-		s.NPNTC("-m .blockDeviceMappings[?] ! .deviceName /dev/sda1 -primary", "-primary", s.e),
-		s.NPNTC("-m .cpuOptions.coreCount ! 4 -primary", "-primary", s.e),
+		s.NPNTC(".architecture ! x86_64 -primary", "-primary", s.e),
+		s.NPNTC(".blockDeviceMappings[?] ! .deviceName /dev/sda1 -primary", "-primary", s.e),
+		s.NPNTC(".cpuOptions.coreCount ! 4 -primary", "-primary", s.e),
 		// De'Morgan's Law: !(p1(a) && p2(a)) == ! p1(a) || ! p2(a). Since there's more than one
 		// tag (e.g. "department"), the negation of this predicate will evaluate to true.
-		s.NPTC("-m .tags[?] ! ( .key termination_date -a .value +1h ) -primary", "-primary", s.e),
+		s.NPTC(".tags[?] ! ( .key termination_date -a .value +1h ) -primary", "-primary", s.e),
 		// De'Morgan's Law: !(p1(a) || p2(a)) == !p1(a) && !p2(a). Substituting, this translates to
 		// "at least one tag that does _not_ have the "key" key set to 'foo' AND 'department'". Since
 		// we have a tag with "key" set to "termination_date", and since "termination_date" is not "foo"
 		// and "department", this predicate evaluates to true.
-		s.NPTC("-m .tags[?] ! ( .key foo -o .key department ) -primary", "-primary", s.e),
-		s.NPNTC("-m .elasticGpuAssociations ! -null -primary", "-primary", s.e),
+		s.NPTC(".tags[?] ! ( .key foo -o .key department ) -primary", "-primary", s.e),
+		s.NPNTC(".elasticGpuAssociations ! -null -primary", "-primary", s.e),
 		// There's only one network interface, so the negation here evaluates to false.
-		s.NPNTC("-m .networkInterfaces[?] ! ( .association.ipOwnerID amazon -a .privateIpAddresses[?] .association.ipOwnerID amazon ) -primary", "-primary", s.e),
+		s.NPNTC(".networkInterfaces[?] ! ( .association.ipOwnerID amazon -a .privateIpAddresses[?] .association.ipOwnerID amazon ) -primary", "-primary", s.e),
 		// Test negation for inner predicate expressions
-		s.NPNTC("-m .tags[0] .key ( ! ( foo -o department ) ) -primary", "-primary", s.e),
-		s.NPNTC("-m .cpuOptions ( .coreCount ( ( -1 -a +5 ) -o ! 4 ) ) .threadsPerCore 1 -primary", "-primary", s.e),
+		s.NPNTC(".tags[0] .key ( ! ( foo -o department ) ) -primary", "-primary", s.e),
+		s.NPNTC(".cpuOptions ( .coreCount ( ( -1 -a +5 ) -o ! 4 ) ) .threadsPerCore 1 -primary", "-primary", s.e),
 	)
 }
 
@@ -101,5 +100,8 @@ func TestMetaPrimary(t *testing.T) {
 	}
 	s.e.Attributes.SetMeta(m)
 	s.Parser = metaPrimary
+	s.ConstructEntry = func(v interface{}) types.Entry {
+		return v.(types.Entry)
+	}
 	suite.Run(t, s)
 }

--- a/cmd/internal/find/primary/name.go
+++ b/cmd/internal/find/primary/name.go
@@ -9,17 +9,18 @@ import (
 
 // namePrimary => -name ShellGlob
 //nolint
-var namePrimary = Parser.newPrimary([]string{"-name"}, func(tokens []string) (types.EntryPredicate, []string, error) {
-	if len(tokens) == 0 {
-		return nil, nil, fmt.Errorf("requires additional arguments")
-	}
-
-	g, err := glob.Compile(tokens[0])
-	if err != nil {
-		return nil, nil, fmt.Errorf("-name: invalid glob: %v", err)
-	}
-
-	return func(e types.Entry) bool {
-		return g.Match(e.CName)
-	}, tokens[1:], nil
+var namePrimary = Parser.add(&primary{
+	tokens: []string{"-name"},
+	parseFunc: func(tokens []string) (types.EntryPredicate, []string, error) {
+		if len(tokens) == 0 {
+			return nil, nil, fmt.Errorf("requires additional arguments")
+		}
+		g, err := glob.Compile(tokens[0])
+		if err != nil {
+			return nil, nil, fmt.Errorf("invalid glob: %v", err)
+		}
+		return func(e types.Entry) bool {
+			return g.Match(e.CName)
+		}, tokens[1:], nil
+	},
 })

--- a/cmd/internal/find/primary/name_test.go
+++ b/cmd/internal/find/primary/name_test.go
@@ -8,30 +8,27 @@ import (
 )
 
 type NamePrimaryTestSuite struct {
-	suite.Suite
+	primaryTestSuite
 }
 
-func (suite *NamePrimaryTestSuite) TestNamePrimaryErrors() {
-	_, _, err := namePrimary.parse([]string{"-name"})
-	suite.Regexp("-name: requires additional arguments", err)
-
-	_, _, err = namePrimary.parse([]string{"-name", "[a"})
-	suite.Regexp("-name: invalid glob: unexpected end of input", err)
+func (s *NamePrimaryTestSuite) TestErrors() {
+	s.RunTestCases(
+		s.NPETC("", "requires additional arguments"),
+		s.NPETC("[a", "invalid glob: unexpected end of input"),
+	)
 }
 
-func (suite *NamePrimaryTestSuite) TestNamePrimaryValidInput() {
-	e1 := types.Entry{}
-	e1.CName = "a"
-	e2 := types.Entry{}
-	e2.CName = "b"
-	p, tokens, err := namePrimary.parse([]string{"-name", "a"})
-	if suite.NoError(err) {
-		suite.Equal([]string{}, tokens)
-		suite.Equal(true, p(e1))
-		suite.Equal(false, p(e2))
-	}
+func (s *NamePrimaryTestSuite) TestValidInput() {
+	s.RTC("a", "", "a", "b")
 }
 
 func TestNamePrimary(t *testing.T) {
-	suite.Run(t, new(NamePrimaryTestSuite))
+	s := new(NamePrimaryTestSuite)
+	s.Parser = namePrimary
+	s.ConstructEntry = func(v interface{}) types.Entry {
+		e := types.Entry{}
+		e.CName = v.(string)
+		return e
+	}
+	suite.Run(t, s)
 }

--- a/cmd/internal/find/primary/parser.go
+++ b/cmd/internal/find/primary/parser.go
@@ -5,19 +5,14 @@ import (
 	"github.com/puppetlabs/wash/cmd/internal/find/types"
 	"github.com/puppetlabs/wash/cmd/internal/find/parser/predicate"
 	"github.com/puppetlabs/wash/cmd/internal/find/parser/errz"
-	"strings"
 )
 
 // Parser parses `wash find` primaries.
 var Parser = &parser{
-	CompositeParser: &predicate.CompositeParser{
-		MatchErrMsg: "unknown primary",
-	},
 	primaries: make(map[string]*primary),
 }
 
 type parser struct {
-	*predicate.CompositeParser
 	primaries map[string]*primary
 }
 
@@ -28,16 +23,29 @@ func (parser *parser) IsPrimary(token string) bool {
 	return ok
 }
 
-func (parser *parser) newPrimary(tokens []string, parse func(tokens []string) (types.EntryPredicate, []string, error)) *primary {
-	p := &primary{
-		tokens: tokens,
-		parseFunc: parse,
+func (parser *parser) Parse(tokens []string) (predicate.Predicate, []string, error)  {
+	if len(tokens) == 0 {
+		return nil, nil, errz.NewMatchError("expected a primary")
 	}
+	token := tokens[0]
+	primary, ok := parser.primaries[token]
+	if !ok {
+		msg := fmt.Sprintf("%v: unknown primary", token)
+		return nil, nil, errz.NewMatchError(msg)
+	}
+	tokens = tokens[1:]
+	p, tokens, err := primary.Parse(tokens)
+	if err != nil {
+		return nil, nil, fmt.Errorf("%v: %v", token, err)
+	}
+	return p, tokens, nil
+}
+
+func (parser *parser) add(p *primary) *primary {
 	p.tokensMap = make(map[string]struct{})
-	for _, token := range tokens {
+	for _, token := range p.tokens {
 		p.tokensMap[token] = struct{}{}
 		parser.primaries[token] = p
-		parser.Parsers = append(parser.Parsers, p)
 	}
 	return p
 }
@@ -49,24 +57,7 @@ type primary struct {
 	parseFunc types.EntryPredicateParser
 }
 
-func (primary *primary) parse(tokens []string) (types.EntryPredicate, []string, error) {
-	tokensErrMsg := fmt.Sprintf("expected one of: %v", strings.Join(primary.tokens, ","))
-	if len(tokens) == 0 {
-		return nil, nil, errz.NewMatchError(tokensErrMsg)
-	}
-	token := tokens[0]
-	if _, ok := primary.tokensMap[token]; !ok {
-		return nil, nil, errz.NewMatchError(tokensErrMsg)
-	}
-	tokens = tokens[1:]
-	p, tokens, err := primary.parseFunc(tokens)
-	if err != nil {
-		return nil, nil, fmt.Errorf("%v: %v", token, err)
-	}
-	return p, tokens, nil
-}
-
 // Parse parses a predicate from the given primary.
 func (primary *primary) Parse(tokens []string) (predicate.Predicate, []string, error) {
-	return primary.parse(tokens)
+	return primary.parseFunc(tokens)
 }

--- a/cmd/internal/find/primary/parser.go
+++ b/cmd/internal/find/primary/parser.go
@@ -13,6 +13,8 @@ var Parser = &parser{
 }
 
 type parser struct {
+	// Options represent the passed-in `wash find` options
+	Options *types.Options
 	primaries map[string]*primary
 }
 
@@ -32,6 +34,9 @@ func (parser *parser) Parse(tokens []string) (predicate.Predicate, []string, err
 	if !ok {
 		msg := fmt.Sprintf("%v: unknown primary", token)
 		return nil, nil, errz.NewMatchError(msg)
+	}
+	if primary.optionsSetter != nil && parser.Options != nil {
+		primary.optionsSetter(parser.Options)
 	}
 	tokens = tokens[1:]
 	p, tokens, err := primary.Parse(tokens)
@@ -54,6 +59,7 @@ func (parser *parser) add(p *primary) *primary {
 type primary struct {
 	tokens []string
 	tokensMap map[string]struct{}
+	optionsSetter func(*types.Options)
 	parseFunc types.EntryPredicateParser
 }
 

--- a/cmd/internal/find/primary/parser_test.go
+++ b/cmd/internal/find/primary/parser_test.go
@@ -1,0 +1,37 @@
+package primary
+
+import (
+	"testing"
+	"github.com/puppetlabs/wash/cmd/internal/find/types"
+	"github.com/puppetlabs/wash/cmd/internal/find/parser/parsertest"
+	"github.com/stretchr/testify/suite"
+)
+
+type ParserTestSuite struct {
+	parsertest.Suite
+}
+
+func (s *ParserTestSuite) TestErrors() {
+	s.RunTestCases(
+		s.NPETC("", "expected a primary", true),
+		s.NPETC("-foo", "foo: unknown primary", true),
+		// Test that a primary parse error is printed as "<primary token>: <err>"
+		s.NPETC("-meta", "-meta: expected a key sequence", false),
+		s.NPETC("-m", "-m: expected a key sequence", false),
+	)
+}
+
+func (s *ParserTestSuite) TestValidInput() {
+	e := types.Entry{}
+	e.CName = "a"
+	s.RunTestCases(
+		s.NPTC("-name a", "", e),
+	)
+}
+
+func TestPrimaryParser(t *testing.T) {
+	// Use the -name primary as a representative case
+	s := new(ParserTestSuite)
+	s.Parser = Parser
+	suite.Run(t, s)
+}

--- a/cmd/internal/find/primary/parser_test.go
+++ b/cmd/internal/find/primary/parser_test.go
@@ -37,7 +37,7 @@ func (s *ParserTestSuite) TestCallsOptionSetter() {
 	}()
 	_, _, err := Parser.Parse([]string{"-meta", ".key", "-true"})
 	if s.NoError(err) {
-		s.Equal(uint(1), opts.Maxdepth)
+		s.Equal(int(1), opts.Maxdepth)
 	}
 }
 

--- a/cmd/internal/find/primary/parser_test.go
+++ b/cmd/internal/find/primary/parser_test.go
@@ -29,6 +29,18 @@ func (s *ParserTestSuite) TestValidInput() {
 	)
 }
 
+func (s *ParserTestSuite) TestCallsOptionSetter() {
+	opts := types.NewOptions()
+	Parser.Options = &opts
+	defer func() {
+		Parser.Options = nil
+	}()
+	_, _, err := Parser.Parse([]string{"-meta", ".key", "-true"})
+	if s.NoError(err) {
+		s.Equal(uint(1), opts.Maxdepth)
+	}
+}
+
 func TestPrimaryParser(t *testing.T) {
 	// Use the -name primary as a representative case
 	s := new(ParserTestSuite)

--- a/cmd/internal/find/primary/path.go
+++ b/cmd/internal/find/primary/path.go
@@ -9,17 +9,18 @@ import (
 
 // pathPrimary => -path ShellGlob
 //nolint
-var pathPrimary = Parser.newPrimary([]string{"-path"}, func(tokens []string) (types.EntryPredicate, []string, error) {
-	if len(tokens) == 0 {
-		return nil, nil, fmt.Errorf("requires additional arguments")
-	}
-
-	g, err := glob.Compile(tokens[0])
-	if err != nil {
-		return nil, nil, fmt.Errorf("invalid glob: %v", err)
-	}
-
-	return func(e types.Entry) bool {
-		return g.Match(e.NormalizedPath)
-	}, tokens[1:], nil
+var pathPrimary = Parser.add(&primary{
+	tokens: []string{"-path"},
+	parseFunc: func(tokens []string) (types.EntryPredicate, []string, error) {
+		if len(tokens) == 0 {
+			return nil, nil, fmt.Errorf("requires additional arguments")
+		}
+		g, err := glob.Compile(tokens[0])
+		if err != nil {
+			return nil, nil, fmt.Errorf("invalid glob: %v", err)
+		}
+		return func(e types.Entry) bool {
+			return g.Match(e.NormalizedPath)
+		}, tokens[1:], nil
+	},
 })

--- a/cmd/internal/find/primary/path_test.go
+++ b/cmd/internal/find/primary/path_test.go
@@ -8,30 +8,27 @@ import (
 )
 
 type PathPrimaryTestSuite struct {
-	suite.Suite
+	primaryTestSuite
 }
 
-func (suite *PathPrimaryTestSuite) TestPathPrimaryErrors() {
-	_, _, err := pathPrimary.parse([]string{"-path"})
-	suite.Regexp("-path: requires additional arguments", err)
-
-	_, _, err = pathPrimary.parse([]string{"-path", "[a"})
-	suite.Regexp("-path: invalid glob: unexpected end of input", err)
+func (s *PathPrimaryTestSuite) TestErrors() {
+	s.RunTestCases(
+		s.NPETC("", "requires additional arguments"),
+		s.NPETC("[a", "invalid glob: unexpected end of input"),
+	)
 }
 
-func (suite *PathPrimaryTestSuite) TestPathPrimaryValidInput() {
-	e1 := types.Entry{}
-	e1.NormalizedPath = "a"
-	e2 := types.Entry{}
-	e2.NormalizedPath = "b"
-	p, tokens, err := pathPrimary.parse([]string{"-path", "a"})
-	if suite.NoError(err) {
-		suite.Equal([]string{}, tokens)
-		suite.Equal(true, p(e1))
-		suite.Equal(false, p(e2))
-	}
+func (s *PathPrimaryTestSuite) TestValidInput() {
+	s.RTC("a", "", "a", "b")
 }
 
 func TestPathPrimary(t *testing.T) {
-	suite.Run(t, new(PathPrimaryTestSuite))
+	s := new(PathPrimaryTestSuite)
+	s.Parser = pathPrimary
+	s.ConstructEntry = func(v interface{}) types.Entry {
+		e := types.Entry{}
+		e.NormalizedPath = v.(string)
+		return e
+	}
+	suite.Run(t, s)
 }

--- a/cmd/internal/find/primary/primary_test.go
+++ b/cmd/internal/find/primary/primary_test.go
@@ -1,0 +1,35 @@
+package primary
+
+import (
+	"github.com/puppetlabs/wash/cmd/internal/find/parser/parsertest"
+	"github.com/puppetlabs/wash/cmd/internal/find/types"
+)
+
+// This file contains common test code for the primaries
+
+type primaryTestSuite struct {
+	parsertest.Suite
+	ConstructEntry func(v interface{}) types.Entry
+}
+
+func (s *primaryTestSuite) NPETC(input string, errRegex string) parsertest.Case {
+	return s.Suite.NPETC(input, errRegex, false)
+}
+
+func (s *primaryTestSuite) NPTC(input string, remInput string, trueValue interface{}) parsertest.Case {
+	return s.Suite.NPTC(input, remInput, s.ConstructEntry(trueValue))
+}
+
+func (s *primaryTestSuite) NPNTC(input string, remInput string, falseValue interface{}) parsertest.Case {
+	return s.Suite.NPNTC(input, remInput, s.ConstructEntry(falseValue))
+}
+
+// RTC => RunTestCase.
+//
+// TODO: May be worth changing NPTC/NPNTC/NPETC => RPTC/RPNTC/RPETC in the toplevel parser test suite.
+func (s *primaryTestSuite) RTC(input string, remInput string, trueValue interface{}, falseValue interface{}) {
+	s.RunTestCases(
+		s.NPTC(input, remInput, trueValue),
+		s.NPNTC(input, remInput, falseValue),
+	)
+}

--- a/cmd/internal/find/primary/size.go
+++ b/cmd/internal/find/primary/size.go
@@ -17,29 +17,32 @@ import (
 //   -size +1k (true if the entry's size is greater than 1 kibibyte (1024 bytes))
 //
 //nolint
-var sizePrimary = Parser.newPrimary([]string{"-size"}, func(tokens []string) (types.EntryPredicate, []string, error) {
-	if len(tokens) == 0 {
-		return nil, nil, fmt.Errorf("requires additional arguments")
-	}
-	numericP, parserID, err := numeric.ParsePredicate(
-		tokens[0],
-		numeric.ParsePositiveInt,
-		numeric.ParseSize,
-	)
-	if err != nil {
-		return nil, nil, fmt.Errorf("%v: illegal size value", tokens[0])
-	}
+var sizePrimary = Parser.add(&primary{
+	tokens: []string{"-size"},
+	parseFunc: func(tokens []string) (types.EntryPredicate, []string, error) {
+		if len(tokens) == 0 {
+			return nil, nil, fmt.Errorf("requires additional arguments")
+		}
+		numericP, parserID, err := numeric.ParsePredicate(
+			tokens[0],
+			numeric.ParsePositiveInt,
+			numeric.ParseSize,
+		)
+		if err != nil {
+			return nil, nil, fmt.Errorf("%v: illegal size value", tokens[0])
+		}
 
-	p := func(e types.Entry) bool {
-		if !e.Attributes.HasSize() {
-			return false
+		p := func(e types.Entry) bool {
+			if !e.Attributes.HasSize() {
+				return false
+			}
+			size := int64(e.Attributes.Size())
+			if parserID == 0 {
+				// n was an integer, so convert the size to the # of 512-byte blocks (rounded up)
+				size = int64(math.Ceil(float64(size) / 512.0))
+			}
+			return numericP(size)
 		}
-		size := int64(e.Attributes.Size())
-		if parserID == 0 {
-			// n was an integer, so convert the size to the # of 512-byte blocks (rounded up)
-			size = int64(math.Ceil(float64(size) / 512.0))
-		}
-		return numericP(size)
-	}
-	return p, tokens[1:], nil
+		return p, tokens[1:], nil
+	},
 })

--- a/cmd/internal/find/types/options.go
+++ b/cmd/internal/find/types/options.go
@@ -23,14 +23,14 @@ func NewOptions() Options {
 	}
 }
 
-// DepthFlag is the name of the depth option's flag
-var DepthFlag = "depth"
-
-// MindepthFlag is the name of the mindepth option's flag
-var MindepthFlag = "mindepth"
-
-// MaxdepthFlag is the name of the maxdepth option's flag
-var MaxdepthFlag = "maxdepth"
+const (
+	// DepthFlag is the name of the depth option's flag
+	DepthFlag = "depth"
+	// MindepthFlag is the name of the mindepth option's flag
+	MindepthFlag = "mindepth"
+	// MaxdepthFlag is the name of the maxdepth option's flag
+	MaxdepthFlag = "maxdepth"
+)
 
 // IsSet returns true if the flag was set, false otherwise.
 func (opts *Options) IsSet(flag string) bool {

--- a/cmd/internal/find/types/options.go
+++ b/cmd/internal/find/types/options.go
@@ -10,6 +10,7 @@ type Options struct {
 	Depth    bool
 	Mindepth uint
 	Maxdepth uint
+	setFlags map[string]struct{}
 }
 
 // NewOptions creates a new Options object
@@ -18,7 +19,28 @@ func NewOptions() Options {
 		Depth:    false,
 		Mindepth: 0,
 		Maxdepth: ^uint(0),
+		setFlags: make(map[string]struct{}),
 	}
+}
+
+// DepthFlag is the name of the depth option's flag
+var DepthFlag = "depth"
+
+// MindepthFlag is the name of the mindepth option's flag
+var MindepthFlag = "mindepth"
+
+// MaxdepthFlag is the name of the maxdepth option's flag
+var MaxdepthFlag = "maxdepth"
+
+// IsSet returns true if the flag was set, false otherwise.
+func (opts *Options) IsSet(flag string) bool {
+	_, ok := opts.setFlags[flag]
+	return ok
+}
+
+// MarkAsSet marks the flag as set.
+func (opts *Options) MarkAsSet(flag string) {
+	opts.setFlags[flag] = struct{}{}
 }
 
 // FlagSet returns a flagset representing
@@ -29,8 +51,8 @@ func (opts *Options) FlagSet() *flag.FlagSet {
 	// TODO: Handle usage later
 	fs.Usage = func() {}
 	fs.SetOutput(ioutil.Discard)
-	fs.BoolVar(&opts.Depth, "depth", opts.Depth, "")
-	fs.UintVar(&opts.Mindepth, "mindepth", opts.Mindepth, "")
-	fs.UintVar(&opts.Maxdepth, "maxdepth", opts.Maxdepth, "")
+	fs.BoolVar(&opts.Depth, DepthFlag, opts.Depth, "")
+	fs.UintVar(&opts.Mindepth, MindepthFlag, opts.Mindepth, "")
+	fs.UintVar(&opts.Maxdepth, MaxdepthFlag, opts.Maxdepth, "")
 	return fs
 }

--- a/cmd/internal/find/types/options.go
+++ b/cmd/internal/find/types/options.go
@@ -9,16 +9,22 @@ import (
 type Options struct {
 	Depth    bool
 	Mindepth uint
-	Maxdepth uint
+	Maxdepth int
 	setFlags map[string]struct{}
 }
+
+// DefaultMaxdepth is the default value of the maxdepth option.
+// It is set to the max value of a 32-bit integer.
+const DefaultMaxdepth = 1<<31 - 1
 
 // NewOptions creates a new Options object
 func NewOptions() Options {
 	return Options{
 		Depth:    false,
 		Mindepth: 0,
-		Maxdepth: ^uint(0),
+		// We make Maxdepth an int because of the `meta` primary.
+		// See the comments in `primary/meta.go` for more details.
+		Maxdepth: DefaultMaxdepth,
 		setFlags: make(map[string]struct{}),
 	}
 }
@@ -53,6 +59,6 @@ func (opts *Options) FlagSet() *flag.FlagSet {
 	fs.SetOutput(ioutil.Discard)
 	fs.BoolVar(&opts.Depth, DepthFlag, opts.Depth, "")
 	fs.UintVar(&opts.Mindepth, MindepthFlag, opts.Mindepth, "")
-	fs.UintVar(&opts.Maxdepth, MaxdepthFlag, opts.Maxdepth, "")
+	fs.IntVar(&opts.Maxdepth, MaxdepthFlag, opts.Maxdepth, "")
 	return fs
 }

--- a/cmd/internal/find/walker.go
+++ b/cmd/internal/find/walker.go
@@ -37,7 +37,7 @@ func (w *walker) walk(e types.Entry, depth uint) {
 		w.visit(e, depth)
 	}
 	childDepth := depth + 1
-	if childDepth <= w.opts.Maxdepth && e.Supports(plugin.ListAction()) {
+	if int(childDepth) <= w.opts.Maxdepth && e.Supports(plugin.ListAction()) {
 		children, err := list(w.conn, e)
 		if err != nil {
 			cmdutil.ErrPrintf("could not get children of %v: %v\n", e.NormalizedPath, err)


### PR DESCRIPTION
The meta primary's a specialized filter. This means that for a
given entry, it is unlikely that the entry's siblings or children
will have the same meta schema. Thus, it does not make sense for
`wash find` to recurse when the user specifies the meta primary
because recursing could lead to wasteful API requests.

Thus to avoid the unnecessary recursion, this commit sets the maxdepth
option to 1 if the meta primary's specified and the flag was not
provided on the command line.