### PR TITLE
Generate help text for `wash find`

### DIFF
--- a/cmd/find.go
+++ b/cmd/find.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/puppetlabs/wash/cmd/internal/find"
 	"github.com/spf13/cobra"
 )
@@ -10,11 +12,14 @@ func findCommand() *cobra.Command {
 		// `wash find` parses its own flags to keep its syntax consistent with the
 		// existing `find` command
 		DisableFlagParsing: true,
-		Use:                "find <path> [expression]",
-		// TODO: More detailed usage. Will need to use custom help text in order to
-		// properly enumerate all the primaries.
-		Short: "Finds stuff",
+		Use:                "find",
+		Short:              "Prints out all entries that satisfy the given expression",
 	}
+	findCmd.SetUsageFunc(func(_ *cobra.Command) error {
+		fmt.Print(find.Usage())
+		return nil
+	})
+	findCmd.SetHelpTemplate(`{{.UsageString}}`)
 
 	// This tells Cobra to stop parsing CLI flags after the first positional
 	// argument. We need it so that Cobra does not interpet our primaries (e.g.

--- a/cmd/internal/find/main.go
+++ b/cmd/internal/find/main.go
@@ -3,11 +3,15 @@
 package find
 
 import (
+	"fmt"
+	"strings"
 	"time"
 
 	"github.com/puppetlabs/wash/api/client"
 	"github.com/puppetlabs/wash/cmd/internal/find/params"
 	"github.com/puppetlabs/wash/cmd/internal/find/parser"
+	"github.com/puppetlabs/wash/cmd/internal/find/primary"
+	"github.com/puppetlabs/wash/cmd/internal/find/types"
 	cmdutil "github.com/puppetlabs/wash/cmd/util"
 	"github.com/puppetlabs/wash/config"
 	"github.com/spf13/cobra"
@@ -18,6 +22,9 @@ func Main(cmd *cobra.Command, args []string) int {
 	params.StartTime = time.Now()
 
 	result, err := parser.Parse(args)
+	if result.Options.Help.Requested {
+		return printHelp(result.Options.Help)
+	}
 	if err != nil {
 		cmdutil.ErrPrintf("find: %v\n", err)
 		return 1
@@ -31,5 +38,29 @@ func Main(cmd *cobra.Command, args []string) int {
 		return 1
 	}
 	newWalker(result, conn).Walk(e)
+	return 0
+}
+
+func printHelp(helpOpt types.HelpOption) int {
+	printDescription := func(desc string) {
+		desc = strings.Trim(desc, "\n")
+		fmt.Println(desc)
+	}
+	if !helpOpt.HasValue {
+		fmt.Print(Usage())
+	} else if helpOpt.Syntax {
+		printDescription(parser.ExpressionSyntaxDescription)
+	} else {
+		p := primary.Get(helpOpt.Primary)
+		if p == nil {
+			cmdutil.ErrPrintf("unknown primary %v", helpOpt.Primary)
+			return 1
+		}
+		desc := p.DetailedDescription
+		if desc == "" {
+			desc = p.Usage() + "\n" + p.Description
+		}
+		printDescription(desc)
+	}
 	return 0
 }

--- a/cmd/internal/find/parser/parseExpression.go
+++ b/cmd/internal/find/parser/parseExpression.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"fmt"
 
+	"github.com/puppetlabs/wash/cmd/util"
 	"github.com/puppetlabs/wash/cmd/internal/find/parser/expression"
 	"github.com/puppetlabs/wash/cmd/internal/find/primary"
 	"github.com/puppetlabs/wash/cmd/internal/find/types"
@@ -36,3 +37,92 @@ func parseExpression(tokens []string) (types.EntryPredicate, error) {
 	}
 	return p.(types.EntryPredicate), nil
 }
+
+// OperandsTable returns a table containing all of `wash find`'s available
+// operands
+func OperandsTable() *cmdutil.Table {
+	return cmdutil.NewTable(
+		[]string{"Operands:",    ""},
+		[]string{"  ( e )",      "Parentheses operator. Evaluates to true if e evaluates to true"},
+		[]string{"  !, -not e", "Logical NOT operator. Evaluates to true if e evaluates to false"},
+		[]string{"  e1 -and e2", "Logical AND operator. Evalutes to true if both e1 and e2 are true"},
+		[]string{"  e1 -a e2",   ""},
+		[]string{"  e1 e2",      ""},
+		[]string{"  e1 -or e2", "Logical OR operator. Evalutes to true if either e1 or e2 are true"},
+		[]string{"  e1 -o e2",   ""},
+	)
+}
+
+// ExpressionSyntaxDescription describes `wash find`'s expression syntax.
+const ExpressionSyntaxDescription = `
+An expression evaluates to a predicate that is applied on a specific set
+of entries. By default, this set consists of all traversed entries,
+including the specified path. You can use the mindepth/maxdepth options
+to restrict this set.
+
+Expressions consist of primaries and operators. Primaries yield a predicate
+that's set on a specific property of the entry (e.g. name, path, ctime),
+while the operators combine these "primary predicates" to form more
+powerful, expressive predicates. Use "wash find -h" to view the available
+primaries, and "wash find -h <primary>" to view a detailed description of the
+specified primary, including examples of how to use it.
+
+The rest of this section discusses the operators, their precedence, and
+includes various examples of valid expressions.
+
+OPERATORS:
+The operators are listed in order of decreasing precedence.
+
+( expression )
+    Evaluates to true if the parenthesized expression evaluates to true.
+
+! expression
+-not expression
+    Unary NOT operator. Evaluates to true if the expression is false.
+
+expression -and expression
+expression -a expression
+expression expression
+    Logical AND operator. Evaluates to true if both expressions evaluate
+    to true. Note that the second expression is not evaluated if the
+    first expression is false.
+
+expression -or expression
+expression -o expression
+    Logical OR operator. Evaluates to true if both expressions evaluate to
+    true. Note that the second expression is not evaluated if the first
+    expression is true.
+
+EXAMPLES:
+The following examples are shown as given to the shell. 
+
+find . -name "*c"
+    Print out all entries whose cname ends with a "c"
+
+find . \! -name "*c"
+    Print out all entries whose cname does not end with a "c"
+
+find . -name "*c" -mtime +1h
+find . -name "*c" -a -mtime +1h
+    Print out all entries whose cname ends with a "c" and
+    whose last modification time was more than one hour ago.
+
+find . -name "*c" -o -name "*d"
+    Print out all entries whose cname ends with a "c" or a "d"
+
+find . -path "docker*containers*" \( -name "*c" -o -name "*d" \) -a -mtime -1h
+find . -path "docker*containers*" \( -name "*c" -o -name "*d" \) -mtime -1h
+    Print out all the Docker containers whose cname ends with a "c"
+    or a "d" that were modified within the last hour. Note that
+    without the parentheses, the latter part of the expression would
+    have been parsed as '-name "*c" OR ( -name "*d" AND -mtime -1h)',
+    which is a completely different predicate.
+
+find ec2/instances -m .state.name running -a -m .tags[?] .key termination_date -a .value +0h
+find ec2/instances -m .state.name running -m .tags[?] .key termination_date .value +0h
+    Print out all the running EC2 instances whose termination_date tag expired.
+    Note that the ".key termination_date -a .value +0h" portion of the example
+    is parsed as part of the meta primary's expression, not the top level
+    expression parser. The latter parses the example as "Meta(state.name, ...)
+    AND Meta(tags[?], ...)", which is two primaries being ANDed together.
+`

--- a/cmd/internal/find/parser/parseExpression.go
+++ b/cmd/internal/find/parser/parseExpression.go
@@ -44,11 +44,11 @@ func OperandsTable() *cmdutil.Table {
 	return cmdutil.NewTable(
 		[]string{"Operands:",    ""},
 		[]string{"  ( e )",      "Parentheses operator. Evaluates to true if e evaluates to true"},
-		[]string{"  !, -not e", "Logical NOT operator. Evaluates to true if e evaluates to false"},
+		[]string{"  !, -not e",  "Logical NOT operator. Evaluates to true if e evaluates to false"},
 		[]string{"  e1 -and e2", "Logical AND operator. Evalutes to true if both e1 and e2 are true"},
 		[]string{"  e1 -a e2",   ""},
 		[]string{"  e1 e2",      ""},
-		[]string{"  e1 -or e2", "Logical OR operator. Evalutes to true if either e1 or e2 are true"},
+		[]string{"  e1 -or e2",  "Logical OR operator. Evalutes to true if either e1 or e2 are true"},
 		[]string{"  e1 -o e2",   ""},
 	)
 }
@@ -123,6 +123,5 @@ find ec2/instances -m .state.name running -m .tags[?] .key termination_date .val
     Print out all the running EC2 instances whose termination_date tag expired.
     Note that the ".key termination_date -a .value +0h" portion of the example
     is parsed as part of the meta primary's expression, not the top level
-    expression parser. The latter parses the example as "Meta(state.name, ...)
-    AND Meta(tags[?], ...)", which is two primaries being ANDed together.
+    expression parser.
 `

--- a/cmd/internal/find/parser/parseOptions.go
+++ b/cmd/internal/find/parser/parseOptions.go
@@ -38,6 +38,37 @@ func parseOptions(args []string) (types.Options, []string, error) {
 	// Parse the args
 	err := fs.Parse(args[0:endIx])
 	if err != nil {
+		if err == flag.ErrHelp {
+			// Parse the help option. Note that we cannot use Go's Value interface
+			// to handle the parsing because that does not enable the "-help" and
+			// "-help <primary>|syntax" usages of the flag. We could get it to work
+			// as "-help" and "-help=<primary>|syntax", but that is inconsistent with
+			// the other options like maxdepth (which allows both "-maxdepth 1" and
+			// "-maxdepth=1"), and it introduces ambiguity between "-help" and
+			// "-help=<primary>" when <primary> = true. The latter ambiguity is due to
+			// Go's flag package treating "-help" as semantically equivalent to "-help=true".
+			//
+			// In general, Go's flag package does not allow one to treat a given
+			// option as a Boolean option with an optional value without sacrificing
+			// some syntactic consistency by requiring the value to be specified as
+			// "<flag>=<value>" instead of both "<flag>=<value>" and "<flag> <value>".
+			o.Help.Requested = true	
+			// args contains the part of args after the help flag.
+			args = fs.Args()
+			if len(args) > 0 {
+				arg := args[0]
+				// The "-" check is to make sure it doesn't conflict with
+				// another option or a `wash find` primary
+				if len(arg) > 0 && arg[0] != '-' {
+					o.Help.HasValue = true
+					if arg == "syntax" {
+						o.Help.Syntax = true
+					} else {
+						o.Help.Primary = arg
+					}
+				}
+			}
+		}
 		return o, nil, err
 	}
 	fs.Visit(func(f *flag.Flag) {

--- a/cmd/internal/find/parser/parseOptions_test.go
+++ b/cmd/internal/find/parser/parseOptions_test.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"flag"
 	"fmt"
 	"regexp"
 	"strings"
@@ -86,6 +87,43 @@ func (suite *ParseOptionsTestSuite) TestParseOptionsNoOptions() {
 
 func (suite *ParseOptionsTestSuite) TestParseOptionInvalidOption() {
 	suite.runTestCases(nPOETC("-unknown", "flag.*unknown"))
+}
+
+func (suite *ParseOptionsTestSuite) TestParseOptionHelpFlag() {
+	for _, helpFlag := range []string{"-h", "-help"} {
+		o, _, err := parseOptions([]string{helpFlag})
+		if suite.Equal(flag.ErrHelp, err) {
+			suite.True(o.Help.Requested)
+			suite.False(o.Help.HasValue)
+		}
+
+		o, _, err = parseOptions([]string{helpFlag, ""})
+		if suite.Equal(flag.ErrHelp, err) {
+			suite.True(o.Help.Requested)
+			suite.False(o.Help.HasValue)
+		}
+
+		o, _, err = parseOptions([]string{helpFlag, "-maxdepth"})
+		if suite.Equal(flag.ErrHelp, err) {
+			suite.True(o.Help.Requested)
+			suite.False(o.Help.HasValue)
+		}
+
+		o, _, err = parseOptions([]string{helpFlag, "foo"})
+		if suite.Equal(flag.ErrHelp, err) {
+			suite.True(o.Help.Requested)
+			suite.True(o.Help.HasValue)
+			suite.False(o.Help.Syntax)
+			suite.Equal("foo", o.Help.Primary)
+		}
+
+		o, _, err = parseOptions([]string{helpFlag, "syntax"})
+		if suite.Equal(flag.ErrHelp, err) {
+			suite.True(o.Help.Requested)
+			suite.True(o.Help.HasValue)
+			suite.True(o.Help.Syntax)
+		}
+	}
 }
 
 func (suite *ParseOptionsTestSuite) TestParseOptionsValidOptions() {

--- a/cmd/internal/find/primary/action.go
+++ b/cmd/internal/find/primary/action.go
@@ -10,8 +10,10 @@ import (
 
 // actionPrimary => <action>
 //nolint
-var actionPrimary = Parser.add(&primary{
-	tokens: []string{"-action"},
+var actionPrimary = Parser.add(&Primary{
+	Description: "Returns true if the entry supports action",
+	name: "action",
+	args: "action",
 	parseFunc: func(tokens []string) (types.EntryPredicate, []string, error) {
 		if len(tokens) == 0 {
 			return nil, nil, fmt.Errorf("requires additional arguments")

--- a/cmd/internal/find/primary/boolean.go
+++ b/cmd/internal/find/primary/boolean.go
@@ -7,9 +7,10 @@ import (
 )
 
 //nolint
-func newBooleanPrimary(val bool) *primary {
-	return Parser.add(&primary{
-		tokens: []string{fmt.Sprintf("-%v", val)},
+func newBooleanPrimary(val bool) *Primary {
+	return Parser.add(&Primary{
+		Description: fmt.Sprintf("Always returns %v", val),
+		name: fmt.Sprintf("%v", val),
 		parseFunc: func(tokens []string) (types.EntryPredicate, []string, error) {
 			return func(e types.Entry) bool {
 				return val

--- a/cmd/internal/find/primary/meta.go
+++ b/cmd/internal/find/primary/meta.go
@@ -60,10 +60,10 @@ N                   => \d+ (i.e. some number > 0)
 */
 //nolint
 var metaPrimary = Parser.add(&Primary{
-    Description: "Returns true if the entry's meta attribute satisfies metaP",
+    Description: "Returns true if the entry's meta attribute satisfies the expression",
     DetailedDescription: metaDetailedDescription,
     name: "meta",
-    args: "metaP",
+    args: "<expression>",
     shortName: "m",
     parseFunc: meta.Parse,
     optionsSetter: func(opts *types.Options) {
@@ -519,8 +519,8 @@ In these examples, let "m" be the value of the entry's 'meta' attribute.
 
 -m .tags[?] .key \( sales -o product \)
     Returns true if m['tags'] has at least one object o s.t. o['key'] == sales OR product.
-    In the real world, this example filters out all EC2 instances that belong to the "sales"
-    or "product" departments.
+    In the real world, this example filters out all EC2 instances that have a "sales" or
+    "product" tag.
 
 -m .state.name pending -o running
     Returns true if m['state']['name'] == pending OR running. In the real world, this

--- a/cmd/internal/find/primary/meta.go
+++ b/cmd/internal/find/primary/meta.go
@@ -59,8 +59,12 @@ StringPredicate     => [^-].*
 N                   => \d+ (i.e. some number > 0)
 */
 //nolint
-var metaPrimary = Parser.add(&primary{
-    tokens: []string{"-meta", "-m"},
+var metaPrimary = Parser.add(&Primary{
+    Description: "Returns true if the entry's meta attribute satisfies metaP",
+    DetailedDescription: metaDetailedDescription,
+    name: "meta",
+    args: "metaP",
+    shortName: "m",
     parseFunc: meta.Parse,
     optionsSetter: func(opts *types.Options) {
         if !opts.IsSet(types.MaxdepthFlag) {
@@ -82,3 +86,440 @@ var metaPrimary = Parser.add(&primary{
         }
     },
 })
+
+const metaDetailedDescription = `
+(-m|-meta) (-empty | KeySequence PredicateExpression)
+
+If -empty is specified, then returns true if the entry's meta attribute
+is empty. Otherwise, returns true if the meta value specified by the key
+sequence satisfies the given predicate expression.
+
+NOTE: If the -maxdepth flag was not provided, then the meta primary
+defaults the maxdepth to 1. This is to avoid unnecessary recursion (and
+API requests) since the meta primary is a specialized filter. You can set
+maxdepth to -1 if you'd like find to always recurse.
+
+KEY SEQUENCES:
+A key sequence consists of a key token followed by zero or more "chunks".
+A "chunk" is a key token OR an array token. Key tokens must be prefixed by
+a ".", and cannot contain a ".", "[", or "]". Valid array tokens are "[?]",
+"[*]", or "[n]", where n >= 0.
+
+Key sequences are parsed as chunks, where each chunk represents either an
+object predicate or an array predicate on the current meta value. A key
+token chunk represents an object predicate, while an array token chunk
+represents an array predicate. Each chunk is followed by a predicate, which
+is either another chunk OR a predicate expression. Below are the semantics
+for each chunk:
+
+  .foo p
+      Returns false if the current value is not an object. Otherwise, returns
+      false if the value does not have a key matching 'foo'. A key matches
+      'foo' if upcase(key) == 'FOO'. Otherwise, returns p(o[mkey]) where mkey
+      is the first matching key.
+
+  .[?] p
+      Returns false if the current value is not an array. Otherwise, returns
+      true if p returns true for some element in the array. Otherwise, returns
+      false.
+
+  .[*] p
+      Returns false if the current value is not an array. Otherwise, returns
+      true if p returns true for all elements in the array. Otherwise, returns
+      false.
+
+  .[n] p
+      Returns false if the current value is not an array. Otherwise, returns
+      false if the array has less than n elements. Otherwise, returns p(a[n]).
+
+Below are some KeySequence examples. Note that 'p' represents the
+predicate parsed by the PredicateExpression part of the input, while
+'m' represents the entry's metadata. For brevity, assume that 'foo'
+in queries of the form m['foo'] represents the first key in m that
+matches 'foo'.
+
+  .foo p
+      Returns p(m['foo'])
+
+  .foo.bar p
+      Returns p(m['foo']['bar'])
+
+  .foo[?] p
+      Returns true if p returns true for some element in m['foo']
+
+  .foo[?].bar p
+      Returns true if some element in m['foo'] is an object o s.t.
+      p(o['bar']) returns true.
+
+PREDICATE EXPRESSIONS:
+Predicate expression syntax is structurally identical to the top-level
+expression syntax (type "wash find -h syntax" to get an overview of the
+latter). Specifically, the "primaries" of predicate expressions consist of
+either an object predicate, an array predicate, or a primitive predicate
+(i.e. a "predicate") while the "operands" of predicate expressions are the
+same as the operands in the top-level expression parser.
+
+See the EXAMPLES section for predicate expression examples. The upcoming
+sections describe each of the predicates.
+
+OBJECT PREDICATE:
+-empty                                         |
+.key (Predicate | '(' PredicateExpression ')')
+
+If -empty is specified, then returns true if the current meta value is an
+empty object.
+
+The latter part of the expression has the same semantics as the object
+predicate described in the KEY SEQUENCES section. The only difference here
+is that the "p" in ".foo p" is either a "predicate" OR a parenthesized
+predicate expression.
+
+Below are some examples of object predicates. Let "m" represent the value
+that the predicate's being applied on.
+
+  -empty
+      Returns true if m is empty
+    
+  .foo +1
+      Returns true if m['foo'] > 1
+
+  .foo \( +1 -a -3 \)
+      Returns true if m['foo'] > 1 AND m['foo'] < 3. In other words, this
+      returns true if 1 < m['foo'] < 3.
+
+  .foo.bar \( \! +1 \)
+  .foo .bar \( \! +1 \)  
+      Returns true if m['foo']['bar'] is NOT > 1. In other words, this returns
+      true if m['foo']['bar'] <= 1. Also note that the "p" here is
+      ".bar \( \! +1 \)". This example is meant to show that key sequences are
+      are also supported by object predicates.
+
+ARRAY PREDICATE:
+-empty                                              |
+'[' ? ']' (Predicate | '(' PredicateExpression ')') |
+'[' * ']' (Predicate | '(' PredicateExpression ')') |
+'[' n ']' (Predicate | '(' PredicateExpression ')') |
+
+If -empty is specified, then returns true if the current meta value is an
+empty array.
+
+The latter part of the expression has the same semantics as the array
+predicate described in the KEY SEQUENCES section. The only difference here
+is that the "p" in "[?] p" is either a "predicate" OR a parenthesized
+predicate expression.
+
+Below are some examples of array predicates. Let "a" represent the value
+that the predicate's being applied on.
+
+  -empty
+      Returns true if a is empty
+    
+  [?] +1
+      Returns true if a has some element that's > 1
+
+  [*] +1
+      Returns true if all of a's elements are > 1
+
+  [n] +1
+      Returns true if a[n] > 1
+
+  [?] \( +1 -a -3 \)
+      Returns true if a has some element e s.t. e > 1 AND e < 3. In
+      other words, this returns true if 1 < e < 3.
+
+  [?].bar \( \! +1 \)
+  [?] .bar \( \! +1 \)  
+      Returns true if a has some element e s.t. e['bar'] is NOT > 1.
+      In other words, this returns true if e['bar'] <= 1. Also note
+      that the "p" here is ".bar \( \! +1 \)". This example is meant to
+      show that key sequences are are also supported by array predicates.
+
+PRIMITIVE PREDICATE:
+NullPredicate    |
+ExistsPredicate  |
+BooleanPredicate |
+NumericPredicate |
+TimePredicate    |
+StringPredicate
+
+All of the above predicates are described in their own section.
+
+NULL PREDICATE:
+-null
+
+Returns true if the current meta value is null. For example, ".foo -null"
+returns true if m['foo'] is null.
+
+EXISTS PREDICATE:
+-exists
+
+Returns true if the current meta value is not null. The exists predicate
+is a useful way to check if an object has a specific key. For example,
+".foo -exists" returns true if m['foo'] is not null, i.e. if m['foo']
+exists.
+
+BOOLEAN PREDICATE:
+-true | -false
+
+Boolean predicates always return false for a non-Boolean value. -true returns
+true if the value is true, while -false returns true if the value is false.
+For example, ".foo -true" returns true if m['foo'] is true, while ".foo -false"
+returns true if m['foo'] is false.
+
+NUMERIC PREDICATE:
+[+|-]? N [ckMGTP] |
+[+|-]? '{' N '}'
+
+where N >= 0. Here are the semantics for numeric predicates. Let v be the
+current meta value that's being compared. Then:
+  * If v is not a number (i.e. not a float64 type), then the predicate returns
+    false
+
+  * If only N is specified, then the predicate returns v == N.
+
+  * If +N is specified, then the predicate returns v > N
+
+  * If -N is specified, then the predicate returns v < N
+
+  * If N is suffixed with a unit, then v is compared to N scaled as:
+        c        character (* 1)
+        k        kibibytes (* 1024)
+        M        mebibytes (* 1024 ^ 2)
+        G        gibibytes (* 1024 ^ 3)
+        T        tebibytes (* 1024 ^ 4)
+        P        pebibytes (* 1024 ^ 5)
+    Suffixing N with units is useful when v represents a size value (e.g. like
+    the size of a VM's filesystem or the amount of memory that VM has).
+
+  * If {N} is specified, then the predicate compares v with -N. {N} is useful
+    for comparing negative numbers.
+
+Below are some examples of numeric predicates
+
+  1
+      Returns true if v == 1
+
+  {1}
+      Returns true if v == -1
+
+  +1
+      Returns true if v > 1
+
+  -1
+      Returns true if v < 1
+
+  +{1}
+      Returns true if v > -1
+
+  -{1}
+      Returns true if v < -1
+
+  1k
+      Returns true if v = (1 * 1024)
+
+  +1k
+      Returns true if v > (1 * 1024)
+
+  -1k
+      Returns true if v < (1 * 1024)
+
+And here's an example of a numeric predicate being used in conjunction
+with an object predicate:
+
+  .memory +1G
+      Returns true if m['memory'] > 1 gibibyte (1 * 1024 ^ 3)
+
+NOTE: Syntax like {1k} is currently not supported. If supported, this
+would semantically mean (-1 * 1024). The reason we don't support it is
+because negative size values do not make sense. If you do want to compare
+against negative size values, you'll have to type out the full number.
+For example, instead of {1k}, you'll need to type out {1024}.
+
+If you find that you frequently need to compare against negative size values,
+then please file a feature request so that we can add this support!
+
+TIME PREDICATE:
+[+|-]? N <smhdw>         |
+[+|-]? '{' N <smhdw> '}'
+
+where N >= 0. Note that units must be specified. Otherwise, there is no (simple)
+way for the parser to distinguish between a numeric predicate and a time
+predicate.
+
+Here are the semantics for time predicates. Let v be the current meta value that's
+being compared. Then:
+  * If v does not represent a time value, then the predicate returns false. Examples
+    of time values include stringified dates or unix seconds.
+
+  * If Nu is specified, where Nu means N suffixed with a unit, then the difference "d"
+    between find's start time and v will be compared to N scaled as: 
+        s        second
+        m        minute (60 seconds)
+        h        hour   (60 minutes)
+        d        day    (24 hours)
+        w        week   (7 days) 
+    The predicate returns "d" == Nu
+
+  * If +Nu is specified, then the predicate returns "d" > Nu
+
+  * If -Nu is specified, then the predicate returns "d" < Nu
+
+  * If {Nu} is specified, then "d" is the difference between v and find's start time.
+    Brackets are useful to distinguish "future" queries from "past" queries.
+
+NOTE: If "d" < 0, then the predicate always returns false. "d" < 0 represents a time
+mismatch (i.e. you are making a past query on a future time value or a future query on a
+past time value). We impose this limitation to make it easier for people to reason about
+time predicates. Otherwise, cases like "-1h" would return true for entries whose meta value
+is a time value in the future despite "-1h" being mentally parsed as "less than one hour
+ago", and thus interpreted as making sense for entries whose time values are in the past.
+
+Below are some examples of time predicates.
+
+  1s
+      Returns true if v was exactly one second ago
+
+  1h
+      Returns true if v was exactly one hour ago
+
+  +1h
+      Returns true if v was more than one hour ago
+
+  -1h
+      Returns true if v was less than one hour ago
+
+  {+1h}
+      Returns true if v is more than one hour from now
+
+  {-1h}
+      Returns true if v is less than one hour from now
+
+And here are some examples of time predicates being used in conjunction with
+object predicates:
+
+  .expiration_date +1h
+      Returns true if m['expiration_date'] was more than one hour ago
+
+  .expiration_date {+1h}
+      Returns true if m['expiration_date'] is more than an hour from now
+
+NOTE: As can be seen from the examples, time predicates only make sense when
+prefixed with a "+" or a "-".
+
+NOTE: As the expiration_date example shows, the "{}" distinguish a "future"
+query from a "past" query. Future queries are a useful way of filtering out
+entries that are going to expire within the next N minutes/hours/days/weeks
+(e.g. security policies, tagged EC2 instances, user credentials, etc.)
+
+STRING PREDICATE:
+Any input that doesn't begin with a "+", "-", "!", "(", or ")" is treated as
+a string predicate. String predicates return false for any non-string values.
+Otherwise, they return true if v == input, where v is the current meta value
+that's being compared.
+
+Below are some examples of string predicates:
+
+  foo
+      Returns true if v == foo 
+
+  bar
+      Returns true if v == bar
+
+And here's an example of a string predicate being used in conjunction with
+an object predicate:
+
+  .owner Mike
+      Returns true if m['owner'] == "Mike"
+
+NOTE: String predicates are a bit limited right now. We plan on adding
+regex/glob support for string predicates, and possibly a way for users to
+specify quoted string literals. The latter's useful when the input begins with
+one of the dis-allowed characters "+", "-", "!", "(", ")".
+
+NEGATION SEMANTICS:
+This section describes each of the aforementioned predicates' negation semantics.
+The information here can be used to reason about input like "! .foo +1".
+
+  OBJECT PREDICATE:  
+  "! .foo p" == ".foo ! p"
+
+  ARRAY PREDICATE:
+  "! [?] p" == "[*] ! p"
+  "! [*] p" == "[?] ! p"
+  "! [n] p" == "[n] ! p"
+
+  NULL PREDICATE:
+  "! -null" == "-exists"
+
+  EXISTS PREDICATE:
+  "! -exists" == "-null"
+
+  BOOLEAN PREDICATE:
+  "! -true"  == "-false"
+  "! -false" == "-true"
+
+  NUMERIC PREDICATE:
+  "! N"  == "+N" -o "-N"       (returns v != N)
+  "! +N" == "-N" -o "N"        (returns v <= N)
+  "! -N" == "+N" -o "N"        (returns v >= N)
+
+  Note that here, N represents a number. For example, N could be specified as
+  "1", "1k", or "{1}".
+
+  TIME PREDICATE:
+  "! 1h"    == "+1h" -o "-1h"          (returns "d" != 1h)
+  "! +1h"   == "-1h" -o "1h"           (returns "d" <= 1h)
+  "! -1h"   == "+1h" -o "1h"           (returns "d" >= 1h)
+
+  where "d" = "FindStartTime - v". Similarly for "future" queries,
+
+  "! {1h}"  == "+{1h}" -o "-{1h}"      (returns "d" != 1h)
+  "! +{1h}" == "-{1h}" -o "{1h}"       (returns "d" <= 1h)
+  "! -{1h}" == "+{1h}" -o "{1h}"       (returns "d" >= 1h)
+
+  where "d" = "v - FindStartTime". Note that the above semantics imply that
+  a negated time predicate will still return false if "d < 0" (i.e.
+  time-mismatches still return false)
+
+NOTE: The above semantics imply that the negated predicates still return false for
+mis-typed values. For example, "! .foo p" returns false if v is not an object;
+"! [?] p" returns false if v is not an array, etc.
+
+EXAMPLES:
+This section contains various, real-world examples of the meta primary's usage. If
+you have an interesting example that you'd like to include here, then please feel
+free to submit a PR!
+
+In these examples, let "m" be the value of the entry's 'meta' attribute.
+
+-meta .tags[?] .key termination_date -a .value +0h
+-m .tags[?] .key termination_date -a .value +0h
+    Returns true if m['tags'] has at least one object o s.t. o['key'] == termination_date
+    and o['value'] has expired. In the real world, this example filters out all EC2
+    instances whose termination_date tag expired.
+
+-m .tags[?] .key termination_date -a .value -{1w}
+    Same as the previous example, except this returns true if o['value'] will expire within
+    the current week. In the real world, this example filters out all EC2 instances whose
+    termination_date tag will expire within the current week.
+
+-m .tags[?] .key \( sales -o product \)
+    Returns true if m['tags'] has at least one object o s.t. o['key'] == sales OR product.
+    In the real world, this example filters out all EC2 instances that belong to the "sales"
+    or "product" departments.
+
+-m .state.name pending -o running
+    Returns true if m['state']['name'] == pending OR running. In the real world, this
+    example filters out pending/running EC2 instances.
+
+-m .vpcid vpc-0eb70f7f626d3db84
+    Returns true if m['vpcid'] == vpc-0eb70f7f626d3db84. In the real world, this example
+    filters out EC2 instances attached to the VPC with ID vpc-0eb70f7f626d3db84.
+
+    NOTE: With regex/glob support, this example could be shortened to something like
+    "-m .vpcid vpc-0eb.*"
+
+-m .mounts[?] .type tmpfs
+    Returns true if m['mounts'] has at least one object o s.t. o['type'] == tmpfs. In the
+    real world, this example filters out all Docker containers that have tmpfs mounts.
+`

--- a/cmd/internal/find/primary/meta.go
+++ b/cmd/internal/find/primary/meta.go
@@ -88,16 +88,30 @@ var metaPrimary = Parser.add(&Primary{
 })
 
 const metaDetailedDescription = `
+The meta primary constructs a predicate on the entry's meta attribute.
+It is a specialized filter, so you should only use it if you need to
+filter your entries on a property that isn't captured by the common Wash
+attributes. For example, the meta primary can be used to filter EC2
+instances on a specific tag. It can be used to filter Docker containers
+with a specified label. In general, the meta primary can be used to filter
+on any property that's specified in the entry's meta attribute. See the
+EXAMPLES section for some interesting real-world examples.
+
+NOTE: Because it is a specialized filter, the meta primary defaults
+maxdepth to 1 if the -maxdepth flag is not provided. This is to avoid
+unnecessary recursion (and API requests), since only entries in the same
+hierarchy are likely to have the same "meta" schema. For example, it
+wouldn't make sense for 'wash find' to recurse into an EC2 instance's
+console output when it is filtering on an EC2 instance's tags.
+
+You can set maxdepth to -1 if you'd like find to always recurse.
+
+USAGE:
 (-m|-meta) (-empty | KeySequence PredicateExpression)
 
 If -empty is specified, then returns true if the entry's meta attribute
 is empty. Otherwise, returns true if the meta value specified by the key
 sequence satisfies the given predicate expression.
-
-NOTE: If the -maxdepth flag was not provided, then the meta primary
-defaults the maxdepth to 1. This is to avoid unnecessary recursion (and
-API requests) since the meta primary is a specialized filter. You can set
-maxdepth to -1 if you'd like find to always recurse.
 
 KEY SEQUENCES:
 A key sequence consists of a key token followed by zero or more "chunks".

--- a/cmd/internal/find/primary/name.go
+++ b/cmd/internal/find/primary/name.go
@@ -9,8 +9,10 @@ import (
 
 // namePrimary => -name ShellGlob
 //nolint
-var namePrimary = Parser.add(&primary{
-	tokens: []string{"-name"},
+var namePrimary = Parser.add(&Primary{
+	Description: "Returns true if the entry's cname matches glob",
+	name: "name",
+	args: "glob",
 	parseFunc: func(tokens []string) (types.EntryPredicate, []string, error) {
 		if len(tokens) == 0 {
 			return nil, nil, fmt.Errorf("requires additional arguments")

--- a/cmd/internal/find/primary/parser_test.go
+++ b/cmd/internal/find/primary/parser_test.go
@@ -11,6 +11,37 @@ type ParserTestSuite struct {
 	parsertest.Suite
 }
 
+func (s *ParserTestSuite) TestRegisteredPrimaries() {
+	expectedList := []*Primary{
+		actionPrimary,
+		truePrimary,
+		falsePrimary,
+		metaPrimary,
+		namePrimary,
+		pathPrimary,
+		sizePrimary,
+		ctimePrimary,
+		mtimePrimary,
+		atimePrimary,
+	}
+	expectedMp := map[string]*Primary{
+		"-action": actionPrimary,
+		"-true": truePrimary,
+		"-false": falsePrimary,
+		"-meta": metaPrimary,
+		"-m": metaPrimary,
+		"-name": namePrimary,
+		"-path": pathPrimary,
+		"-size": sizePrimary,
+		"-ctime": ctimePrimary,
+		"-mtime": mtimePrimary,
+		"-atime": atimePrimary,
+	}
+
+	s.ElementsMatch(expectedList, Parser.primaries)
+	s.Equal(expectedMp, Parser.primaryMap)
+}
+
 func (s *ParserTestSuite) TestErrors() {
 	s.RunTestCases(
 		s.NPETC("", "expected a primary", true),

--- a/cmd/internal/find/primary/path.go
+++ b/cmd/internal/find/primary/path.go
@@ -9,8 +9,10 @@ import (
 
 // pathPrimary => -path ShellGlob
 //nolint
-var pathPrimary = Parser.add(&primary{
-	tokens: []string{"-path"},
+var pathPrimary = Parser.add(&Primary{
+	Description: "Returns true if the entry's normalized path matches glob",
+	name: "path",
+	args: "glob",
 	parseFunc: func(tokens []string) (types.EntryPredicate, []string, error) {
 		if len(tokens) == 0 {
 			return nil, nil, fmt.Errorf("requires additional arguments")

--- a/cmd/internal/find/primary/size.go
+++ b/cmd/internal/find/primary/size.go
@@ -10,15 +10,12 @@ import (
 
 // sizePrimary => -size (+|-)?(\d+ | numeric.SizeRegex)
 //
-// Example inputs:
-//   -size 2   (true if the entry's size in 512-byte blocks, rounded up, is 2)
-//   -size +2  (true if the entry's size in 512-byte blocks, rounded up, is greater than 2)
-//   -size -2  (true if the entry's size in 512-byte blocks, rounded up, is less than 2)
-//   -size +1k (true if the entry's size is greater than 1 kibibyte (1024 bytes))
-//
 //nolint
-var sizePrimary = Parser.add(&primary{
-	tokens: []string{"-size"},
+var sizePrimary = Parser.add(&Primary{
+	Description: "Returns true if the entry's size attribute satisfies sizeP",
+	DetailedDescription: sizeDetailedDescription,
+	name: "size",
+	args: "sizeP",
 	parseFunc: func(tokens []string) (types.EntryPredicate, []string, error) {
 		if len(tokens) == 0 {
 			return nil, nil, fmt.Errorf("requires additional arguments")
@@ -46,3 +43,34 @@ var sizePrimary = Parser.add(&primary{
 		return p, tokens[1:], nil
 	},
 })
+
+const sizeDetailedDescription = `
+-size [+|-]n[ckMGTP]
+
+Returns true if the entry's size attribute is n 512-byte blocks,
+rounded up to the nearest block. If n is suffixed with a unit,
+then the size is compared as-is to n scaled as:
+
+c        character (byte)
+k        kibibytes (1024 bytes)
+M        mebibytes (1024 kibibytes)
+G        gibibytes (1024 mebibytes)
+T        tebibytes (1024 gibibytes)
+P        pebibytes (1024 tebibytes)
+
+If n is prefixed with a +/-, then the comparison returns true if
+the size is greater-than/less-than n.
+
+Examples:
+  -size 2        Returns true if the entry's size is 2 512-byte blocks,
+                 rounded up to the nearest block
+
+  -size +2       Returns true if the entry's size is greater than 2
+                 512-byte blocks, rounded up to the nearest block
+
+  -size -2       Returns true if the entry's size is less than 2
+                 512-byte blocks, rounded up to the nearest block
+
+  -size +1k      Returns true if the entry's size is greater than 1
+                 kibibyte
+`

--- a/cmd/internal/find/primary/size.go
+++ b/cmd/internal/find/primary/size.go
@@ -12,10 +12,10 @@ import (
 //
 //nolint
 var sizePrimary = Parser.add(&Primary{
-	Description: "Returns true if the entry's size attribute satisfies sizeP",
+	Description: "Returns true if the entry's size attribute satisfies the given size predicate",
 	DetailedDescription: sizeDetailedDescription,
 	name: "size",
-	args: "sizeP",
+	args: "[+|-]n[ckMGTP]",
 	parseFunc: func(tokens []string) (types.EntryPredicate, []string, error) {
 		if len(tokens) == 0 {
 			return nil, nil, fmt.Errorf("requires additional arguments")
@@ -49,7 +49,7 @@ const sizeDetailedDescription = `
 
 Returns true if the entry's size attribute is n 512-byte blocks,
 rounded up to the nearest block. If n is suffixed with a unit,
-then the size is compared as-is to n scaled as:
+then the raw size is compared to n scaled as:
 
 c        character (byte)
 k        kibibytes (1024 bytes)

--- a/cmd/internal/find/primary/timeAttr.go
+++ b/cmd/internal/find/primary/timeAttr.go
@@ -30,10 +30,10 @@ func getTimeAttrValue(name string, e types.Entry) (time.Time, bool) {
 // timeAttrPrimary => -<name> (+|-)?(\d+ | (numeric.DurationRegex)+)
 func newTimeAttrPrimary(name string) *Primary {
 	return Parser.add(&Primary{
-		Description: fmt.Sprintf("Returns true if the entry's %v attribute satisfies timeP", name),
+		Description: fmt.Sprintf("Returns true if the entry's %v attribute satisfies the given time predicate", name),
 		DetailedDescription: timeAttrDetailedDescription(name),
 		name: name,
-		args: "timeP",
+		args: "[+|-]n[smhdw]",
 		parseFunc: func(tokens []string) (types.EntryPredicate, []string, error) {
 			if params.StartTime.IsZero() {
 				panic("Attempting to parse a time primary without setting params.StartTime")
@@ -77,7 +77,7 @@ func timeAttrDetailedDescription(name string) string {
 
 Returns true if the entry's {name} attribute is exactly n days,
 rounded up to the nearest day. If n is suffixed with a unit, then
-the {name} is compared as-is to n scaled as:
+the raw {name} is compared to n scaled as:
 
 s        second
 m        minute (60 seconds)

--- a/cmd/internal/find/types/options.go
+++ b/cmd/internal/find/types/options.go
@@ -70,10 +70,10 @@ func OptionsTable() *cmdutil.Table {
 	return cmdutil.NewTable(
 		[]string{"Flags:",                 ""},
 		[]string{"      -depth",           "Visit the children first before the parent (default false)"},
-		[]string{"      -mindepth levels", "Do not print entries at levels less than levels (default 0)"},
-		[]string{"      -maxdepth levels", "Do not print entries at levels greater than levels (default infinity)"},
-		[]string{"  -h, -help",            "Print the usage"},
-		[]string{"  -h, -help <primary>",  "Print a detailed description of the specified primary"},
+		[]string{"      -mindepth depth",  "Do not print entries at levels less than depth (default 0)"},
+		[]string{"      -maxdepth depth",  "Do not print entries at levels greater than depth (default infinity)"},
+		[]string{"  -h, -help",            "Print this usage"},
+		[]string{"  -h, -help <primary>",  "Print a detailed description of the specified primary (e.g. \"-help meta\")"},
 		[]string{"  -h, -help syntax",     "Print a detailed description of find's expression syntax"},
 	)
 }

--- a/cmd/internal/find/types/options.go
+++ b/cmd/internal/find/types/options.go
@@ -3,6 +3,8 @@ package types
 import (
 	"flag"
 	"io/ioutil"
+
+	"github.com/puppetlabs/wash/cmd/util"
 )
 
 // Options represents the find command's options.
@@ -10,6 +12,7 @@ type Options struct {
 	Depth    bool
 	Mindepth uint
 	Maxdepth int
+	Help HelpOption
 	setFlags map[string]struct{}
 }
 
@@ -54,11 +57,41 @@ func (opts *Options) MarkAsSet(flag string) {
 func (opts *Options) FlagSet() *flag.FlagSet {
 	// Create the flag-set that's tied to our options.
 	fs := flag.NewFlagSet("options", flag.ContinueOnError)
-	// TODO: Handle usage later
-	fs.Usage = func() {}
 	fs.SetOutput(ioutil.Discard)
 	fs.BoolVar(&opts.Depth, DepthFlag, opts.Depth, "")
 	fs.UintVar(&opts.Mindepth, MindepthFlag, opts.Mindepth, "")
 	fs.IntVar(&opts.Maxdepth, MaxdepthFlag, opts.Maxdepth, "")
 	return fs
 }
+
+// OptionsTable returns a table containing all of `wash find`'s available
+// options
+func OptionsTable() *cmdutil.Table {
+	return cmdutil.NewTable(
+		[]string{"Flags:",                 ""},
+		[]string{"      -depth",           "Visit the children first before the parent (default false)"},
+		[]string{"      -mindepth levels", "Do not print entries at levels less than levels (default 0)"},
+		[]string{"      -maxdepth levels", "Do not print entries at levels greater than levels (default infinity)"},
+		[]string{"  -h, -help",            "Print the usage"},
+		[]string{"  -h, -help <primary>",  "Print a detailed description of the specified primary"},
+		[]string{"  -h, -help syntax",     "Print a detailed description of find's expression syntax"},
+	)
+}
+
+// HelpOption represents the -help option. If HasValue is set, then
+// that means the input was "-help <primary>|syntax". In that case,
+// only one of Primary/Syntax is set. Otherwise, the input was "-help".
+//
+// See the comments in parser.parseOptions for more details on why
+// this does not implement the Value interface.
+type HelpOption struct {
+	Requested bool
+	HasValue bool
+	// Cannot use *primary.Primary here b/c doing so would introduce
+	// an import cycle. Resolving that import cycle for a slightly
+	// cleaner implementation is not worth the additional complexity
+	// associated with introducing more fine-grained packages.
+	Primary string
+	Syntax bool
+}
+

--- a/cmd/internal/find/usage.go
+++ b/cmd/internal/find/usage.go
@@ -1,0 +1,40 @@
+package find
+
+import (
+	"github.com/puppetlabs/wash/cmd/internal/find/types"
+	"github.com/puppetlabs/wash/cmd/internal/find/parser"
+	"github.com/puppetlabs/wash/cmd/internal/find/primary"
+)
+
+// Usage returns `wash find`'s usage string
+func Usage() string {
+	u := ""
+	u += "Recursively descends the directory tree of the specified path, evaluating an\n"
+	u += "'expression' composed of 'primaries' and 'operands' for each entry in the tree.\n"
+	u += "\n"
+	u += "Usage:\n"
+	u += "  wash find [path] [options] [expression]\n"
+	u += "\n"
+
+	t := types.OptionsTable()
+	addEmptyRow := func() {
+		t.Append([][]string{
+			[]string{"", ""},
+		})
+	}
+	addEmptyRow()
+	t.Append(primary.Table().Rows())
+	addEmptyRow()
+	t.Append(parser.OperandsTable().Rows())
+	u += t.Format()
+	u += "\n"
+
+	u += "Use \"wash find --help <primary>\" for more information about a primary. To view\n"
+	u += "a detailed description of find's expression syntax, use \"wash find --help syntax\".\n"
+	u += "\n"
+	u += "NOTE: All entry attribute primaries return false if the given entry does not have\n"
+	u += "the specified attribute. For example, the -mtime primary will always return false\n"
+	u += "if the entry does not have an mtime attribute."
+
+	return u
+}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -63,7 +63,7 @@ func formatListEntries(ls []apitypes.Entry) string {
 
 		table[i] = []string{name, mtimeStr, verbs}
 	}
-	return cmdutil.FormatTable(headers(), table)
+	return cmdutil.NewTableWithHeaders(headers(), table).Format()
 }
 
 func listMain(cmd *cobra.Command, args []string) exitCode {

--- a/cmd/ps.go
+++ b/cmd/ps.go
@@ -153,7 +153,7 @@ func formatStats(stats []psresult) string {
 			st.command,
 		}
 	}
-	return cmdutil.FormatTable(headers, table)
+	return cmdutil.NewTableWithHeaders(headers, table).Format()
 }
 
 func psMain(cmd *cobra.Command, args []string) exitCode {

--- a/cmd/util/tables.go
+++ b/cmd/util/tables.go
@@ -27,27 +27,94 @@ type ColumnHeader struct {
 	ShortName, FullName string
 }
 
-// FormatTable formats the provided headers and string table to display
-// with sufficient padding to align columns.
-func FormatTable(headers []ColumnHeader, rows [][]string) string {
+// Table represents a formatted table. Use the NewTable* functions
+// to create your Table objects.
+type Table struct {
+	headers []ColumnHeader
+	rows [][]string
+	numColumns int
+	hasHeaders bool
+}
+
+// NewTable creates a new Table object with the given
+// rows
+func NewTable(rows... []string) *Table {
+	if len(rows) == 0 {
+		panic("cmdutil.NewTable called without any rows")
+	}
+	return &Table{
+		rows: rows,
+		numColumns: len(rows[0]),
+		hasHeaders: false,
+	}
+}
+
+// NewTableWithHeaders creates a new Table object with the given
+// headers and rows
+func NewTableWithHeaders(headers []ColumnHeader, rows [][]string) *Table {
+	if len(headers) == 0 {
+		panic("cmdutil.NewTableWithHeaders called without any headers")
+	}
+	if len(rows) == 0 {
+		panic("cmdutil.NewTableWithHeaders called without any rows")
+	}
+	return &Table{
+		headers: headers,
+		rows: rows,
+		numColumns: len(headers),
+		hasHeaders: true,
+	}
+}
+
+// Rows returns the table's rows
+func (t *Table) Rows() [][]string {
+	return t.rows
+}
+
+// Append appends the given rows to t
+func (t *Table) Append(rows [][]string) {
+	t.rows = append(t.rows, rows...)
+}
+
+// Format formats the provided table to display with sufficient padding
+// to align columns
+func (t *Table) Format() string {
+	headers := make([]ColumnHeader, t.numColumns)
+	if t.hasHeaders {
+		headers = t.headers
+	}
+
 	// Setup the output table
 	tab := tabular.New()
 	for i, column := range headers {
 		// Don't pad the last column
 		var width int
 		if i < len(headers)-1 {
-			width = len(LongestFieldFromColumn(rows, i)) + 2
+			longestColumn := LongestFieldFromColumn(t.rows, i)
+			if !t.hasHeaders {
+				// Construct a stub header so that the tabular
+				// library generates the right format string
+				// for the table. Using the zeroed ColumnHeader
+				// objects is not enough because they still result
+				// in an incorrectly formatted table.
+				column.ShortName = longestColumn
+				column.FullName = longestColumn
+			}
+			width = len(longestColumn) + 2
 		}
 		tab.Col(column.ShortName, column.FullName, width)
 	}
 
 	table := tab.Parse("*")
-	out := fmt.Sprintln(table.Header)
+	out := ""
+	if t.hasHeaders {
+		out = fmt.Sprintln(table.Header)
+	}
 
-	values := make([]interface{}, len(headers))
-	for _, row := range rows {
-		if len(values) != len(row) {
-			panic("all rows must be the same length")
+	values := make([]interface{}, t.numColumns)
+	for _, row := range t.rows {
+		if len(row) != t.numColumns {
+			panic("all rows must have the same number of columns")
 		}
 		for i, item := range row {
 			values[i] = item


### PR DESCRIPTION
This commit supports the help flags (-h/-help) for `wash find`.
Specifically, `wash find -h` outputs a general help message;
`wash find -h <primary>` outputs the detailed description of
the specified primary; while `wash find -h syntax` outputs
a detailed description of `wash find`'s expression syntax.

Signed-off-by: Enis Inan <enis.inan@puppet.com>