### PR TITLE
Restore loglevel and logfile options for `wash server`

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -25,6 +25,12 @@ func serverCommand() *cobra.Command {
 		Args:  cobra.MinimumNArgs(1),
 	}
 
+	serverCmd.Flags().String("loglevel", "info", "Set the logging level")
+	errz.Fatal(viper.BindPFlag("loglevel", serverCmd.Flags().Lookup("loglevel")))
+
+	serverCmd.Flags().String("logfile", "", "Set the log file's location. Defaults to stdout")
+	errz.Fatal(viper.BindPFlag("logfile", serverCmd.Flags().Lookup("logfile")))
+
 	serverCmd.Flags().String("external-plugins", "", "Specify the file to load any external plugins")
 	errz.Fatal(viper.BindPFlag("external-plugins", serverCmd.Flags().Lookup("external-plugins")))
 


### PR DESCRIPTION
They were "moved" in a prior commit, but I misunderstood how flags
worked and thought they'd be inherited. Restore them for the server.

Signed-off-by: Michael Smith <michael.smith@puppet.com>