### PR TITLE
Move common API logging to ServeHTTP handler

### DIFF
--- a/api/cache.go
+++ b/api/cache.go
@@ -29,21 +29,16 @@ var cacheHandler handler = func(w http.ResponseWriter, r *http.Request) *errorRe
 		return errResp
 	}
 
-	ctx := r.Context()
-	activity.Record(ctx, "API: Cache DELETE %v", path)
 	deleted, err := plugin.ClearCacheFor(path)
 	if err != nil {
-		activity.Record(ctx, "API: Cache DELETE flush cache errored constructing regexp from %v: %v", path, err)
 		return unknownErrorResponse(fmt.Errorf("Could not use path %v in a regexp: %v", path, err))
 	}
+	activity.Record(r.Context(), "API: Cache DELETE %v %+v", path, deleted)
 
 	w.WriteHeader(http.StatusOK)
 	jsonEncoder := json.NewEncoder(w)
 	if err = jsonEncoder.Encode(deleted); err != nil {
-		activity.Record(ctx, "API: Cache DELETE marshalling %v errored: %v", path, err)
 		return unknownErrorResponse(fmt.Errorf("Could not marshal deleted keys for %v: %v", path, err))
 	}
-
-	activity.Record(ctx, "API: Cache DELETE %v complete: %v", path, deleted)
 	return nil
 }

--- a/api/exec.go
+++ b/api/exec.go
@@ -112,7 +112,6 @@ var execHandler handler = func(w http.ResponseWriter, r *http.Request) *errorRes
 	}
 	result, err := entry.(plugin.Execable).Exec(ctx, body.Cmd, body.Args, opts)
 	if err != nil {
-		activity.Record(ctx, "API: Exec %v errored: %v", path, err)
 		return erroredActionResponse(path, plugin.ExecAction(), err.Error())
 	}
 
@@ -130,7 +129,5 @@ var execHandler handler = func(w http.ResponseWriter, r *http.Request) *errorRes
 	enc := json.NewEncoder(&streamableResponseWriter{fw})
 	streamOutput(ctx, enc, result.OutputCh)
 	streamExitCode(ctx, enc, result.ExitCodeCB)
-
-	activity.Record(ctx, "API: Exec %v complete", path)
 	return nil
 }

--- a/api/history.go
+++ b/api/history.go
@@ -40,7 +40,6 @@ var historyHandler handler = func(w http.ResponseWriter, r *http.Request) *error
 	}
 	jsonEncoder := json.NewEncoder(w)
 	if err := jsonEncoder.Encode(&commands); err != nil {
-		activity.Record(r.Context(), "Unable to encode history: %v", err)
 		return unknownErrorResponse(fmt.Errorf("Could not marshal %v: %v", history, err))
 	}
 	return nil

--- a/api/info.go
+++ b/api/info.go
@@ -4,8 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-
-	"github.com/puppetlabs/wash/activity"
 )
 
 // swagger:route GET /fs/info info entryInfo
@@ -25,23 +23,18 @@ import (
 //       404: errorResp
 //       500: errorResp
 var infoHandler handler = func(w http.ResponseWriter, r *http.Request) *errorResponse {
-	ctx := r.Context()
 	entry, path, errResp := getEntryFromRequest(r)
 	if errResp != nil {
 		return errResp
 	}
 
-	activity.Record(ctx, "API: Info %v", path)
 	w.WriteHeader(http.StatusOK)
 	jsonEncoder := json.NewEncoder(w)
 	// TODO: Include the entry's full metadata?
 	apiEntry := toAPIEntry(entry)
 	apiEntry.Path = path
 	if err := jsonEncoder.Encode(&apiEntry); err != nil {
-		activity.Record(ctx, "API: Info: marshalling %v errored: %v", path, err)
 		return unknownErrorResponse(fmt.Errorf("Could not marshal %v: %v", path, err))
 	}
-
-	activity.Record(ctx, "API: Info %v complete", path)
 	return nil
 }

--- a/api/list.go
+++ b/api/list.go
@@ -44,12 +44,9 @@ var listHandler handler = func(w http.ResponseWriter, r *http.Request) *errorRes
 		return unsupportedActionResponse(path, plugin.ListAction())
 	}
 
-	activity.Record(ctx, "API: List %v", path)
 	group := entry.(plugin.Group)
 	entries, err := plugin.CachedList(ctx, group)
 	if err != nil {
-		activity.Record(ctx, "API: List %v errored: %v", path, err)
-
 		if cnameErr, ok := err.(plugin.DuplicateCNameErr); ok {
 			return duplicateCNameResponse(cnameErr)
 		}
@@ -68,10 +65,7 @@ var listHandler handler = func(w http.ResponseWriter, r *http.Request) *errorRes
 	w.WriteHeader(http.StatusOK)
 	jsonEncoder := json.NewEncoder(w)
 	if err = jsonEncoder.Encode(result); err != nil {
-		activity.Record(ctx, "API: List marshalling %v errored: %v", path, err)
 		return unknownErrorResponse(fmt.Errorf("Could not marshal list results for %v: %v", path, err))
 	}
-
-	activity.Record(ctx, "API: List %v complete", path)
 	return nil
 }

--- a/api/metadata.go
+++ b/api/metadata.go
@@ -37,11 +37,9 @@ var metadataHandler handler = func(w http.ResponseWriter, r *http.Request) *erro
 		return errResp
 	}
 
-	activity.Record(ctx, "API: Metadata %v", path)
 	metadata, err := plugin.CachedMetadata(ctx, entry)
 
 	if err != nil {
-		activity.Record(ctx, "API: Metadata %v errored: %v", path, err)
 		return unknownErrorResponse(err)
 	}
 	activity.Record(ctx, "API: Metadata %v %+v", path, metadata)
@@ -49,10 +47,7 @@ var metadataHandler handler = func(w http.ResponseWriter, r *http.Request) *erro
 	w.WriteHeader(http.StatusOK)
 	jsonEncoder := json.NewEncoder(w)
 	if err = jsonEncoder.Encode(metadata); err != nil {
-		activity.Record(ctx, "API: Metadata marshalling %v errored: %v", path, err)
 		return unknownErrorResponse(fmt.Errorf("Could not marshal metadata for %v: %v", path, err))
 	}
-
-	activity.Record(ctx, "API: Metadata %v complete", path)
 	return nil
 }

--- a/api/read.go
+++ b/api/read.go
@@ -35,11 +35,9 @@ var readHandler handler = func(w http.ResponseWriter, r *http.Request) *errorRes
 		return unsupportedActionResponse(path, plugin.ReadAction())
 	}
 
-	activity.Record(ctx, "API: Read %v", path)
 	content, err := plugin.CachedOpen(ctx, entry.(plugin.Readable))
 
 	if err != nil {
-		activity.Record(ctx, "API: Read %v errored: %v", path, err)
 		return erroredActionResponse(path, plugin.ReadAction(), err.Error())
 	}
 	activity.Record(ctx, "API: Reading %v", path)
@@ -50,10 +48,7 @@ var readHandler handler = func(w http.ResponseWriter, r *http.Request) *errorRes
 		activity.Record(ctx, "API: Reading %v incomplete: %v/%v", path, n, content.Size())
 	}
 	if err != nil {
-		activity.Record(ctx, "API: Reading %v errored: %v", path, err)
 		return erroredActionResponse(path, plugin.ReadAction(), err.Error())
 	}
-
-	activity.Record(ctx, "API: Reading %v complete", path)
 	return nil
 }

--- a/api/server.go
+++ b/api/server.go
@@ -46,6 +46,7 @@ func (handle handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	activity.Record(r.Context(), "API: %v %v", r.Method, r.URL)
 
 	if err := handle(w, r); err != nil {
+		activity.Record(r.Context(), "API: %v %v: %v", r.Method, r.URL, err)
 		w.WriteHeader(err.statusCode)
 
 		// NOTE: Do not set these headers in the middleware because not
@@ -57,6 +58,8 @@ func (handle handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		if _, err := fmt.Fprintln(w, err.Error()); err != nil {
 			log.Warnf("API: Failed writing error response: %v", err)
 		}
+	} else {
+		activity.Record(r.Context(), "API: %v %v complete", r.Method, r.URL)
 	}
 }
 

--- a/api/stream.go
+++ b/api/stream.go
@@ -41,11 +41,9 @@ var streamHandler handler = func(w http.ResponseWriter, r *http.Request) *errorR
 		return unknownErrorResponse(fmt.Errorf("Cannot stream %v, response handler does not support flushing", path))
 	}
 
-	activity.Record(ctx, "API: Stream %v", path)
 	rdr, err := entry.(plugin.Streamable).Stream(ctx)
 
 	if err != nil {
-		activity.Record(ctx, "API: Stream %v errored: %v", path, err)
 		return erroredActionResponse(path, plugin.StreamAction(), err.Error())
 	}
 	activity.Record(ctx, "API: Streaming %v", path)
@@ -65,7 +63,5 @@ var streamHandler handler = func(w http.ResponseWriter, r *http.Request) *errorR
 		// Common for copy to error when the caller closes the connection.
 		activity.Record(ctx, "API: Streaming %v errored: %v", path, err)
 	}
-
-	activity.Record(ctx, "API: Streaming %v complete", path)
 	return nil
 }


### PR DESCRIPTION
Reduce logging redundancy by having the handler wrapper log start,
error, and complete for API requests.

Signed-off-by: Michael Smith <michael.smith@puppet.com>