### PR TITLE
Update instructions around running Wash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-# Run with: docker run --device /dev/fuse --cap-add SYS_ADMIN -v /var/run/docker.sock:/var/run/docker.sock
-# Then enter: docker exec -it <name> sh
-
+# Run with: docker run --device /dev/fuse --cap-add SYS_ADMIN -v /var/run/docker.sock:/var/run/docker.sock -v /proc:/proc -it <name>
+# Warning: these docker options give the container complete access to the host system. This
+# container is designed for convenience, not security.
 FROM golang:alpine AS build_base
 
 RUN apk update && apk add --no-cache git
@@ -17,8 +17,5 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -installsuffix cgo -ldflag
 FROM alpine AS wash
 RUN apk update && apk add --no-cache fuse ca-certificates
 COPY --from=builder /workdir/wash /bin/wash
-WORKDIR /mnt
 
-# Eventually move to entrypoint with #!/bin/sh\nwash server /mnt 2>/var/log/wash.log &\nsh
-# Challenging now because /mnt is a different inode after wash finishes initializing.
-ENTRYPOINT ["wash", "server", "/mnt"]
+ENTRYPOINT ["wash"]

--- a/README.md
+++ b/README.md
@@ -96,18 +96,19 @@ Add your mount directory to Spotlight's list of excluded directories to avoid he
 
 ## Usage
 
-Mount `wash`'s filesystem and API server with
+Start the `wash` daemon and shell with
 ```
-wash server mnt
+wash
 ```
-In another shell, navigate to `mnt` to view available resources.
+
+The `wash` shell provides wrappers for executing most subcommands. You can usually find the native POSIX variants in `/usr/bin` or `/bin`.
 
 See available subcommands - such as `ls` and `exec` - with
 ```
 wash help
 ```
 
-When done, `cd` out of `mnt`, then run `umount mnt` or `Ctrl-C` the server process.
+When done, `exit` to exit the shell and shutdown the daemon.
 
 ### Wash by Example
 
@@ -122,8 +123,9 @@ This starts a small [Flask](http://flask.pocoo.org) webapp that keeps a count of
 
 Navigate the filesystem to view running containers
 ```
-$ cd mnt/docker/containers
-$ wash ls
+$ wash
+wash$ cd docker/containers
+wash$ wash ls
 NAME                                                                CREATED               ACTIONS
 ./                                                                  <unknown>             list
 45a0265546d63a8f1b0d17033748db1468dc49dfd09cdaf2db62c45a60e82aaf/   20 Mar 19 17:02 PDT   exec, list, metadata
@@ -137,7 +139,7 @@ log             <unknown>             read, stream
 
 Those containers are displayed as a directory, and provide access to their logs and metadata as files. Recent output from both can be accessed with common tools.
 ```
-$ tail */log
+wash$ tail */log
 ==> 382776912d9373e6c4dc1350894b5290b22c36893a8fed08e2ba53fbb680c8a6/log <==
  * Serving Flask app "app" (lazy loading)
  * Environment: production
@@ -155,7 +157,7 @@ $ tail */log
 
 The list earlier also noted that the container "directories" support the *metadata* action. We can get structured metadata in ether YAML or JSON with `wash meta`
 ```
-$ wash meta 382776912d9373e6c4dc1350894b5290b22c36893a8fed08e2ba53fbb680c8a6 -o yaml
+wash$ meta 382776912d9373e6c4dc1350894b5290b22c36893a8fed08e2ba53fbb680c8a6 -o yaml
 AppArmorProfile: ""
 Args:
 - app.py
@@ -169,7 +171,7 @@ $ wash exec 45a0265546d63a8f1b0d17033748db1468dc49dfd09cdaf2db62c45a60e82aaf who
 root
 ```
 
-Try exploring `mnt/docker/volumes` to interact with the volume created for Redis.
+Try exploring `docker/volumes` to interact with the volume created for Redis.
 
 ### Record of Activity
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -82,10 +82,10 @@
 <li>E.g. on CentOS: <code>yum install fuse fuse-libs</code></li>
 <li>E.g. on Ubuntu: <code>apt-get install fuse</code></li>
 </ul></li>
-<li>Start the server
+<li>Start <code>wash</code>
 
 <ul>
-<li><code>./wash server wash-root-dir</code></li>
+<li><code>./wash</code></li>
 </ul></li>
 </ol>
 
@@ -93,9 +93,9 @@
 
 <p>For more of a guided tour that includes spinning up some resources <code>wash</code> can talk to, check out our <a href="https://github.com/puppetlabs/wash#wash-by-example"><code>docker compose</code> example</a>.</p>
 
-<p>Once the server is up, you can use vanilla <code>ls</code>, <code>cd</code>, etc. to explore <code>wash-root-dir</code>. You can then start experimenting with <code>wash</code> subcommands, like <code>wash ls</code> and <code>wash tail</code>, to navigate that filesystem in a more <code>wash</code>-optimized way.</p>
+<p>Once the server is up, you can use vanilla <code>ls</code>, <code>cd</code>, etc. to explore. You can then start experimenting with <code>wash</code> subcommands, like <code>wash ls</code> and <code>wash tail</code>, to navigate that filesystem in a more <code>wash</code>-optimized way. <code>wash</code> provides wrappers for some of these; you can usually find the native POSIX variants in <code>/usr/bin</code> or <code>/bin</code>.</p>
 
-<p>When you&rsquo;re done, make sure there are no processes still using <code>wash-root-dir</code>, and you can just <code>Ctrl-C</code> the server.</p>
+<p>When you&rsquo;re done, <code>exit</code> the shell.</p>
 
 <h2 id="current-features">Current features</h2>
 

--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -42,16 +42,16 @@ Exploring, understanding, and inspecting modern infrastructure should be simple 
    * E.g. on MacOS using homebrew: `brew cask install osxfuse`
    * E.g. on CentOS: `yum install fuse fuse-libs`
    * E.g. on Ubuntu: `apt-get install fuse`
-3. Start the server
-   * `./wash server wash-root-dir`
+3. Start `wash`
+   * `./wash`
 
 At this point, if you haven't already, you should fire up some resources that `wash` can actually introspect. Otherwise, as Han Solo would say, "this is going to be a real short trip". So fire up some Docker containers, create some EC2 instances, toss some files into S3, launch a Kubernetes pod, etc. 
 
 For more of a guided tour that includes spinning up some resources `wash` can talk to, check out our [`docker compose` example](https://github.com/puppetlabs/wash#wash-by-example).
 
-Once the server is up, you can use vanilla `ls`, `cd`, etc. to explore `wash-root-dir`. You can then start experimenting with `wash` subcommands, like `wash ls` and `wash tail`, to navigate that filesystem in a more `wash`-optimized way.
+Once the server is up, you can use vanilla `ls`, `cd`, etc. to explore. You can then start experimenting with `wash` subcommands, like `wash ls` and `wash tail`, to navigate that filesystem in a more `wash`-optimized way. `wash` provides wrappers for some of these; you can usually find the native POSIX variants in `/usr/bin` or `/bin`.
 
-When you're done, make sure there are no processes still using `wash-root-dir`, and you can just `Ctrl-C` the server.
+When you're done, `exit` the shell.
 
 ## Current features
 


### PR DESCRIPTION
Switch instructions to enter and exit `wash` rather than separately
start the server.

Update the Docker container to provide the same experience, and tweak
activity journals for the container process isolation model.

Signed-off-by: Michael Smith <michael.smith@puppet.com>