### PR TITLE
Change plugin.ExecResult => plugin.RunningCommand

### DIFF
--- a/api/exec.go
+++ b/api/exec.go
@@ -81,14 +81,6 @@ var execHandler handler = func(w http.ResponseWriter, r *http.Request) *errorRes
 		return erroredActionResponse(path, plugin.ExecAction(), err.Error())
 	}
 
-	// Setup context cancellation handling
-	if cmd.StopFunc != nil {
-		go func() {
-			<-ctx.Done()
-			cmd.StopFunc()
-		}()
-	}
-
 	w.WriteHeader(http.StatusOK)
 	fw.Flush()
 

--- a/plugin/aws/ec2Instance.go
+++ b/plugin/aws/ec2Instance.go
@@ -182,7 +182,7 @@ func (inst *ec2Instance) checkLatestConsoleOutput(ctx context.Context) (*ec2Inst
 	return nil, fmt.Errorf("could not access the latest console log: %v", err)
 }
 
-func (inst *ec2Instance) Exec(ctx context.Context, cmd string, args []string, opts plugin.ExecOptions) (*plugin.ExecCommand, error) {
+func (inst *ec2Instance) Exec(ctx context.Context, cmd string, args []string, opts plugin.ExecOptions) (*plugin.RunningCommand, error) {
 	meta, err := inst.Metadata(ctx)
 	if err != nil {
 		return nil, err

--- a/plugin/aws/ec2Instance.go
+++ b/plugin/aws/ec2Instance.go
@@ -182,10 +182,10 @@ func (inst *ec2Instance) checkLatestConsoleOutput(ctx context.Context) (*ec2Inst
 	return nil, fmt.Errorf("could not access the latest console log: %v", err)
 }
 
-func (inst *ec2Instance) Exec(ctx context.Context, cmd string, args []string, opts plugin.ExecOptions) (plugin.ExecResult, error) {
+func (inst *ec2Instance) Exec(ctx context.Context, cmd string, args []string, opts plugin.ExecOptions) (plugin.ExecCommand, error) {
 	meta, err := inst.Metadata(ctx)
 	if err != nil {
-		return plugin.ExecResult{}, err
+		return plugin.ExecCommand{}, err
 	}
 
 	// TODO: scrape default user and authorized keys from console output. Probably only works for Amazon AMIs.
@@ -197,7 +197,7 @@ func (inst *ec2Instance) Exec(ctx context.Context, cmd string, args []string, op
 	} else if ipaddr, ok := meta["PublicIpAddress"]; ok {
 		hostname = ipaddr.(string)
 	} else {
-		return plugin.ExecResult{}, fmt.Errorf("No public interface found for %v", inst)
+		return plugin.ExecCommand{}, fmt.Errorf("No public interface found for %v", inst)
 	}
 
 	// Use the default user for Amazon AMIs. See above for ideas on making this more general. Can be

--- a/plugin/aws/ec2Instance.go
+++ b/plugin/aws/ec2Instance.go
@@ -182,10 +182,10 @@ func (inst *ec2Instance) checkLatestConsoleOutput(ctx context.Context) (*ec2Inst
 	return nil, fmt.Errorf("could not access the latest console log: %v", err)
 }
 
-func (inst *ec2Instance) Exec(ctx context.Context, cmd string, args []string, opts plugin.ExecOptions) (plugin.ExecCommand, error) {
+func (inst *ec2Instance) Exec(ctx context.Context, cmd string, args []string, opts plugin.ExecOptions) (*plugin.ExecCommand, error) {
 	meta, err := inst.Metadata(ctx)
 	if err != nil {
-		return plugin.ExecCommand{}, err
+		return nil, err
 	}
 
 	// TODO: scrape default user and authorized keys from console output. Probably only works for Amazon AMIs.
@@ -197,7 +197,7 @@ func (inst *ec2Instance) Exec(ctx context.Context, cmd string, args []string, op
 	} else if ipaddr, ok := meta["PublicIpAddress"]; ok {
 		hostname = ipaddr.(string)
 	} else {
-		return plugin.ExecCommand{}, fmt.Errorf("No public interface found for %v", inst)
+		return nil, fmt.Errorf("No public interface found for %v", inst)
 	}
 
 	// Use the default user for Amazon AMIs. See above for ideas on making this more general. Can be

--- a/plugin/docker/container.go
+++ b/plugin/docker/container.go
@@ -56,9 +56,7 @@ func (c *container) List(ctx context.Context) ([]plugin.Entry, error) {
 	return []plugin.Entry{cm, clf, vol.NewFS("fs", c)}, nil
 }
 
-func (c *container) Exec(ctx context.Context, cmd string, args []string, opts plugin.ExecOptions) (plugin.ExecCommand, error) {
-	execCommand := plugin.ExecCommand{}
-
+func (c *container) Exec(ctx context.Context, cmd string, args []string, opts plugin.ExecOptions) (*plugin.ExecCommand, error) {
 	command := append([]string{cmd}, args...)
 	activity.Record(ctx, "Exec %v on %v", command, c.Name())
 
@@ -68,21 +66,21 @@ func (c *container) Exec(ctx context.Context, cmd string, args []string, opts pl
 	}
 	created, err := c.client.ContainerExecCreate(ctx, c.id, cfg)
 	if err != nil {
-		return execCommand, err
+		return nil, err
 	}
 
 	resp, err := c.client.ContainerExecAttach(ctx, created.ID, types.ExecStartCheck{})
 	if err != nil {
-		return execCommand, err
+		return nil, err
 	}
 
-	// Asynchronously copy container exec output to an exec output channel.
-	outputCh, stdout, stderr := plugin.CreateExecOutputStreams(ctx)
+	execCommand := plugin.NewExecCommand(ctx)
+
+	// Asynchronously copy container exec output
 	go func() {
-		_, err := stdcopy.StdCopy(stdout, stderr, resp.Reader)
+		_, err := stdcopy.StdCopy(execCommand.Stdout(), execCommand.Stderr(), resp.Reader)
 		activity.Record(ctx, "Exec on %v complete: %v", c.Name(), err)
-		stdout.CloseWithError(err)
-		stderr.CloseWithError(err)
+		execCommand.CloseStreamsWithError(err)
 		resp.Close()
 	}()
 
@@ -101,7 +99,7 @@ func (c *container) Exec(ctx context.Context, cmd string, args []string, opts pl
 		}()
 	}
 
-	execCommand.OutputCh = outputCh
+
 	execCommand.StopFunc = func() {
 		// Close the response on cancellation. Copying will block until there's more to read from the
 		// exec output. For an action with no more output it may never return.

--- a/plugin/docker/container.go
+++ b/plugin/docker/container.go
@@ -100,7 +100,7 @@ func (c *container) Exec(ctx context.Context, cmd string, args []string, opts pl
 	}
 
 
-	execCommand.StopFunc = func() {
+	execCommand.SetStopFunc(func() {
 		// Close the response on cancellation. Copying will block until there's more to read from the
 		// exec output. For an action with no more output it may never return.
 		if opts.Tty {
@@ -109,7 +109,7 @@ func (c *container) Exec(ctx context.Context, cmd string, args []string, opts pl
 			activity.Record(ctx, "Sent ETX on context termination: %v", err)
 		}
 		resp.Close()
-	}
+	})
 	execCommand.SetExitCodeCB(func() (int, error) {
 		if writeErr != nil {
 			return 0, err

--- a/plugin/docker/container.go
+++ b/plugin/docker/container.go
@@ -110,7 +110,7 @@ func (c *container) Exec(ctx context.Context, cmd string, args []string, opts pl
 		}
 		resp.Close()
 	}
-	execCommand.ExitCodeCB = func() (int, error) {
+	execCommand.SetExitCodeCB(func() (int, error) {
 		if writeErr != nil {
 			return 0, err
 		}
@@ -126,7 +126,7 @@ func (c *container) Exec(ctx context.Context, cmd string, args []string, opts pl
 
 		activity.Record(ctx, "Exec on %v exited %v", c.Name(), resp.ExitCode)
 		return resp.ExitCode, nil
-	}
+	})
 
 	return execCommand, nil
 }

--- a/plugin/docker/container.go
+++ b/plugin/docker/container.go
@@ -74,18 +74,6 @@ func (c *container) Exec(ctx context.Context, cmd string, args []string, opts pl
 		return nil, err
 	}
 
-	cmdObj := plugin.NewRunningCommand(ctx)
-	cmdObj.SetStopFunc(func() {
-		// Close the response on cancellation. Copying will block until there's more to read from the
-		// exec output. For an action with no more output it may never return.
-		if opts.Tty {
-			// If resp.Conn is still open, send Ctrl-C over resp.Conn before closing it.
-			_, err := resp.Conn.Write([]byte{0x03})
-			activity.Record(ctx, "Sent ETX on context termination: %v", err)
-		}
-		resp.Close()
-	})
-
 	// If stdin is supplied, asynchronously copy it to container exec input.
 	if opts.Stdin != nil {
 		go func() {
@@ -100,7 +88,19 @@ func (c *container) Exec(ctx context.Context, cmd string, args []string, opts pl
 		}()
 	}
 
-	// Asynchronously copy container exec output, then send over the exit code
+	cmdObj := plugin.NewRunningCommand(ctx)
+	cmdObj.SetStopFunc(func() {
+		// Close the response on cancellation. Copying will block until there's more to read from the
+		// exec output. For an action with no more output it may never return.
+		if opts.Tty {
+			// If resp.Conn is still open, send Ctrl-C over resp.Conn before closing it.
+			_, err := resp.Conn.Write([]byte{0x03})
+			activity.Record(ctx, "Sent ETX on context termination: %v", err)
+		}
+		resp.Close()
+	})
+	// Asynchronously copy container exec output, then fetch the exit code once
+	// the copy's finished.
 	go func() {
 		_, err := stdcopy.StdCopy(cmdObj.Stdout(), cmdObj.Stderr(), resp.Reader)
 		activity.Record(ctx, "Exec on %v complete: %v", c.Name(), err)
@@ -120,6 +120,5 @@ func (c *container) Exec(ctx context.Context, cmd string, args []string, opts pl
 		activity.Record(ctx, "Exec on %v exited %v", c.Name(), resp.ExitCode)
 		cmdObj.SetExitCode(resp.ExitCode)
 	}()
-
 	return cmdObj, nil
 }

--- a/plugin/docker/container.go
+++ b/plugin/docker/container.go
@@ -104,7 +104,7 @@ func (c *container) Exec(ctx context.Context, cmd string, args []string, opts pl
 	go func() {
 		_, err := stdcopy.StdCopy(cmdObj.Stdout(), cmdObj.Stderr(), resp.Reader)
 		activity.Record(ctx, "Exec on %v complete: %v", c.Name(), err)
-		cmdObj.CloseStreams(err)
+		cmdObj.CloseStreamsWithError(err)
 		resp.Close()
 
 		// Command's finished. Now send the exit code.

--- a/plugin/execCommand.go
+++ b/plugin/execCommand.go
@@ -1,0 +1,46 @@
+package plugin
+
+import (
+	"context"
+)
+
+// This file contains the implementation of the ExecCommand type
+
+// NewExecCommand creates a new ExecCommand object that runs for
+// the duration of the specified context.
+//
+// TODO: Clarify the comments here a bit.
+func NewExecCommand(ctx context.Context) *ExecCommand {
+	cmd := &ExecCommand{}
+	cmd.OutputCh = make(chan ExecOutputChunk)
+	closer := &multiCloser{ch: cmd.OutputCh, countdown: 2}
+	cmd.stdout = &OutputStream{ctx: ctx, id: Stdout, ch: cmd.OutputCh, closer: closer}
+	cmd.stderr = &OutputStream{ctx: ctx, id: Stderr, ch: cmd.OutputCh, closer: closer}
+	// TODO: Stop the command here upon context cancellation
+	return cmd
+}
+
+// Stdout returns the command's stdout stream
+func (cmd *ExecCommand) Stdout() *OutputStream {
+	return cmd.stdout
+}
+
+// Stderr returns the command's stderr stream
+func (cmd *ExecCommand) Stderr() *OutputStream {
+	return cmd.stderr
+}
+
+// CloseStreams closes the command's stdout and stderr
+// streams. It is used to signal that execution is
+// complete.
+func (cmd *ExecCommand) CloseStreams() {
+	cmd.CloseStreamsWithError(nil)
+}
+
+// CloseStreamsWithError closes the command's stdout and stderr
+// streams with the specified error. It is used to signal that
+// execution is complete.
+func (cmd *ExecCommand) CloseStreamsWithError(err error) {
+	cmd.stdout.CloseWithError(err)
+	cmd.stderr.CloseWithError(err)
+}

--- a/plugin/execCommand.go
+++ b/plugin/execCommand.go
@@ -53,10 +53,20 @@ func (cmd *ExecCommand) Wait(processChunk func(ExecOutputChunk)) {
 // SetExitCodeCB sets the exit code callback. This is used to fetch the
 // command's exit code after execution completes. You should use this if
 // your plugin API requires a separate request to fetch the command's exit
-// code. See the implementation of Container#Exec in the Docker plugin for
-// an example.
+// code. Otherwise, use cmd.SetExitCode to set the exit code.
+//
+// See the implementation of Container#Exec in the Docker plugin for an
+// example of how this is used.
 func (cmd *ExecCommand) SetExitCodeCB(exitCodeCB func() (int, error)) {
 	cmd.exitCodeCB = exitCodeCB
+}
+
+// SetExitCode sets the command's exit code. Use this after the command's
+// finished its execution.
+func (cmd *ExecCommand) SetExitCode(exitCode int) {
+	cmd.exitCodeCB = func() (int, error) {
+		return exitCode, nil
+	}
 }
 
 // ExitCode returns the command's exit code. This should be called after

--- a/plugin/execCommand.go
+++ b/plugin/execCommand.go
@@ -6,10 +6,10 @@ import (
 
 // This file contains the implementation of the ExecCommand type
 
-// NewExecCommand creates a new ExecCommand object that runs for
-// the duration of the specified context.
-//
-// TODO: Clarify the comments here a bit.
+// NewExecCommand creates a new ExecCommand object that's tied to
+// the passed-in execution context. You should call this function
+// once you've verified that your plugin API has successfully
+// started executing the command.
 func NewExecCommand(ctx context.Context) *ExecCommand {
 	cmd := &ExecCommand{}
 	cmd.ctx = ctx
@@ -21,9 +21,9 @@ func NewExecCommand(ctx context.Context) *ExecCommand {
 	return cmd
 }
 
-// SetStopFunc sets the function that stops the running command. stopFunc is called
-// when the execution context completes to perform necessary termination. Hence,
-// it should noop for a finished command.
+// SetStopFunc sets the function that stops the running command. stopFunc
+// is called when the execution context completes to perform necessary
+// termination. Hence, it should noop for a finished command.
 func (cmd *ExecCommand) SetStopFunc(stopFunc func()) {
 	if stopFunc != nil {
 		go func() {
@@ -33,12 +33,14 @@ func (cmd *ExecCommand) SetStopFunc(stopFunc func()) {
 	}
 }
 
-// Stdout returns the command's stdout stream
+// Stdout returns the command's stdout stream. Attach this to your
+// plugin API's stdout stream.
 func (cmd *ExecCommand) Stdout() *OutputStream {
 	return cmd.stdout
 }
 
-// Stderr returns the command's stderr stream
+// Stderr returns the command's stderr stream. Attach this to your
+// plugin API's stderr stream.
 func (cmd *ExecCommand) Stderr() *OutputStream {
 	return cmd.stderr
 }

--- a/plugin/externalPluginEntry.go
+++ b/plugin/externalPluginEntry.go
@@ -332,7 +332,7 @@ func (e *externalPluginEntry) Exec(ctx context.Context, cmd string, args []strin
 	go func() {
 		ec, err := ExitCodeFromErr(cmdObj.Wait())
 		if err != nil {
-			runningCmd.CloseStreams(err)
+			runningCmd.CloseStreamsWithError(err)
 			return
 		}
 		runningCmd.SetExitCode(ec)

--- a/plugin/externalPluginEntry.go
+++ b/plugin/externalPluginEntry.go
@@ -330,26 +330,14 @@ func (e *externalPluginEntry) Exec(ctx context.Context, cmd string, args []strin
 	}
 
 	// Wait for the command to finish
-	var exitCode int
-	var cmdWaitErr error
 	go func() {
 		ec, err := ExitCodeFromErr(cmdObj.Wait())
 		if err != nil {
-			cmdWaitErr = err
-		} else {
-			exitCode = ec
+			execCmd.CloseStreamsWithError(err)
+			return
 		}
-
-		execCmd.CloseStreamsWithError(err)
+		execCmd.SetExitCode(ec)
 	}()
-
-	execCmd.SetExitCodeCB(func() (int, error) {
-		if cmdWaitErr != nil {
-			return 0, cmdWaitErr
-		}
-
-		return exitCode, nil
-	})
-
+	
 	return execCmd, nil
 }

--- a/plugin/externalPluginEntry.go
+++ b/plugin/externalPluginEntry.go
@@ -325,7 +325,6 @@ func (e *externalPluginEntry) Exec(ctx context.Context, cmd string, args []strin
 	// Start the command
 	activity.Record(ctx, "Starting command: %v %v", cmdObj.Path, strings.Join(cmdObj.Args, " "))
 	if err := cmdObj.Start(); err != nil {
-		runningCmd.CloseStreams()
 		return nil, err
 	}
 
@@ -333,7 +332,7 @@ func (e *externalPluginEntry) Exec(ctx context.Context, cmd string, args []strin
 	go func() {
 		ec, err := ExitCodeFromErr(cmdObj.Wait())
 		if err != nil {
-			runningCmd.CloseStreamsWithError(err)
+			runningCmd.CloseStreams(err)
 			return
 		}
 		runningCmd.SetExitCode(ec)

--- a/plugin/externalPluginEntry.go
+++ b/plugin/externalPluginEntry.go
@@ -343,13 +343,13 @@ func (e *externalPluginEntry) Exec(ctx context.Context, cmd string, args []strin
 		execCmd.CloseStreamsWithError(err)
 	}()
 
-	execCmd.ExitCodeCB = func() (int, error) {
+	execCmd.SetExitCodeCB(func() (int, error) {
 		if cmdWaitErr != nil {
 			return 0, cmdWaitErr
 		}
 
 		return exitCode, nil
-	}
+	})
 
 	return execCmd, nil
 }

--- a/plugin/externalPluginEntry.go
+++ b/plugin/externalPluginEntry.go
@@ -299,8 +299,8 @@ func (e *externalPluginEntry) Stream(ctx context.Context) (io.ReadCloser, error)
 }
 
 // Exec executes a command on the given entry
-func (e *externalPluginEntry) Exec(ctx context.Context, cmd string, args []string, opts ExecOptions) (ExecResult, error) {
-	execResult := ExecResult{}
+func (e *externalPluginEntry) Exec(ctx context.Context, cmd string, args []string, opts ExecOptions) (ExecCommand, error) {
+	execCmd := ExecCommand{}
 
 	// TODO: Figure out how to pass-in opts when we have entries
 	// besides Stdin. Could do something like
@@ -328,7 +328,7 @@ func (e *externalPluginEntry) Exec(ctx context.Context, cmd string, args []strin
 	if err := cmdObj.Start(); err != nil {
 		stdout.Close()
 		stderr.Close()
-		return execResult, err
+		return execCmd, err
 	}
 
 	// Wait for the command to finish
@@ -346,8 +346,8 @@ func (e *externalPluginEntry) Exec(ctx context.Context, cmd string, args []strin
 		stderr.CloseWithError(err)
 	}()
 
-	execResult.OutputCh = outputCh
-	execResult.ExitCodeCB = func() (int, error) {
+	execCmd.OutputCh = outputCh
+	execCmd.ExitCodeCB = func() (int, error) {
 		if cmdWaitErr != nil {
 			return 0, cmdWaitErr
 		}
@@ -355,5 +355,5 @@ func (e *externalPluginEntry) Exec(ctx context.Context, cmd string, args []strin
 		return exitCode, nil
 	}
 
-	return execResult, nil
+	return execCmd, nil
 }

--- a/plugin/externalPluginEntry.go
+++ b/plugin/externalPluginEntry.go
@@ -299,9 +299,7 @@ func (e *externalPluginEntry) Stream(ctx context.Context) (io.ReadCloser, error)
 }
 
 // Exec executes a command on the given entry
-func (e *externalPluginEntry) Exec(ctx context.Context, cmd string, args []string, opts ExecOptions) (ExecCommand, error) {
-	execCmd := ExecCommand{}
-
+func (e *externalPluginEntry) Exec(ctx context.Context, cmd string, args []string, opts ExecOptions) (*ExecCommand, error) {
 	// TODO: Figure out how to pass-in opts when we have entries
 	// besides Stdin. Could do something like
 	//   <plugin_script> exec <path> <state> <opts> <cmd> <args...>
@@ -318,17 +316,17 @@ func (e *externalPluginEntry) Exec(ctx context.Context, cmd string, args []strin
 		cmdObj.Stdin = opts.Stdin
 	}
 
+	execCmd := NewExecCommand(ctx)
+
 	// Set-up the output streams
-	outputCh, stdout, stderr := CreateExecOutputStreams(ctx)
-	cmdObj.Stdout = stdout
-	cmdObj.Stderr = stderr
+	cmdObj.Stdout = execCmd.Stdout()
+	cmdObj.Stderr = execCmd.Stderr()
 
 	// Start the command
 	activity.Record(ctx, "Starting command: %v %v", cmdObj.Path, strings.Join(cmdObj.Args, " "))
 	if err := cmdObj.Start(); err != nil {
-		stdout.Close()
-		stderr.Close()
-		return execCmd, err
+		execCmd.CloseStreams()
+		return nil, err
 	}
 
 	// Wait for the command to finish
@@ -342,11 +340,9 @@ func (e *externalPluginEntry) Exec(ctx context.Context, cmd string, args []strin
 			exitCode = ec
 		}
 
-		stdout.CloseWithError(err)
-		stderr.CloseWithError(err)
+		execCmd.CloseStreamsWithError(err)
 	}()
 
-	execCmd.OutputCh = outputCh
 	execCmd.ExitCodeCB = func() (int, error) {
 		if cmdWaitErr != nil {
 			return 0, cmdWaitErr

--- a/plugin/kubernetes/pod.go
+++ b/plugin/kubernetes/pod.go
@@ -179,7 +179,7 @@ func (p *pod) Exec(ctx context.Context, cmd string, args []string, opts plugin.E
 			err = nil
 		}
 
-		cmdObj.CloseStreams(err)
+		cmdObj.CloseStreamsWithError(err)
 	}()
 
 	return cmdObj, nil

--- a/plugin/kubernetes/pod.go
+++ b/plugin/kubernetes/pod.go
@@ -155,14 +155,14 @@ func (p *pod) Exec(ctx context.Context, cmd string, args []string, opts plugin.E
 			stdin = r
 		}
 
-		execCommand.StopFunc = func() {
+		execCommand.SetStopFunc(func() {
 			// Close the response on context cancellation. Copying will block until there's more to
 			// read from the exec output. For an action with no more output it may never return.
 			// Append Ctrl-C to input to signal end of execution.
 			_, err := w.Write([]byte{0x03})
 			activity.Record(ctx, "Sent ETX on context termination: %v", err)
 			w.Close()
-		}
+		})
 	}
 
 	go func() {

--- a/plugin/kubernetes/pod.go
+++ b/plugin/kubernetes/pod.go
@@ -183,9 +183,9 @@ func (p *pod) Exec(ctx context.Context, cmd string, args []string, opts plugin.E
 		execCommand.CloseStreamsWithError(err)
 	}()
 
-	execCommand.ExitCodeCB = func() (int, error) {
+	execCommand.SetExitCodeCB(func() (int, error) {
 		return exitcode, nil
-	}
+	})
 
 	return execCommand, nil
 }

--- a/plugin/kubernetes/pod.go
+++ b/plugin/kubernetes/pod.go
@@ -179,7 +179,7 @@ func (p *pod) Exec(ctx context.Context, cmd string, args []string, opts plugin.E
 			err = nil
 		}
 
-		cmdObj.CloseStreamsWithError(err)
+		cmdObj.CloseStreams(err)
 	}()
 
 	return cmdObj, nil

--- a/plugin/outputStream.go
+++ b/plugin/outputStream.go
@@ -73,19 +73,3 @@ func (c *multiCloser) Close() {
 	}
 	c.mux.Unlock()
 }
-
-// CreateExecOutputStreams creates a pair of writers representing stdout
-// and stderr. They are used to transfer chunks of the Exec'ed cmd's
-// output in the order they're received by the corresponding API. The
-// writers maintain the ordering by writing to a channel.
-//
-// This method returns outputCh, stdout, and stderr, respectively.
-func CreateExecOutputStreams(ctx context.Context) (<-chan ExecOutputChunk, *OutputStream, *OutputStream) {
-	outputCh := make(chan ExecOutputChunk)
-	closer := &multiCloser{ch: outputCh, countdown: 2}
-
-	stdout := &OutputStream{ctx: ctx, id: Stdout, ch: outputCh, closer: closer}
-	stderr := &OutputStream{ctx: ctx, id: Stderr, ch: outputCh, closer: closer}
-
-	return outputCh, stdout, stderr
-}

--- a/plugin/outputStream.go
+++ b/plugin/outputStream.go
@@ -41,13 +41,8 @@ func (s *OutputStream) Write(data []byte) (int, error) {
 	return len(data), err
 }
 
-// close ensures the channel is closed when the last OutputStream is closed.
-func (s *OutputStream) close() {
-	s.closer.Close()
-}
-
-// closeWithError sends the given error before calling close()
-func (s *OutputStream) closeWithError(err error) {
+// CloseWithError sends the given error before closing the OutputStream.
+func (s *OutputStream) CloseWithError(err error) {
 	if err != nil {
 		// Avoid re-sending ctx.Err() if it was already sent
 		// by OutputStream#Write
@@ -56,7 +51,7 @@ func (s *OutputStream) closeWithError(err error) {
 		}
 	}
 
-	s.close()
+	s.closer.Close()
 }
 
 type multiCloser struct {

--- a/plugin/outputStream.go
+++ b/plugin/outputStream.go
@@ -41,13 +41,13 @@ func (s *OutputStream) Write(data []byte) (int, error) {
 	return len(data), err
 }
 
-// Close ensures the channel is closed when the last OutputStream is closed.
-func (s *OutputStream) Close() {
+// close ensures the channel is closed when the last OutputStream is closed.
+func (s *OutputStream) close() {
 	s.closer.Close()
 }
 
-// CloseWithError sends the given error before calling Close()
-func (s *OutputStream) CloseWithError(err error) {
+// closeWithError sends the given error before calling close()
+func (s *OutputStream) closeWithError(err error) {
 	if err != nil {
 		// Avoid re-sending ctx.Err() if it was already sent
 		// by OutputStream#Write
@@ -56,7 +56,7 @@ func (s *OutputStream) CloseWithError(err error) {
 		}
 	}
 
-	s.Close()
+	s.close()
 }
 
 type multiCloser struct {

--- a/plugin/outputStream_test.go
+++ b/plugin/outputStream_test.go
@@ -173,7 +173,7 @@ func (suite *OutputStreamTestSuite) TestCloseWithError() {
 }
 
 /*
-TODO: Move this test over to execCommand.go
+TODO: Move this test over to runningCommand.go
 func (suite *OutputStreamTestSuite) TestCreateExecOutputStreams() {
 	outputCh, stdout, stderr := CreateExecOutputStreams(context.Background())
 

--- a/plugin/outputStream_test.go
+++ b/plugin/outputStream_test.go
@@ -3,7 +3,6 @@ package plugin
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"testing"
 	"time"
 
@@ -173,6 +172,8 @@ func (suite *OutputStreamTestSuite) TestCloseWithError() {
 
 }
 
+/*
+TODO: Move this test over to execCommand.go
 func (suite *OutputStreamTestSuite) TestCreateExecOutputStreams() {
 	outputCh, stdout, stderr := CreateExecOutputStreams(context.Background())
 
@@ -222,8 +223,8 @@ func (suite *OutputStreamTestSuite) TestCreateExecOutputStreams() {
 
 	// outputCh should be closed, so assert that it is
 	suite.assertClosedChannel(outputCh)
-
 }
+*/
 
 func TestOutputStream(t *testing.T) {
 	suite.Run(t, new(OutputStreamTestSuite))

--- a/plugin/outputStream_test.go
+++ b/plugin/outputStream_test.go
@@ -109,14 +109,6 @@ func (suite *OutputStreamTestSuite) assertClosedChannel(ch <-chan ExecOutputChun
 	}
 }
 
-func (suite *OutputStreamTestSuite) TestClose() {
-	ch := make(chan ExecOutputChunk)
-	stream := OutputStream{ch: ch, closer: &multiCloser{ch: ch, countdown: 1}}
-
-	stream.close()
-	suite.assertClosedChannel(stream.ch)
-}
-
 func (suite *OutputStreamTestSuite) TestCloseWithError() {
 	newOutputStream := func(ctx context.Context) OutputStream {
 		ch := make(chan ExecOutputChunk, 1)
@@ -125,7 +117,7 @@ func (suite *OutputStreamTestSuite) TestCloseWithError() {
 
 	// Test that if err == nil, then nothing was sent to the channel
 	stream := newOutputStream(context.Background())
-	stream.closeWithError(nil)
+	stream.CloseWithError(nil)
 	suite.assertClosedChannel(stream.ch)
 
 	// Useful assertion for the subsequent tests
@@ -150,7 +142,7 @@ func (suite *OutputStreamTestSuite) TestCloseWithError() {
 	// Test that if err != nil, then the error is sent to the channel
 	stream = newOutputStream(context.Background())
 	sentErr := fmt.Errorf("an arbitrary error")
-	stream.closeWithError(sentErr)
+	stream.CloseWithError(sentErr)
 	assertSentError(stream, sentErr)
 	suite.assertClosedChannel(stream.ch)
 
@@ -159,7 +151,7 @@ func (suite *OutputStreamTestSuite) TestCloseWithError() {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	stream = newOutputStream(ctx)
 	cancelFunc()
-	stream.closeWithError(ctx.Err())
+	stream.CloseWithError(ctx.Err())
 	assertSentError(stream, ctx.Err())
 	suite.assertClosedChannel(stream.ch)
 
@@ -167,7 +159,7 @@ func (suite *OutputStreamTestSuite) TestCloseWithError() {
 	// a previous Write sent it
 	stream = newOutputStream(ctx)
 	stream.sentCtxErr = true
-	stream.closeWithError(ctx.Err())
+	stream.CloseWithError(ctx.Err())
 	suite.assertClosedChannel(stream.ch)
 
 }

--- a/plugin/outputStream_test.go
+++ b/plugin/outputStream_test.go
@@ -113,7 +113,7 @@ func (suite *OutputStreamTestSuite) TestClose() {
 	ch := make(chan ExecOutputChunk)
 	stream := OutputStream{ch: ch, closer: &multiCloser{ch: ch, countdown: 1}}
 
-	stream.Close()
+	stream.close()
 	suite.assertClosedChannel(stream.ch)
 }
 
@@ -125,7 +125,7 @@ func (suite *OutputStreamTestSuite) TestCloseWithError() {
 
 	// Test that if err == nil, then nothing was sent to the channel
 	stream := newOutputStream(context.Background())
-	stream.CloseWithError(nil)
+	stream.closeWithError(nil)
 	suite.assertClosedChannel(stream.ch)
 
 	// Useful assertion for the subsequent tests
@@ -150,7 +150,7 @@ func (suite *OutputStreamTestSuite) TestCloseWithError() {
 	// Test that if err != nil, then the error is sent to the channel
 	stream = newOutputStream(context.Background())
 	sentErr := fmt.Errorf("an arbitrary error")
-	stream.CloseWithError(sentErr)
+	stream.closeWithError(sentErr)
 	assertSentError(stream, sentErr)
 	suite.assertClosedChannel(stream.ch)
 
@@ -159,7 +159,7 @@ func (suite *OutputStreamTestSuite) TestCloseWithError() {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	stream = newOutputStream(ctx)
 	cancelFunc()
-	stream.CloseWithError(ctx.Err())
+	stream.closeWithError(ctx.Err())
 	assertSentError(stream, ctx.Err())
 	suite.assertClosedChannel(stream.ch)
 
@@ -167,7 +167,7 @@ func (suite *OutputStreamTestSuite) TestCloseWithError() {
 	// a previous Write sent it
 	stream = newOutputStream(ctx)
 	stream.sentCtxErr = true
-	stream.CloseWithError(ctx.Err())
+	stream.closeWithError(ctx.Err())
 	suite.assertClosedChannel(stream.ch)
 
 }
@@ -184,8 +184,8 @@ func (suite *OutputStreamTestSuite) TestCreateExecOutputStreams() {
 		// which means that outputCh should be closed before
 		// expectedChunksCh.
 		defer close(expectedChunksCh)
-		defer stdout.Close()
-		defer stderr.Close()
+		defer stdout.close()
+		defer stderr.close()
 
 		writeTo := func(streamName string, stream *OutputStream, data string) {
 			expectedChunksCh <- ExecOutputChunk{StreamID: stream.id, Data: data}

--- a/plugin/runningCommand.go
+++ b/plugin/runningCommand.go
@@ -2,31 +2,52 @@ package plugin
 
 import (
 	"context"
+	"fmt"
+
+	"sync"
 )
 
 
 // RunningCommand represents a running command that was invoked by Execable#exec.
 // Use plugin.NewRunningCommand to create these objects.
 type RunningCommand struct {
-	ctx        context.Context
-	exitCodeCB func() (int, error)
-	outputCh   chan ExecOutputChunk
-	stdout     *OutputStream
-	stderr     *OutputStream
+	ctx           context.Context
+	outputCh      chan ExecOutputChunk
+	stdout        *OutputStream
+	stderr        *OutputStream
+	mux           sync.Mutex
+	streamsClosed bool
+	exitCodeCh    chan int
+	exitCodeErrCh chan error
 }
 
 // NewRunningCommand creates a new RunningCommand object that's tied to
-// the passed-in execution context. You should call this function
-// once you've verified that your plugin API has successfully
-// started executing the command.
+// the passed-in execution context. When the execution context is cancelled,
+// the returned command's stdout/stderr streams will automatically be closed.
+// This means that you do not have to worry about handling dangling output
+// streams if your plugin API fails to properly start the command.
 func NewRunningCommand(ctx context.Context) *RunningCommand {
-	cmd := &RunningCommand{}
-	cmd.ctx = ctx
+	cmd := &RunningCommand{
+		ctx: ctx,
+		exitCodeCh: make(chan int, 1),
+		exitCodeErrCh: make(chan error, 1),
+	}
+
 	// Create the output streams
 	cmd.outputCh = make(chan ExecOutputChunk)
 	closer := &multiCloser{ch: cmd.outputCh, countdown: 2}
 	cmd.stdout = &OutputStream{ctx: cmd.ctx, id: Stdout, ch: cmd.outputCh, closer: closer}
 	cmd.stderr = &OutputStream{ctx: cmd.ctx, id: Stderr, ch: cmd.outputCh, closer: closer}
+
+	// Ensure that the command's properly cleaned up when the context is
+	// cancelled.
+	go func() {
+		<-cmd.ctx.Done()
+		cmd.CloseStreams(ctx.Err())
+		close(cmd.exitCodeCh)
+		close(cmd.exitCodeErrCh)
+	}()
+
 	return cmd
 }
 
@@ -35,6 +56,13 @@ func NewRunningCommand(ctx context.Context) *RunningCommand {
 // termination. Hence, it should noop for a finished command.
 func (cmd *RunningCommand) SetStopFunc(stopFunc func()) {
 	if stopFunc != nil {
+		// Thankfully, goroutines are cheap. Otherwise, mixing this in with
+		// the goroutine in NewRunningCommand heavily complicates things.
+		// For example, we'd have to worry about the possibility that the
+		// NewRunningCommand goroutine is invoked before the Execable#Exec
+		// implementation can set a stopFunc, which can happen if the context
+		// is prematurely cancelled. That can result in an orphaned process
+		// in some plugin APIs, which is bad.
 		go func() {
 			<-cmd.ctx.Done()
 			stopFunc()
@@ -54,51 +82,75 @@ func (cmd *RunningCommand) Stderr() *OutputStream {
 	return cmd.stderr
 }
 
-// CloseStreams closes the command's stdout and stderr
-// streams.
-func (cmd *RunningCommand) CloseStreams() {
-	cmd.CloseStreamsWithError(nil)
-}
-
-// CloseStreamsWithError closes the command's stdout and stderr
-// streams with the specified error.
-func (cmd *RunningCommand) CloseStreamsWithError(err error) {
-	cmd.Stdout().CloseWithError(err)
-	cmd.Stderr().CloseWithError(err)
+// CloseStreams closes the command's stdout and stderr streams with
+// the specified error. This should be called with err == nil when the
+// command's finished its execution, or when an IO error occurs.
+//
+// NOTE: CloseStreams is automatically called whenever the execution
+// context is cancelled, so you do not have to worry about handling
+// dangling output streams.
+func (cmd *RunningCommand) CloseStreams(err error) {
+	// The lock is necessary because this can be invoked by multiple threads
+	// (Execable#Exec + the goroutine in NewRunningComamnd)
+	cmd.mux.Lock()
+	defer cmd.mux.Unlock()
+	if cmd.streamsClosed {
+		return
+	}
+	cmd.Stdout().closeWithError(err)
+	cmd.Stderr().closeWithError(err)
+	cmd.streamsClosed = true
 }
 
 // Wait waits for the command to finish, passing in each chunk
-// of the command's output to processChunk.
-func (cmd *RunningCommand) Wait(processChunk func(ExecOutputChunk)) {
+// of the command's output to processChunk. It returns the command's
+// exit code, or an error if it failed to fetch the command's exit
+// code.
+func (cmd *RunningCommand) Wait(processChunk func(ExecOutputChunk)) (int, error) {
 	for chunk := range cmd.outputCh {
 		processChunk(chunk)
 	}
-}
-
-// SetExitCodeCB sets the exit code callback. This is used to fetch the
-// command's exit code after execution completes. You should use this if
-// your plugin API requires a separate request to fetch the command's exit
-// code. Otherwise, use cmd.SetExitCode to set the exit code.
-//
-// See the implementation of Container#Exec in the Docker plugin for an
-// example of how this is used.
-func (cmd *RunningCommand) SetExitCodeCB(exitCodeCB func() (int, error)) {
-	cmd.exitCodeCB = exitCodeCB
-}
-
-// SetExitCode sets the command's exit code. Use this after the command's
-// finished its execution.
-func (cmd *RunningCommand) SetExitCode(exitCode int) {
-	cmd.exitCodeCB = func() (int, error) {
+	select {
+	// Note that the channels are only closed when the context is cancelled.
+	case exitCode, ok := <-cmd.exitCodeCh:
+		if !ok {
+			return 0, fmt.Errorf("failed to fetch the command's exit code: %v", cmd.ctx.Err())
+		}
 		return exitCode, nil
+	case err, ok := <-cmd.exitCodeErrCh:
+		if !ok {
+			return 0, fmt.Errorf("failed to fetch the command's exit code: %v", cmd.ctx.Err())
+		}
+		return 0, err
 	}
 }
 
-// ExitCode returns the command's exit code. This should be called after
-// the command's finished its execution.
-func (cmd *RunningCommand) ExitCode() (int, error) {
-	if cmd.exitCodeCB == nil {
-		panic("cmd.ExitCode called with a nil exit code callback")
+// SetExitCode sets the command's exit code. You should call this
+// function after closing the command's output streams.
+func (cmd *RunningCommand) SetExitCode(exitCode int) {
+	select {
+	case <-cmd.ctx.Done():
+		// Don't send anything if the context is cancelled. Otherwise,
+		// we will panic trying to send to a closed channel.
+	default:
+		cmd.exitCodeCh <- exitCode
 	}
-	return cmd.exitCodeCB()
+}
+
+// SetExitCodeErr sets the exit code error, which occurs when the
+// plugin API fails to fetch the comand's exit code. You should call
+// this function after closing the command's output streams.
+//
+// NOTE: You should only use this function if your plugin API requires
+// a separate request to fetch the command's exit code. Otherwise,
+// use SetExitCode. See the implementation of Container#Exec in the
+// Docker plugin for an example of when and how this is used.
+func (cmd *RunningCommand) SetExitCodeErr(err error) {
+	select {
+	case <-cmd.ctx.Done():
+		// Don't send anything if the context is cancelled. Otherwise,
+		// we will panic trying to send to a closed channel.
+	default:
+		cmd.exitCodeErrCh <- err
+	}
 }

--- a/plugin/runningCommand.go
+++ b/plugin/runningCommand.go
@@ -3,8 +3,6 @@ package plugin
 import (
 	"context"
 	"fmt"
-
-	"sync"
 )
 
 
@@ -15,39 +13,22 @@ type RunningCommand struct {
 	outputCh      chan ExecOutputChunk
 	stdout        *OutputStream
 	stderr        *OutputStream
-	mux           sync.Mutex
-	streamsClosed bool
 	exitCodeCh    chan int
 	exitCodeErrCh chan error
 }
 
 // NewRunningCommand creates a new RunningCommand object that's tied to
-// the passed-in execution context. When the execution context is cancelled,
-// the returned command's stdout/stderr streams will automatically be closed.
-// This means that you do not have to worry about handling dangling output
-// streams if your plugin API fails to properly start the command.
+// the passed-in execution context.
 func NewRunningCommand(ctx context.Context) *RunningCommand {
 	cmd := &RunningCommand{
 		ctx: ctx,
 		exitCodeCh: make(chan int, 1),
 		exitCodeErrCh: make(chan error, 1),
 	}
-
-	// Create the output streams
 	cmd.outputCh = make(chan ExecOutputChunk)
 	closer := &multiCloser{ch: cmd.outputCh, countdown: 2}
 	cmd.stdout = &OutputStream{ctx: cmd.ctx, id: Stdout, ch: cmd.outputCh, closer: closer}
 	cmd.stderr = &OutputStream{ctx: cmd.ctx, id: Stderr, ch: cmd.outputCh, closer: closer}
-
-	// Ensure that the command's properly cleaned up when the context is
-	// cancelled.
-	go func() {
-		<-cmd.ctx.Done()
-		cmd.CloseStreams(ctx.Err())
-		close(cmd.exitCodeCh)
-		close(cmd.exitCodeErrCh)
-	}()
-
 	return cmd
 }
 
@@ -56,13 +37,6 @@ func NewRunningCommand(ctx context.Context) *RunningCommand {
 // termination. Hence, it should noop for a finished command.
 func (cmd *RunningCommand) SetStopFunc(stopFunc func()) {
 	if stopFunc != nil {
-		// Thankfully, goroutines are cheap. Otherwise, mixing this in with
-		// the goroutine in NewRunningCommand heavily complicates things.
-		// For example, we'd have to worry about the possibility that the
-		// NewRunningCommand goroutine is invoked before the Execable#Exec
-		// implementation can set a stopFunc, which can happen if the context
-		// is prematurely cancelled. That can result in an orphaned process
-		// in some plugin APIs, which is bad.
 		go func() {
 			<-cmd.ctx.Done()
 			stopFunc()
@@ -82,36 +56,18 @@ func (cmd *RunningCommand) Stderr() *OutputStream {
 	return cmd.stderr
 }
 
-// CloseStreams closes the command's stdout and stderr streams with
-// the specified error. This should be called with err == nil when the
-// command's finished its execution, or when an IO error occurs.
-//
-// NOTE: CloseStreams is automatically called whenever the execution
-// context is cancelled, so you do not have to worry about handling
-// dangling output streams.
+// CloseStreams closes the command's stdout/stderr streams with the
+// specified error. It should only be called when the command's
+// finished its execution.
 func (cmd *RunningCommand) CloseStreams(err error) {
-	// The lock is necessary because this can be invoked by multiple threads
-	// (Execable#Exec + the goroutine in NewRunningComamnd)
-	cmd.mux.Lock()
-	defer cmd.mux.Unlock()
-	if cmd.streamsClosed {
-		return
-	}
 	cmd.Stdout().closeWithError(err)
 	cmd.Stderr().closeWithError(err)
-	cmd.streamsClosed = true
 }
 
 // SetExitCode sets the command's exit code. You should call this
 // function after closing the command's output streams.
 func (cmd *RunningCommand) SetExitCode(exitCode int) {
-	select {
-	case <-cmd.ctx.Done():
-		// Don't send anything if the context is cancelled. Otherwise,
-		// we will panic trying to send to a closed channel.
-	default:
-		cmd.exitCodeCh <- exitCode
-	}
+	cmd.exitCodeCh <- exitCode
 }
 
 // SetExitCodeErr sets the exit code error, which occurs when the
@@ -123,13 +79,7 @@ func (cmd *RunningCommand) SetExitCode(exitCode int) {
 // use SetExitCode. See the implementation of Container#Exec in the
 // Docker plugin for an example of when and how this is used.
 func (cmd *RunningCommand) SetExitCodeErr(err error) {
-	select {
-	case <-cmd.ctx.Done():
-		// Don't send anything if the context is cancelled. Otherwise,
-		// we will panic trying to send to a closed channel.
-	default:
-		cmd.exitCodeErrCh <- err
-	}
+	cmd.exitCodeErrCh <- err
 }
 
 // StreamOutput streams the running command's output
@@ -142,15 +92,11 @@ func (cmd *RunningCommand) StreamOutput() <-chan ExecOutputChunk {
 // ExitCode will return an error if it fails to fetch the command's exit code.
 func (cmd *RunningCommand) ExitCode() (int, error) {
 	select {
-		// Note that the channels are only closed when the context is cancelled.
-		case exitCode, ok := <-cmd.exitCodeCh:
-			if ok {
-				return exitCode, nil
-			}
-		case err, ok := <-cmd.exitCodeErrCh:
-			if ok {
-				return 0, err
-			}
+	case <-cmd.ctx.Done():
+		return 0, fmt.Errorf("failed to fetch the command's exit code: %v", cmd.ctx.Err())
+	case exitCode := <-cmd.exitCodeCh:
+		return exitCode, nil
+	case err := <-cmd.exitCodeErrCh:
+		return 0, err
 	}
-	return 0, fmt.Errorf("failed to fetch the command's exit code: %v", cmd.ctx.Err())
 }

--- a/plugin/runningCommand.go
+++ b/plugin/runningCommand.go
@@ -56,12 +56,11 @@ func (cmd *RunningCommand) Stderr() *OutputStream {
 	return cmd.stderr
 }
 
-// CloseStreams closes the command's stdout/stderr streams with the
-// specified error. It should only be called when the command's
-// finished its execution.
-func (cmd *RunningCommand) CloseStreams(err error) {
-	cmd.Stdout().closeWithError(err)
-	cmd.Stderr().closeWithError(err)
+// CloseStreamsWithError closes the command's stdout/stderr streams
+// with the given error.
+func (cmd *RunningCommand) CloseStreamsWithError(err error) {
+	cmd.Stdout().CloseWithError(err)
+	cmd.Stderr().CloseWithError(err)
 }
 
 // SetExitCode sets the command's exit code. You should call this

--- a/plugin/types.go
+++ b/plugin/types.go
@@ -111,8 +111,8 @@ type ExecOutputChunk struct {
 // StopFunc:    stops the command. It should noop for a finished command. StopFunc is called when
 //              the execution context completes to perform necessary termination.
 type ExecCommand struct {
-	ExitCodeCB func() (int, error)
 	StopFunc   func()
+	exitCodeCB func() (int, error)
 	outputCh   chan ExecOutputChunk
 	stdout     *OutputStream
 	stderr     *OutputStream

--- a/plugin/types.go
+++ b/plugin/types.go
@@ -105,6 +105,7 @@ type ExecOutputChunk struct {
 }
 
 // ExecCommand represents a running command that was invoked by Execable#exec.
+// You should use plugin.NewExecCommand to create these objects.
 type ExecCommand struct {
 	ctx        context.Context
 	exitCodeCB func() (int, error)

--- a/plugin/types.go
+++ b/plugin/types.go
@@ -105,13 +105,8 @@ type ExecOutputChunk struct {
 }
 
 // ExecCommand represents a running command that was invoked by Execable#exec.
-// Any of these fields can be nil.
-//
-// ExitCodeCB:  is called after execution completes to determine the final status of execution.
-// StopFunc:    stops the command. It should noop for a finished command. StopFunc is called when
-//              the execution context completes to perform necessary termination.
 type ExecCommand struct {
-	StopFunc   func()
+	ctx        context.Context
 	exitCodeCB func() (int, error)
 	outputCh   chan ExecOutputChunk
 	stdout     *OutputStream

--- a/plugin/types.go
+++ b/plugin/types.go
@@ -104,20 +104,10 @@ type ExecOutputChunk struct {
 	Err       error
 }
 
-// ExecCommand represents a running command that was invoked by Execable#exec.
-// You should use plugin.NewExecCommand to create these objects.
-type ExecCommand struct {
-	ctx        context.Context
-	exitCodeCB func() (int, error)
-	outputCh   chan ExecOutputChunk
-	stdout     *OutputStream
-	stderr     *OutputStream
-}
-
 // Execable is an entry that can have a command run on it.
 type Execable interface {
 	Entry
-	Exec(ctx context.Context, cmd string, args []string, opts ExecOptions) (*ExecCommand, error)
+	Exec(ctx context.Context, cmd string, args []string, opts ExecOptions) (*RunningCommand, error)
 }
 
 // Streamable is an entry that returns a stream of updates.

--- a/plugin/types.go
+++ b/plugin/types.go
@@ -114,15 +114,17 @@ type ExecOutputChunk struct {
 // StopFunc:    stops the command. It should noop for a finished command. StopFunc is called when
 //              the execution context completes to perform necessary termination.
 type ExecCommand struct {
-	OutputCh   <-chan ExecOutputChunk
+	OutputCh   chan ExecOutputChunk
 	ExitCodeCB func() (int, error)
 	StopFunc   func()
+	stdout     *OutputStream
+	stderr     *OutputStream
 }
 
 // Execable is an entry that can have a command run on it.
 type Execable interface {
 	Entry
-	Exec(ctx context.Context, cmd string, args []string, opts ExecOptions) (ExecCommand, error)
+	Exec(ctx context.Context, cmd string, args []string, opts ExecOptions) (*ExecCommand, error)
 }
 
 // Streamable is an entry that returns a stream of updates.

--- a/plugin/types.go
+++ b/plugin/types.go
@@ -107,16 +107,13 @@ type ExecOutputChunk struct {
 // ExecCommand represents a running command that was invoked by Execable#exec.
 // Any of these fields can be nil.
 //
-// OutputCh:    contains timestamped chunks of the command's stdout/stderr. This should be set
-//              to the channel that's returned by plugin.CreateExecOutputStreams(). OutputCh
-//              must be closed to signal that execution is complete.
 // ExitCodeCB:  is called after execution completes to determine the final status of execution.
 // StopFunc:    stops the command. It should noop for a finished command. StopFunc is called when
 //              the execution context completes to perform necessary termination.
 type ExecCommand struct {
-	OutputCh   chan ExecOutputChunk
 	ExitCodeCB func() (int, error)
 	StopFunc   func()
+	outputCh   chan ExecOutputChunk
 	stdout     *OutputStream
 	stderr     *OutputStream
 }

--- a/plugin/types.go
+++ b/plugin/types.go
@@ -104,25 +104,25 @@ type ExecOutputChunk struct {
 	Err       error
 }
 
-// ExecResult is a struct that contains the result of invoking Execable#exec.
+// ExecCommand represents a running command that was invoked by Execable#exec.
 // Any of these fields can be nil.
 //
-// OutputCh: contains timestamped chunks of the running command's stdout/stderr. This should be set
-//           to the channel that's returned by plugin.CreateExecOutputStreams(). OutputCh must be
-//           closed to signal that execution is complete.
-// ExitCodeCB: is called after execution completes to determine final status of execution.
-// CancelFunc: cancels a running command. It should noop for a finished command. CancelFunc is
-//             called when the execution context completes to perform necessary termination.
-type ExecResult struct {
+// OutputCh:    contains timestamped chunks of the command's stdout/stderr. This should be set
+//              to the channel that's returned by plugin.CreateExecOutputStreams(). OutputCh
+//              must be closed to signal that execution is complete.
+// ExitCodeCB:  is called after execution completes to determine the final status of execution.
+// StopFunc:    stops the command. It should noop for a finished command. StopFunc is called when
+//              the execution context completes to perform necessary termination.
+type ExecCommand struct {
 	OutputCh   <-chan ExecOutputChunk
 	ExitCodeCB func() (int, error)
-	CancelFunc func()
+	StopFunc   func()
 }
 
 // Execable is an entry that can have a command run on it.
 type Execable interface {
 	Entry
-	Exec(ctx context.Context, cmd string, args []string, opts ExecOptions) (ExecResult, error)
+	Exec(ctx context.Context, cmd string, args []string, opts ExecOptions) (ExecCommand, error)
 }
 
 // Streamable is an entry that returns a stream of updates.

--- a/transport/ssh.go
+++ b/transport/ssh.go
@@ -164,7 +164,7 @@ func ExecSSH(ctx context.Context, id Identity, cmd []string, opts plugin.ExecOpt
 	go func() {
 		err := session.Wait()
 		activity.Record(ctx, "Closing session for %v: %v", id.Host, session.Close())
-		cmdObj.CloseStreams(nil)
+		cmdObj.CloseStreamsWithError(nil)
 		if err == nil {
 			cmdObj.SetExitCode(0)
 		} else if exitErr, ok := err.(*ssh.ExitError); ok {

--- a/transport/ssh.go
+++ b/transport/ssh.go
@@ -161,7 +161,7 @@ func ExecSSH(ctx context.Context, id Identity, cmd []string, opts plugin.ExecOpt
 		execCmd.CloseStreams()
 	}()
 
-	execCmd.StopFunc = func() {
+	execCmd.SetStopFunc(func() {
 		// Close the session on context cancellation. Copying will block until there's more to read
 		// from the exec output. For an action with no more output it may never return.
 		// If a TTY is setup and the session is still open, send Ctrl-C over before closing it.
@@ -169,7 +169,7 @@ func ExecSSH(ctx context.Context, id Identity, cmd []string, opts plugin.ExecOpt
 			activity.Record(ctx, "Sent SIGINT on context termination: %v", session.Signal(ssh.SIGINT))
 		}
 		activity.Record(ctx, "Closing session on context termination for %v: %v", id.Host, session.Close())
-	}
+	})
 	execCmd.SetExitCodeCB(func() (int, error) {
 		if exitErr == nil {
 			return 0, nil

--- a/transport/ssh.go
+++ b/transport/ssh.go
@@ -170,13 +170,13 @@ func ExecSSH(ctx context.Context, id Identity, cmd []string, opts plugin.ExecOpt
 		}
 		activity.Record(ctx, "Closing session on context termination for %v: %v", id.Host, session.Close())
 	}
-	execCmd.ExitCodeCB = func() (int, error) {
+	execCmd.SetExitCodeCB(func() (int, error) {
 		if exitErr == nil {
 			return 0, nil
 		} else if err, ok := exitErr.(*ssh.ExitError); ok {
 			return err.ExitStatus(), nil
 		}
 		return 0, exitErr
-	}
+	})
 	return execCmd, nil
 }

--- a/transport/ssh.go
+++ b/transport/ssh.go
@@ -97,19 +97,17 @@ type Identity struct {
 // Host *.compute.amazonaws.com
 //   StrictHostKeyChecking no
 // ```
-func ExecSSH(ctx context.Context, id Identity, cmd []string, opts plugin.ExecOptions) (plugin.ExecCommand, error) {
-	var execCmd plugin.ExecCommand
-
+func ExecSSH(ctx context.Context, id Identity, cmd []string, opts plugin.ExecOptions) (*plugin.ExecCommand, error) {
 	// find port, username, etc from .ssh/config
 	port, err := ssh_config.GetStrict(id.Host, "Port")
 	if err != nil {
-		return execCmd, err
+		return nil, err
 	}
 
 	user := id.User
 	if user == "" {
 		if user, err = ssh_config.GetStrict(id.Host, "User"); err != nil {
-			return execCmd, err
+			return nil, err
 		}
 	}
 
@@ -119,30 +117,30 @@ func ExecSSH(ctx context.Context, id Identity, cmd []string, opts plugin.ExecOpt
 
 	strictHostKeyChecking, err := ssh_config.GetStrict(id.Host, "StrictHostKeyChecking")
 	if err != nil {
-		return execCmd, err
+		return nil, err
 	}
 
 	connection, err := sshConnect(id.Host, port, user, strictHostKeyChecking != "no")
 	if err != nil {
-		return execCmd, fmt.Errorf("Failed to connect: %s", err)
+		return nil, fmt.Errorf("Failed to connect: %s", err)
 	}
 
 	// Run command via session
 	session, err := connection.NewSession()
 	if err != nil {
-		return execCmd, fmt.Errorf("Failed to create session: %s", err)
+		return nil, fmt.Errorf("Failed to create session: %s", err)
 	}
 
 	if opts.Tty {
 		// sshd only processes signal codes if a TTY has been allocated. So set one up when requested.
 		modes := ssh.TerminalModes{ssh.ECHO: 0, ssh.TTY_OP_ISPEED: 14400, ssh.TTY_OP_OSPEED: 14400}
 		if err := session.RequestPty("xterm", 40, 80, modes); err != nil {
-			return execCmd, fmt.Errorf("Unable to setup a TTY: %v", err)
+			return nil, fmt.Errorf("Unable to setup a TTY: %v", err)
 		}
 	}
 
-	outputch, stdout, stderr := plugin.CreateExecOutputStreams(ctx)
-	session.Stdin, session.Stdout, session.Stderr = opts.Stdin, stdout, stderr
+	execCmd := plugin.NewExecCommand(ctx)
+	session.Stdin, session.Stdout, session.Stderr = opts.Stdin, execCmd.Stdout(), execCmd.Stderr()
 
 	if opts.Elevate {
 		cmd = append([]string{"sudo"}, cmd...)
@@ -160,11 +158,9 @@ func ExecSSH(ctx context.Context, id Identity, cmd []string, opts plugin.ExecOpt
 	go func() {
 		exitErr = session.Wait()
 		activity.Record(ctx, "Closing session for %v: %v", id.Host, session.Close())
-		stdout.Close()
-		stderr.Close()
+		execCmd.CloseStreams()
 	}()
 
-	execCmd.OutputCh = outputch
 	execCmd.StopFunc = func() {
 		// Close the session on context cancellation. Copying will block until there's more to read
 		// from the exec output. For an action with no more output it may never return.

--- a/volume/fs.go
+++ b/volume/fs.go
@@ -103,14 +103,6 @@ func (d *FS) VolumeStream(ctx context.Context, path string) (io.ReadCloser, erro
 		return nil, err
 	}
 
-	// Setup context cancellation handling
-	if cmd.StopFunc != nil {
-		go func() {
-			<-ctx.Done()
-			cmd.StopFunc()
-		}()
-	}
-
 	r, w := io.Pipe()
 	go func() {
 		// Exec uses context; if it's canceled, the OutputCh will close. Close the writer.

--- a/volume/fs.go
+++ b/volume/fs.go
@@ -56,7 +56,7 @@ func exec(ctx context.Context, executor plugin.Execable, cmdline []string) (*byt
 		return nil, fmt.Errorf("exec errored: %v", errs)
 	}
 
-	exitcode, err := cmd.ExitCodeCB()
+	exitcode, err := cmd.ExitCode()
 	if err != nil {
 		return nil, err
 	} else if exitcode != 0 {

--- a/volume/fs.go
+++ b/volume/fs.go
@@ -41,7 +41,7 @@ func exec(ctx context.Context, executor plugin.Execable, cmdline []string) (*byt
 
 	var buf bytes.Buffer
 	var errs []error
-	exitcode, exitErr := cmd.Wait(func(chunk plugin.ExecOutputChunk) {
+	for chunk := range cmd.StreamOutput() {
 		if chunk.Err != nil {
 			errs = append(errs, chunk.Err)
 		} else {
@@ -49,14 +49,15 @@ func exec(ctx context.Context, executor plugin.Execable, cmdline []string) (*byt
 			if chunk.StreamID == plugin.Stdout {
 				fmt.Fprint(&buf, chunk.Data)
 			}
-		}	
-	})
+		}
+	}
 
 	if len(errs) > 0 {
 		return nil, fmt.Errorf("exec errored: %v", errs)
 	}
 
-	if exitErr != nil {
+	exitcode, err := cmd.ExitCode()
+	if err != nil {
 		return nil, err
 	} else if exitcode != 0 {
 		// Can happen due to permission denied. Leave handling up to the caller.
@@ -106,11 +107,11 @@ func (d *FS) VolumeStream(ctx context.Context, path string) (io.ReadCloser, erro
 	go func() {
 		// Exec uses context; if it's canceled, the OutputCh will close. Close the writer.
 		var errs []error
-		_, _ = cmd.Wait(func(chunk plugin.ExecOutputChunk) {
+		for chunk := range cmd.StreamOutput() {
 			if chunk.Err != nil {
 				activity.Record(ctx, "Error on exec: %v", chunk.Err)
 				errs = append(errs, chunk.Err)
-				return
+				continue
 			}
 
 			activity.Record(ctx, "%v: %v", chunk.StreamID, chunk.Data)
@@ -120,7 +121,7 @@ func (d *FS) VolumeStream(ctx context.Context, path string) (io.ReadCloser, erro
 					errs = append(errs, err)
 				}
 			}
-		})
+		}
 
 		if len(errs) > 0 {
 			err = w.CloseWithError(fmt.Errorf("Multiple errors from exec output: %v", errs))

--- a/volume/fs.go
+++ b/volume/fs.go
@@ -34,14 +34,14 @@ func (d *FS) List(ctx context.Context) ([]plugin.Entry, error) {
 var errNonZero = fmt.Errorf("Exec exited non-zero")
 
 func exec(ctx context.Context, executor plugin.Execable, cmdline []string) (*bytes.Buffer, error) {
-	result, err := executor.Exec(ctx, cmdline[0], cmdline[1:], plugin.ExecOptions{Elevate: true})
+	cmd, err := executor.Exec(ctx, cmdline[0], cmdline[1:], plugin.ExecOptions{Elevate: true})
 	if err != nil {
 		return nil, err
 	}
 
 	var buf bytes.Buffer
 	var errs []error
-	for chunk := range result.OutputCh {
+	for chunk := range cmd.OutputCh {
 		if chunk.Err != nil {
 			errs = append(errs, chunk.Err)
 		} else {
@@ -56,7 +56,7 @@ func exec(ctx context.Context, executor plugin.Execable, cmdline []string) (*byt
 		return nil, fmt.Errorf("exec errored: %v", errs)
 	}
 
-	exitcode, err := result.ExitCodeCB()
+	exitcode, err := cmd.ExitCodeCB()
 	if err != nil {
 		return nil, err
 	} else if exitcode != 0 {
@@ -97,17 +97,17 @@ func (d *FS) VolumeOpen(ctx context.Context, path string) (plugin.SizedReader, e
 func (d *FS) VolumeStream(ctx context.Context, path string) (io.ReadCloser, error) {
 	activity.Record(ctx, "Streaming %v on %v", path, plugin.ID(d.executor))
 	execOpts := plugin.ExecOptions{Elevate: true, Tty: true}
-	result, err := d.executor.Exec(ctx, "tail", []string{"-f", path}, execOpts)
+	cmd, err := d.executor.Exec(ctx, "tail", []string{"-f", path}, execOpts)
 	if err != nil {
 		activity.Record(ctx, "Exec error in VolumeRead: %v", err)
 		return nil, err
 	}
 
 	// Setup context cancellation handling
-	if result.CancelFunc != nil {
+	if cmd.StopFunc != nil {
 		go func() {
 			<-ctx.Done()
-			result.CancelFunc()
+			cmd.StopFunc()
 		}()
 	}
 
@@ -115,7 +115,7 @@ func (d *FS) VolumeStream(ctx context.Context, path string) (io.ReadCloser, erro
 	go func() {
 		// Exec uses context; if it's canceled, the OutputCh will close. Close the writer.
 		var errs []error
-		for chunk := range result.OutputCh {
+		for chunk := range cmd.OutputCh {
 			if chunk.Err != nil {
 				activity.Record(ctx, "Error on exec: %v", chunk.Err)
 				errs = append(errs, chunk.Err)

--- a/volume/fs_test.go
+++ b/volume/fs_test.go
@@ -37,8 +37,8 @@ func (suite *fsTestSuite) TearDownSuite() {
 	plugin.UnsetTestCache()
 }
 
-func createResult(data string) *plugin.ExecCommand {
-	cmd := plugin.NewExecCommand(context.Background())
+func createResult(data string) *plugin.RunningCommand {
+	cmd := plugin.NewRunningCommand(context.Background())
 	go func() {
 		_, err := cmd.Stdout().Write([]byte(data))
 		if err != nil {
@@ -149,7 +149,7 @@ type mockExecutor struct {
 	mock.Mock
 }
 
-func (m *mockExecutor) Exec(ctx context.Context, cmd string, args []string, opts plugin.ExecOptions) (*plugin.ExecCommand, error) {
+func (m *mockExecutor) Exec(ctx context.Context, cmd string, args []string, opts plugin.ExecOptions) (*plugin.RunningCommand, error) {
 	arger := m.Called(ctx, cmd, args, opts)
-	return arger.Get(0).(*plugin.ExecCommand), arger.Error(1)
+	return arger.Get(0).(*plugin.RunningCommand), arger.Error(1)
 }

--- a/volume/fs_test.go
+++ b/volume/fs_test.go
@@ -45,7 +45,7 @@ func createResult(data string) *plugin.RunningCommand {
 			msg := fmt.Sprintf("Unexpected error while setting up mocks: %v", err)
 			panic(msg)
 		}
-		cmd.CloseStreams(nil)
+		cmd.CloseStreamsWithError(nil)
 		cmd.SetExitCode(0)
 	}()
 	return cmd

--- a/volume/fs_test.go
+++ b/volume/fs_test.go
@@ -45,7 +45,7 @@ func createResult(data string) *plugin.RunningCommand {
 			msg := fmt.Sprintf("Unexpected error while setting up mocks: %v", err)
 			panic(msg)
 		}
-		cmd.CloseStreams()
+		cmd.CloseStreams(nil)
 		cmd.SetExitCode(0)
 	}()
 	return cmd

--- a/volume/fs_test.go
+++ b/volume/fs_test.go
@@ -36,15 +36,15 @@ func (suite *fsTestSuite) TearDownSuite() {
 	plugin.UnsetTestCache()
 }
 
-func createResult(data string) plugin.ExecResult {
+func createResult(data string) plugin.ExecCommand {
 	outputch := make(chan plugin.ExecOutputChunk, 1)
-	execResult := plugin.ExecResult{
+	cmd := plugin.ExecCommand{
 		OutputCh:   outputch,
 		ExitCodeCB: func() (int, error) { return 0, nil },
 	}
 	outputch <- plugin.ExecOutputChunk{StreamID: plugin.Stdout, Data: data}
 	close(outputch)
-	return execResult
+	return cmd
 }
 
 func createExec() *mockExecutor {
@@ -145,7 +145,7 @@ type mockExecutor struct {
 	mock.Mock
 }
 
-func (m *mockExecutor) Exec(ctx context.Context, cmd string, args []string, opts plugin.ExecOptions) (plugin.ExecResult, error) {
+func (m *mockExecutor) Exec(ctx context.Context, cmd string, args []string, opts plugin.ExecOptions) (plugin.ExecCommand, error) {
 	arger := m.Called(ctx, cmd, args, opts)
-	return arger.Get(0).(plugin.ExecResult), arger.Error(1)
+	return arger.Get(0).(plugin.ExecCommand), arger.Error(1)
 }

--- a/volume/fs_test.go
+++ b/volume/fs_test.go
@@ -46,10 +46,8 @@ func createResult(data string) *plugin.ExecCommand {
 			panic(msg)
 		}
 		cmd.CloseStreams()
+		cmd.SetExitCode(0)
 	}()
-	cmd.SetExitCodeCB(func() (int, error) {
-		return 0, nil
-	})
 	return cmd
 }
 

--- a/volume/fs_test.go
+++ b/volume/fs_test.go
@@ -47,9 +47,9 @@ func createResult(data string) *plugin.ExecCommand {
 		}
 		cmd.CloseStreams()
 	}()
-	cmd.ExitCodeCB = func() (int, error) {
+	cmd.SetExitCodeCB(func() (int, error) {
 		return 0, nil
-	}
+	})
 	return cmd
 }
 


### PR DESCRIPTION
plugin.RunningCommand better reflects how we've been using plugin.ExecResult. It also removes some cleanup burden from the plugin author, from clients of plugin.RunningCommand, and also simplifies the plugin interface by removing the ExitCodeCB so that the implementations better reflect the flow of an exec'ing command.