### PR TITLE
Refactor Exec's plugin interface

### DIFF
--- a/plugin/aws/ec2Instance.go
+++ b/plugin/aws/ec2Instance.go
@@ -182,10 +182,10 @@ func (inst *ec2Instance) checkLatestConsoleOutput(ctx context.Context) (*ec2Inst
 	return nil, fmt.Errorf("could not access the latest console log: %v", err)
 }
 
-func (inst *ec2Instance) Exec(ctx context.Context, cmd string, args []string, opts plugin.ExecOptions) (plugin.ExecResult, error) {
+func (inst *ec2Instance) Exec(ctx context.Context, cmd string, args []string, opts plugin.ExecOptions) (plugin.ExecCommand, error) {
 	meta, err := inst.Metadata(ctx)
 	if err != nil {
-		return plugin.ExecResult{}, err
+		return nil, err
 	}
 
 	// TODO: scrape default user and authorized keys from console output. Probably only works for Amazon AMIs.
@@ -197,7 +197,7 @@ func (inst *ec2Instance) Exec(ctx context.Context, cmd string, args []string, op
 	} else if ipaddr, ok := meta["PublicIpAddress"]; ok {
 		hostname = ipaddr.(string)
 	} else {
-		return plugin.ExecResult{}, fmt.Errorf("No public interface found for %v", inst)
+		return nil, fmt.Errorf("No public interface found for %v", inst)
 	}
 
 	// Use the default user for Amazon AMIs. See above for ideas on making this more general. Can be

--- a/plugin/execCommand.go
+++ b/plugin/execCommand.go
@@ -1,0 +1,128 @@
+package plugin
+
+import (
+	"context"
+	"fmt"
+)
+
+// ExecCommandImpl implements the plugin.ExecCommand interface.
+// Use plugin.NewExecCommand to create instances of these objects.
+type ExecCommandImpl struct {
+	ctx           context.Context
+	outputCh      chan ExecOutputChunk
+	stdout        *OutputStream
+	stderr        *OutputStream
+	exitCodeCh    chan int
+	exitCodeErrCh chan error
+}
+
+// NewExecCommand creates a new ExecCommandImpl object whose
+// lifetime is tied to the passed-in execution context.
+func NewExecCommand(ctx context.Context) *ExecCommandImpl {
+	cmd := &ExecCommandImpl{
+		ctx: ctx,
+		exitCodeCh: make(chan int, 1),
+		exitCodeErrCh: make(chan error, 1),
+	}
+
+	// Create the output streams
+	cmd.outputCh = make(chan ExecOutputChunk)
+	closer := &multiCloser{ch: cmd.outputCh, countdown: 2}
+	cmd.stdout = &OutputStream{ctx: cmd.ctx, id: Stdout, ch: cmd.outputCh, closer: closer}
+	cmd.stderr = &OutputStream{ctx: cmd.ctx, id: Stderr, ch: cmd.outputCh, closer: closer}
+
+	// Ensure that the output streams are closed when the context
+	// is cancelled. This guarantees that callers won't be blocked
+	// when they are streaming our command's output.
+	go func() {
+		<-cmd.ctx.Done()
+		cmd.CloseStreamsWithError(ctx.Err())
+	}()
+
+	return cmd
+}
+
+// SetStopFunc sets the function that stops the running command. stopFunc
+// is called when the execution context completes to perform necessary
+// termination.
+func (cmd *ExecCommandImpl) SetStopFunc(stopFunc func()) {
+	// Thankfully, goroutines are cheap. Otherwise, mixing this in with
+	// the goroutine in NewExecCommand heavily complicates things.
+	// For example, we'd have to worry about the possibility that the
+	// NewExecCommand goroutine is invoked before the Execable#Exec
+	// implementation can set a stopFunc, which can happen if the context
+	// is prematurely cancelled. That can result in an orphaned process
+	// in some plugin APIs, which is bad.
+	if stopFunc != nil {
+		go func() {
+			<-cmd.ctx.Done()
+			stopFunc()
+		}()
+	}
+}
+
+// Stdout returns the command's stdout stream. Attach this to your
+// plugin API's stdout stream.
+func (cmd *ExecCommandImpl) Stdout() *OutputStream {
+	return cmd.stdout
+}
+
+// Stderr returns the command's stderr stream. Attach this to your
+// plugin API's stderr stream.
+func (cmd *ExecCommandImpl) Stderr() *OutputStream {
+	return cmd.stderr
+}
+
+// CloseStreamsWithError closes the command's stdout/stderr streams
+// with the given error.
+func (cmd *ExecCommandImpl) CloseStreamsWithError(err error) {
+	cmd.Stdout().CloseWithError(err)
+	cmd.Stderr().CloseWithError(err)
+}
+
+// SetExitCode sets the command's exit code.
+func (cmd *ExecCommandImpl) SetExitCode(exitCode int) {
+	select {
+	case <-cmd.ctx.Done():
+		// Don't send anything if the context is cancelled.
+	default:
+		cmd.exitCodeCh <- exitCode
+	}
+}
+
+// SetExitCodeErr sets the exit code error, which occurs when the
+// plugin API fails to fetch the comand's exit code.
+//
+// NOTE: You should only use this function if your plugin API requires
+// a separate request to fetch the command's exit code. Otherwise,
+// use SetExitCode. See the implementation of Container#Exec in the
+// Docker plugin for an example of when and how this is used.
+func (cmd *ExecCommandImpl) SetExitCodeErr(err error) {
+	select {
+	case <-cmd.ctx.Done():
+		// Don't send anything if the context is cancelled.
+	default:
+		cmd.exitCodeErrCh <- err
+	}
+}
+
+// OutputCh implements ExecCommand#OutputCh
+func (cmd *ExecCommandImpl) OutputCh() <-chan ExecOutputChunk {
+	return cmd.outputCh
+}
+
+// ExitCode implements ExecCommand#ExitCode
+func (cmd *ExecCommandImpl) ExitCode() (int, error) {
+	select {
+	case <-cmd.ctx.Done():
+		return 0, fmt.Errorf("failed to fetch the command's exit code: %v", cmd.ctx.Err())
+	case exitCode := <-cmd.exitCodeCh:
+		return exitCode, nil
+	case err := <-cmd.exitCodeErrCh:
+		return 0, err
+	}
+}
+
+// sealed implements ExecCommand#sealed
+func (cmd *ExecCommandImpl) sealed() {
+}

--- a/plugin/execCommandImpl.go
+++ b/plugin/execCommandImpl.go
@@ -19,6 +19,10 @@ type ExecCommandImpl struct {
 // NewExecCommand creates a new ExecCommandImpl object whose
 // lifetime is tied to the passed-in execution context.
 func NewExecCommand(ctx context.Context) *ExecCommandImpl {
+	if ctx == nil {
+		panic("plugin.NewExecCommand called with a nil context")
+	}
+	
 	cmd := &ExecCommandImpl{
 		ctx: ctx,
 		exitCodeCh: make(chan int, 1),

--- a/plugin/execCommandImpl_test.go
+++ b/plugin/execCommandImpl_test.go
@@ -1,0 +1,182 @@
+package plugin
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type ExecCommandImplTestSuite struct {
+	suite.Suite
+	ctx         context.Context
+	cancelFunc  context.CancelFunc
+}
+
+func (suite *ExecCommandImplTestSuite) SetupTest() {
+	suite.ctx, suite.cancelFunc = context.WithCancel(context.Background())
+}
+
+func (suite *ExecCommandImplTestSuite) TearDownTest() {
+	// Ensure that the context is cancelled to avoid dangling
+	// goroutines
+	suite.cancelFunc()
+}
+
+func (suite *ExecCommandImplTestSuite) NewExecCommand() *ExecCommandImpl {
+	return NewExecCommand(suite.ctx)
+}
+
+func (suite *ExecCommandImplTestSuite) TestNewExecCommand_CreatesOutputStreams() {
+	execCmd := suite.NewExecCommand()
+
+	// Our simulated command alternates writing to stdout + stderr
+	expectedChunksCh := make(chan ExecOutputChunk, 1)
+	go func() {
+		// stdout + stderr will be closed before expectedChunksCh,
+		// which means that outputCh should be closed before
+		// expectedChunksCh.
+		defer close(expectedChunksCh)
+		defer execCmd.CloseStreamsWithError(nil)
+
+		writeTo := func(streamName string, stream *OutputStream, data string) {
+			expectedChunksCh <- ExecOutputChunk{StreamID: stream.id, Data: data}
+			_, err := stream.Write([]byte(data))
+			if !suite.NoError(err) {
+				suite.FailNow(
+					fmt.Sprintf("Unexpected error writing to %v: %v", streamName, err),
+				)
+			}
+		}
+		for i := 0; i < 5; i++ {
+			data := strconv.Itoa(i)
+			writeTo("stdout", execCmd.Stdout(), data)
+			writeTo("stderr", execCmd.Stderr(), data)
+		}
+	}()
+
+	for expectedChunk := range expectedChunksCh {
+		timer := time.NewTimer(1 * time.Second)
+		select {
+		case <-timer.C:
+			suite.FailNow(
+				fmt.Sprintf("Timed out while waiting for chunk %v to be sent to the output channel", expectedChunk),
+			)
+		case chunk, ok := <-execCmd.OutputCh():
+			if !ok {
+				suite.FailNow(
+					fmt.Sprintf("Expected chunk %v, but output channel was prematurely closed", expectedChunk),
+				)
+			}
+			EqualChunk(suite.Suite, expectedChunk, chunk)
+		}
+	}
+
+	assertClosedChannel(suite.Suite, execCmd.OutputCh())
+}
+
+func (suite *ExecCommandImplTestSuite) TestNewExecCommand_CancelledContext_ClosesOutputCh() {
+	execCmd := suite.NewExecCommand()
+	suite.cancelFunc()
+	assertSentError(suite.Suite, execCmd.Stdout(), suite.ctx.Err())
+	assertSentError(suite.Suite, execCmd.Stderr(), suite.ctx.Err())
+	assertClosedChannel(suite.Suite, execCmd.OutputCh())
+}
+
+func (suite *ExecCommandImplTestSuite) TestSetStopFunc_CancelledContext_StopsCommand() {
+	execCmd := suite.NewExecCommand()
+	stoppedCh := make(chan bool, 1)
+	time.AfterFunc(1 * time.Second, func() {
+		close(stoppedCh)
+	})
+	execCmd.SetStopFunc(func() {
+		stoppedCh <- true
+	})
+	suite.cancelFunc()
+
+	stopped, ok := <-stoppedCh
+	if !ok {
+		suite.Fail("The command was not stopped")
+	} else {
+		suite.True(stopped)
+	}
+}
+
+func (suite *ExecCommandImplTestSuite) TestSetExitCode_CancelledContext_DoesNotSetExitCode() {
+	execCmd := suite.NewExecCommand()
+	suite.cancelFunc()
+	execCmd.SetExitCode(1)
+	select {
+	case <-execCmd.exitCodeCh:
+		suite.Fail("SetExitCode set the exit code on a cancelled context")
+	default:
+		// Exit code was not sent, so the test passed
+	}
+}
+
+func (suite *ExecCommandImplTestSuite) TestSetExitCode_SetsExitCode() {
+	execCmd := suite.NewExecCommand()
+	execCmd.SetExitCode(1)
+	select {
+	case exitCode := <-execCmd.exitCodeCh:
+		suite.Equal(1, exitCode)
+	default:
+		suite.Fail("SetExitCode did not send the exit code on exitCodeCh")
+	}
+}
+
+func (suite *ExecCommandImplTestSuite) TestSetExitCodeErr_CancelledContext_DoesNotSetExitCodeErr() {
+	execCmd := suite.NewExecCommand()
+	suite.cancelFunc()
+	execCmd.SetExitCodeErr(fmt.Errorf("an error"))
+	select {
+	case <-execCmd.exitCodeErrCh:
+		suite.Fail("SetExitCodeErr set the exit code error on a cancelled context")
+	default:
+		// Exit code error was not sent, so the test passed
+	}
+}
+
+func (suite *ExecCommandImplTestSuite) TestSetExitCodeErr_SetsExitCodeErr() {
+	execCmd := suite.NewExecCommand()
+	expectedErr := fmt.Errorf("error")
+	execCmd.SetExitCodeErr(expectedErr)
+	select {
+	case err := <-execCmd.exitCodeErrCh:
+		suite.Equal(expectedErr, err)
+	default:
+		suite.Fail("SetExitCodeErr did not send the exit code error on exitCodeErrCh")
+	}
+}
+
+func (suite *ExecCommandImplTestSuite) TestExitCode_CancelledContext_ReturnsError() {
+	execCmd := suite.NewExecCommand()
+	suite.cancelFunc()
+	_, err := execCmd.ExitCode()
+	suite.Regexp(suite.ctx.Err(), err)
+}
+
+func (suite *ExecCommandImplTestSuite) TestExitCode_ReturnsExitCodeIfSet() {
+	execCmd := suite.NewExecCommand()
+	execCmd.SetExitCode(1)
+	exitCode, err := execCmd.ExitCode()
+	if suite.NoError(err) {
+		suite.Equal(1, exitCode)
+	}
+}
+
+func (suite *ExecCommandImplTestSuite) TestExitCode_ReturnsExitCodeErrIfSet() {
+	execCmd := suite.NewExecCommand()
+	expectedErr := fmt.Errorf("error")
+	execCmd.SetExitCodeErr(expectedErr)
+	_, err := execCmd.ExitCode()
+	suite.Equal(expectedErr, err)
+}
+
+func TestExecCommandImpl(t *testing.T) {
+	suite.Run(t, new(ExecCommandImplTestSuite))
+}
+

--- a/plugin/outputStream_test.go
+++ b/plugin/outputStream_test.go
@@ -142,6 +142,8 @@ func assertSentError(suite suite.Suite, stream *OutputStream, err error) {
 func (suite *OutputStreamTestSuite) TestCloseWithError_NoError() {
 	stream := newOutputStream(context.Background())
 	stream.CloseWithError(nil)
+	// Note that if an error was sent, then assertClosed would fail
+	// because it'd read-in the sent error.
 	suite.assertClosed(stream)
 }
 

--- a/plugin/outputStream_test.go
+++ b/plugin/outputStream_test.go
@@ -3,7 +3,6 @@ package plugin
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"testing"
 	"time"
 
@@ -110,27 +109,21 @@ func (suite *OutputStreamTestSuite) assertClosedChannel(ch <-chan ExecOutputChun
 	}
 }
 
-func (suite *OutputStreamTestSuite) TestClose() {
-	ch := make(chan ExecOutputChunk)
-	stream := OutputStream{ch: ch, closer: &multiCloser{ch: ch, countdown: 1}}
-
-	stream.Close()
-	suite.assertClosedChannel(stream.ch)
-}
-
 func (suite *OutputStreamTestSuite) TestCloseWithError() {
-	newOutputStream := func(ctx context.Context) OutputStream {
+	newOutputStream := func(ctx context.Context) *OutputStream {
 		ch := make(chan ExecOutputChunk, 1)
-		return OutputStream{ctx: ctx, id: Stdout, ch: ch, closer: &multiCloser{ch: ch, countdown: 1}}
+		return &OutputStream{ctx: ctx, id: Stdout, ch: ch, closer: &multiCloser{ch: ch, countdown: 1}}
 	}
 
 	// Test that if err == nil, then nothing was sent to the channel
 	stream := newOutputStream(context.Background())
+	suite.False(stream.closed)
 	stream.CloseWithError(nil)
 	suite.assertClosedChannel(stream.ch)
+	suite.True(stream.closed)
 
 	// Useful assertion for the subsequent tests
-	assertSentError := func(stream OutputStream, err error) {
+	assertSentError := func(stream *OutputStream, err error) {
 		sentErrorMsg := fmt.Sprintf("Expected the error '%v' to be sent", err)
 
 		select {
@@ -151,28 +144,37 @@ func (suite *OutputStreamTestSuite) TestCloseWithError() {
 	// Test that if err != nil, then the error is sent to the channel
 	stream = newOutputStream(context.Background())
 	sentErr := fmt.Errorf("an arbitrary error")
+	suite.False(stream.closed)
 	stream.CloseWithError(sentErr)
 	assertSentError(stream, sentErr)
 	suite.assertClosedChannel(stream.ch)
+	suite.True(stream.closed)
 
 	// Test that if err == ctx.Err(), then ctx.Err() is sent if a previous
 	// Write did not send it
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	stream = newOutputStream(ctx)
 	cancelFunc()
+	suite.False(stream.closed)
 	stream.CloseWithError(ctx.Err())
 	assertSentError(stream, ctx.Err())
 	suite.assertClosedChannel(stream.ch)
+	suite.True(stream.closed)
 
 	// Now, test that if err == ctx.Err(), then ctx.Err() is _not_ sent if
 	// a previous Write sent it
 	stream = newOutputStream(ctx)
 	stream.sentCtxErr = true
+	suite.False(stream.closed)
 	stream.CloseWithError(ctx.Err())
 	suite.assertClosedChannel(stream.ch)
+	suite.True(stream.closed)
 
+	// TODO: Add test to ensure that consecutive closes noop
 }
 
+/*
+TODO: Move this test over to runningCommand.go
 func (suite *OutputStreamTestSuite) TestCreateExecOutputStreams() {
 	outputCh, stdout, stderr := CreateExecOutputStreams(context.Background())
 
@@ -183,8 +185,8 @@ func (suite *OutputStreamTestSuite) TestCreateExecOutputStreams() {
 		// which means that outputCh should be closed before
 		// expectedChunksCh.
 		defer close(expectedChunksCh)
-		defer stdout.Close()
-		defer stderr.Close()
+		defer stdout.close()
+		defer stderr.close()
 
 		writeTo := func(streamName string, stream *OutputStream, data string) {
 			expectedChunksCh <- ExecOutputChunk{StreamID: stream.id, Data: data}
@@ -222,8 +224,8 @@ func (suite *OutputStreamTestSuite) TestCreateExecOutputStreams() {
 
 	// outputCh should be closed, so assert that it is
 	suite.assertClosedChannel(outputCh)
-
 }
+*/
 
 func TestOutputStream(t *testing.T) {
 	suite.Run(t, new(OutputStreamTestSuite))

--- a/volume/fs_test.go
+++ b/volume/fs_test.go
@@ -2,6 +2,7 @@ package volume
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -36,15 +37,18 @@ func (suite *fsTestSuite) TearDownSuite() {
 	plugin.UnsetTestCache()
 }
 
-func createResult(data string) plugin.ExecResult {
-	outputch := make(chan plugin.ExecOutputChunk, 1)
-	execResult := plugin.ExecResult{
-		OutputCh:   outputch,
-		ExitCodeCB: func() (int, error) { return 0, nil },
-	}
-	outputch <- plugin.ExecOutputChunk{StreamID: plugin.Stdout, Data: data}
-	close(outputch)
-	return execResult
+func createResult(data string) plugin.ExecCommand {
+	cmd := plugin.NewExecCommand(context.Background())
+	go func() {
+		_, err := cmd.Stdout().Write([]byte(data))
+		if err != nil {
+			msg := fmt.Sprintf("Unexpected error while setting up mocks: %v", err)
+			panic(msg)
+		}
+		cmd.CloseStreamsWithError(nil)
+		cmd.SetExitCode(0)
+	}()
+	return cmd
 }
 
 func createExec() *mockExecutor {
@@ -145,7 +149,7 @@ type mockExecutor struct {
 	mock.Mock
 }
 
-func (m *mockExecutor) Exec(ctx context.Context, cmd string, args []string, opts plugin.ExecOptions) (plugin.ExecResult, error) {
+func (m *mockExecutor) Exec(ctx context.Context, cmd string, args []string, opts plugin.ExecOptions) (plugin.ExecCommand, error) {
 	arger := m.Called(ctx, cmd, args, opts)
-	return arger.Get(0).(plugin.ExecResult), arger.Error(1)
+	return arger.Get(0).(plugin.ExecCommand), arger.Error(1)
 }


### PR DESCRIPTION
This commit refactors Exec's plugin interface to be more plugin-author
friendly, and simpler to understand. It includes the following changes:

* Rename plugin.ExecResult => plugin.ExecCommand

plugin.ExecCommand better reflects what is being returned.

* Enforce a strict separation between what an Exec caller needs to care
about (plugin.ExecCommand) vs. what a plugin author needs to care about
(plugin.ExecCommandImpl) when implementing Exec

Exec callers should only care about a command's output channel and exit
code. They should not have to worry about context-cancellation cleanup
like ensuring that the command's stopped. That cleanup is the plugin
author's responsibility. On the other hand, it would be annoying for a
plugin author to have to remember to handle context-cancellation
cleanup.

The plugin.ExecCommand interface and the plugin.ExecCommandImpl object
solve both of these problems. Execable#Exec returns a plugin.ExecCommand
object, which only includes OutputCh and ExitCode. These are precisely the
things that Exec callers need to care about. Conversely, the
plugin.ExecCommandImpl implements the plugin.ExecCommand interface, but
also includes additional helpers that are meant to help plugin authors
write their code, including helpers that handle context cancellation
cleanup.

Finally, plugin.ExecCommandImpl replaces the previous ExitCodeCB via
helpers that set the exit-code/exit-code errors. This is more idiomatic
with how one thinks about what exec'ing a command would look like
("Stream the output" => "Get/Set the exit code").