### PR TITLE
Fix AWS region on S3 buckets

### DIFF
--- a/plugin/aws/s3Bucket.go
+++ b/plugin/aws/s3Bucket.go
@@ -225,16 +225,18 @@ func (b *s3Bucket) getRegion(ctx context.Context) (string, error) {
 		}
 
 		// The response will be empty if the bucket is in Amazon's default region (us-east-1)
-		region := s3Client.NormalizeBucketLocation(awsSDK.StringValue(resp.LocationConstraint))
-		// Update client to be region-specific
-		b.client = s3Client.New(b.session, aws.NewConfig().WithRegion(region))
-
-		return region, nil
+		return s3Client.NormalizeBucketLocation(awsSDK.StringValue(resp.LocationConstraint)), nil
 	})
 
 	if err != nil {
 		return "", err
 	}
 
-	return resp.(string), nil
+	region := resp.(string)
+	if awsSDK.StringValue(b.client.Config.Region) != region {
+		// Update client to be region-specific
+		b.client = s3Client.New(b.session, aws.NewConfig().WithRegion(resp.(string)))
+	}
+
+	return region, nil
 }


### PR DESCRIPTION
When making multiple requests to list the same S3 bucket, the first request would get the region and update the client to use that region but subsequent requests for the same path (but with new instances of the s3Bucket object) would use the cached region and not update the client. This resulted in lots of failures due to incorrect region after the first request. Fix so we always update the client to the correct region.

Signed-off-by: Michael Smith <michael.smith@puppet.com>