### PR TITLE
 Support ExecOptions in external plugin exec

### DIFF
--- a/plugin/externalPluginEntry.go
+++ b/plugin/externalPluginEntry.go
@@ -229,8 +229,13 @@ func (e *externalPluginEntry) Stream(ctx context.Context) (io.ReadCloser, error)
 }
 
 func (e *externalPluginEntry) Exec(ctx context.Context, cmd string, args []string, opts ExecOptions) (ExecCommand, error) {
+	// Serialize opts to JSON
+	optsJSON, err := json.Marshal(opts)
+	if err != nil {
+		return nil, fmt.Errorf("could not marshal opts %v into JSON: %v", opts, err)
+	}
 	// Start the command.
-	cmdObj := e.script.NewInvocation(ctx, "exec", e, append([]string{cmd}, args...)...)
+	cmdObj := e.script.NewInvocation(ctx, "exec", e, append([]string{string(optsJSON), cmd}, args...)...)
 	execCmd := NewExecCommand(ctx)
 	cmdObj.SetStdout(execCmd.Stdout())
 	cmdObj.SetStderr(execCmd.Stderr())

--- a/plugin/internal/command.go
+++ b/plugin/internal/command.go
@@ -9,12 +9,12 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"strings"
 	"sync"
 	"syscall"
 	"time"
 
 	"github.com/puppetlabs/wash/activity"
+	"github.com/kballard/go-shellquote"
 )
 
 // Command is a wrapper to exec.Cmd. It handles context-cancellation cleanup
@@ -118,8 +118,8 @@ func (cmd *Command) String() string {
 	if cmd.pgid >= 0 {
 		str += fmt.Sprintf("(PGID %v) ", cmd.pgid)
 	}
-	str += strings.Join(cmd.c.Args, " ")
-	return "'" + str + "'"
+	str += shellquote.Join(cmd.c.Args...)
+	return str
 }
 
 // Run is a wrapper to exec.Cmd#Run

--- a/plugin/types.go
+++ b/plugin/types.go
@@ -66,6 +66,7 @@ type Root interface {
 // Examples of potential features: user, privileged, map of environment variables, timeout.
 type ExecOptions struct {
 	// Stdin can be used to pass a stream of input to write to stdin when executing the command.
+	// It is not included in ExecOption's JSON serialization.
 	Stdin io.Reader `json:"-"`
 
 	// Tty instructs the executor to allocate a TTY (pseudo-terminal), which lets Wash communicate

--- a/plugin/types.go
+++ b/plugin/types.go
@@ -66,7 +66,7 @@ type Root interface {
 // Examples of potential features: user, privileged, map of environment variables, timeout.
 type ExecOptions struct {
 	// Stdin can be used to pass a stream of input to write to stdin when executing the command.
-	Stdin io.Reader
+	Stdin io.Reader `json:"-"`
 
 	// Tty instructs the executor to allocate a TTY (pseudo-terminal), which lets Wash communicate
 	// with the running process via its Stdin. The TTY is used to send a process termination signal
@@ -81,10 +81,10 @@ type ExecOptions struct {
 	// NOTE TO CALLERS: The Tty option is useful for executing your own stream-like commands (e.g.
 	// tail -f), because it ensures that there are no orphaned processes after the request is
 	// cancelled/finished.
-	Tty bool
+	Tty bool `json:"tty"`
 
 	// Elevate execution to run as a privileged user if not already running as a privileged user.
-	Elevate bool
+	Elevate bool `json:"elevate"`
 }
 
 // ExecPacketType identifies the packet type.

--- a/website/static/docs/external_plugins/examples/sshfs.sh
+++ b/website/static/docs/external_plugins/examples/sshfs.sh
@@ -16,6 +16,11 @@
 # as the root user. For example, it assumes that something like
 # "ssh root@<vm> ls" works.
 #
+# Since Wash passes-in JSON objects to external plugin scripts,
+# this example also requires jq to handle the parsing. We will
+# eventually add multiple input formats, some of which are more
+# "bash" friendly.
+#
 # If you'd like to try this plugin out, then add the following to
 # your plugins.yaml file:
 #
@@ -158,8 +163,9 @@ function print_children {
   # `test-d` and stat on each entry to obtain the following information:
   #   <is_dir> <sizeAttr> <atime> <mtime> <ctime> <mode> <path>
   #
-  # TODO: Handle TTY strangeness in the returned output. For now, it is
-  # enough to set it to false.
+  # NOTE: This example sets the TTY option to false. Setting it to true
+  # results in some strangeness in the returned output. If you have ideas
+  # on how to fix that strangeness, please feel free to submit a PR!
   stat_output=`vm_exec ${vm} "find ${dir} -mindepth 1 -maxdepth 1 -exec bash -c 'test -d \\$0; echo -n \"\\$? \"' {} \; -exec stat -c '%s %X %Y %Z %f %n' {} \;" false`
   if [[ -z "${stat_output}" ]]; then
     echo "[]"

--- a/website/static/docs/external_plugins/examples/sshfs.sh
+++ b/website/static/docs/external_plugins/examples/sshfs.sh
@@ -260,18 +260,27 @@ if [[ "${path}" == "" ]]; then
     exit 0
   ;;
   "exec")
-    cmd="$3"
-
+    opts="$4"
+    cmd="$5"
+    shift
+    shift
     shift
     shift
     shift
     args="$@"
 
-    # exec'ing <cmd> <args> on a VM is equivalent to exec'ing it
-    # on the VM via. ssh (vm_exec)
+    # First we parse the provided Exec options. Wash guarantees that
+    # the passed-in options are valid JSON and that they are all present,
+    # so we don't need to do our own validation.
     #
-    # TODO: Handle stdin + other exec options.
-    vm_exec "${vm}" "${cmd} ${args}" "false"
+    # NOTE: Only the "tty" option is relevant. We don't need to worry about
+    # "elevate" because we are already running our commands as root.
+    tty=`echo "${opts}" | jq .tty`
+
+    # Now we exec the command and exit with its exit code.
+    #
+    # NOTE: Our process' Stdin is the content of the "Stdin" Exec option.
+    cat /dev/stdin | vm_exec "${vm}" "${cmd} ${args}" "${tty}"
     exit "$?"
   ;;
   "metadata")


### PR DESCRIPTION
Contributions to this project require sign-off consistent with the [Developers Certificate of Origin](https://developercertificate.org). This can be as simple as using `git commit -s` on each commit.