### PR TITLE
Rename "Group" => "Parent"

### DIFF
--- a/api/cache_test.go
+++ b/api/cache_test.go
@@ -84,14 +84,14 @@ func (suite *CacheHandlerTestSuite) TestRejectsGet() {
 
 func (suite *CacheHandlerTestSuite) TestClearCache() {
 	// Populate the cache with a mocked resource and plugin.Cached*
-	group := newMockedGroup()
-	group.SetTestID("/dir")
-	group.On("List", mock.Anything).Return([]plugin.Entry{}, nil)
+	parent := newMockedParent()
+	parent.SetTestID("/dir")
+	parent.On("List", mock.Anything).Return([]plugin.Entry{}, nil)
 
 	reqCtx := context.WithValue(context.Background(), mountpointKey, "/")
 
 	expectedChildren := make(map[string]plugin.Entry)
-	if children, err := plugin.CachedList(reqCtx, group); suite.Nil(err) {
+	if children, err := plugin.CachedList(reqCtx, parent); suite.Nil(err) {
 		suite.Equal(expectedChildren, children)
 	}
 
@@ -102,7 +102,7 @@ func (suite *CacheHandlerTestSuite) TestClearCache() {
 	suite.Equal(http.StatusOK, w.Code)
 	suite.Equal("[]\n", w.Body.String())
 
-	if children, err := plugin.CachedList(context.Background(), group); suite.Nil(err) {
+	if children, err := plugin.CachedList(context.Background(), parent); suite.Nil(err) {
 		suite.Equal(expectedChildren, children)
 	}
 
@@ -113,11 +113,11 @@ func (suite *CacheHandlerTestSuite) TestClearCache() {
 	suite.Equal(http.StatusOK, w.Code)
 	suite.Equal(`["List::/dir"]`, strings.TrimSpace(w.Body.String()))
 
-	if children, err := plugin.CachedList(context.Background(), group); suite.Nil(err) {
+	if children, err := plugin.CachedList(context.Background(), parent); suite.Nil(err) {
 		suite.Equal(expectedChildren, children)
 	}
 
-	group.AssertNumberOfCalls(suite.T(), "List", 2)
+	parent.AssertNumberOfCalls(suite.T(), "List", 2)
 }
 
 func (suite *CacheHandlerTestSuite) TestClearCacheErrors() {
@@ -145,20 +145,20 @@ func TestCacheHandler(t *testing.T) {
 	suite.Run(t, new(CacheHandlerTestSuite))
 }
 
-type mockedGroup struct {
+type mockedParent struct {
 	plugin.EntryBase
 	mock.Mock
 }
 
-func newMockedGroup() *mockedGroup {
-	g := &mockedGroup{
-		EntryBase: plugin.NewEntry("mockGroup"),
+func newMockedParent() *mockedParent {
+	p := &mockedParent{
+		EntryBase: plugin.NewEntry("mockParent"),
 	}
 
-	return g
+	return p
 }
 
-func (g *mockedGroup) List(ctx context.Context) ([]plugin.Entry, error) {
-	args := g.Called(ctx)
+func (p *mockedParent) List(ctx context.Context) ([]plugin.Entry, error) {
+	args := p.Called(ctx)
 	return args.Get(0).([]plugin.Entry), args.Error(1)
 }

--- a/api/helpers.go
+++ b/api/helpers.go
@@ -30,10 +30,10 @@ func findEntry(ctx context.Context, root plugin.Entry, segments []string) (plugi
 	curEntry := root
 	visitedSegments := make([]string, 0, cap(segments))
 	for _, segment := range segments {
-		switch curGroup := curEntry.(type) {
-		case plugin.Group:
+		switch curParent := curEntry.(type) {
+		case plugin.Parent:
 			// Get the entries via. List()
-			entries, err := plugin.CachedList(ctx, curGroup)
+			entries, err := plugin.CachedList(ctx, curParent)
 			if err != nil {
 				if cnameErr, ok := err.(plugin.DuplicateCNameErr); ok {
 					return nil, duplicateCNameResponse(cnameErr)
@@ -47,7 +47,7 @@ func findEntry(ctx context.Context, root plugin.Entry, segments []string) (plugi
 			if !ok {
 				reason := fmt.Sprintf("The %v entry does not exist", segment)
 				if len(visitedSegments) != 0 {
-					reason += fmt.Sprintf(" in the %v group", strings.Join(visitedSegments, "/"))
+					reason += fmt.Sprintf(" in the %v parent", strings.Join(visitedSegments, "/"))
 				}
 
 				return nil, entryNotFoundResponse(path, reason)
@@ -56,7 +56,7 @@ func findEntry(ctx context.Context, root plugin.Entry, segments []string) (plugi
 			curEntry = entry
 			visitedSegments = append(visitedSegments, segment)
 		default:
-			reason := fmt.Sprintf("The entry %v is not a group", strings.Join(visitedSegments, "/"))
+			reason := fmt.Sprintf("The entry %v is not a parent", strings.Join(visitedSegments, "/"))
 			return nil, entryNotFoundResponse(path, reason)
 		}
 	}

--- a/api/list.go
+++ b/api/list.go
@@ -44,8 +44,8 @@ var listHandler handler = func(w http.ResponseWriter, r *http.Request) *errorRes
 		return unsupportedActionResponse(path, plugin.ListAction())
 	}
 
-	group := entry.(plugin.Group)
-	entries, err := plugin.CachedList(ctx, group)
+	parent := entry.(plugin.Parent)
+	entries, err := plugin.CachedList(ctx, parent)
 	if err != nil {
 		if cnameErr, ok := err.(plugin.DuplicateCNameErr); ok {
 			return duplicateCNameResponse(cnameErr)

--- a/fuse/core.go
+++ b/fuse/core.go
@@ -55,12 +55,12 @@ var uid, gid = getIDs()
 
 type fuseNode struct {
 	ftype             string
-	parent            plugin.Group
+	parent            plugin.Parent
 	entry             plugin.Entry
 	entryCreationTime time.Time
 }
 
-func newFuseNode(ftype string, parent plugin.Group, entry plugin.Entry) *fuseNode {
+func newFuseNode(ftype string, parent plugin.Parent, entry plugin.Entry) *fuseNode {
 	return &fuseNode{
 		ftype:             ftype,
 		parent:            parent,

--- a/fuse/dir.go
+++ b/fuse/dir.go
@@ -19,14 +19,14 @@ var _ fs.Node = (*dir)(nil)
 var _ = fs.NodeRequestLookuper(&dir{})
 var _ = fs.HandleReadDirAller(&dir{})
 
-func newDir(p plugin.Group, e plugin.Group) *dir {
+func newDir(p plugin.Parent, e plugin.Parent) *dir {
 	return &dir{newFuseNode("d", p, e)}
 }
 
 func (d *dir) children(ctx context.Context) (map[string]plugin.Entry, error) {
 	// Cache List requests. FUSE often lists the contents then immediately calls find on individual entries.
 	if plugin.ListAction().IsSupportedOn(d.entry) {
-		return plugin.CachedList(ctx, d.entry.(plugin.Group))
+		return plugin.CachedList(ctx, d.entry.(plugin.Parent))
 	}
 
 	return map[string]plugin.Entry{}, fuse.ENOENT
@@ -50,13 +50,13 @@ func (d *dir) Lookup(ctx context.Context, req *fuse.LookupRequest, resp *fuse.Lo
 	}
 
 	if plugin.ListAction().IsSupportedOn(entry) {
-		childdir := newDir(d.entry.(plugin.Group), entry.(plugin.Group))
+		childdir := newDir(d.entry.(plugin.Parent), entry.(plugin.Parent))
 		activity.Record(ctx, "FUSE: Found directory %v", childdir)
 		return childdir, nil
 	}
 
 	activity.Record(ctx, "FUSE: Found file %v/%v", d, cname)
-	return newFile(d.entry.(plugin.Group), entry), nil
+	return newFile(d.entry.(plugin.Parent), entry), nil
 }
 
 // ReadDirAll lists all children of the directory.

--- a/fuse/file.go
+++ b/fuse/file.go
@@ -19,7 +19,7 @@ type file struct {
 var _ fs.Node = (*file)(nil)
 var _ = fs.NodeOpener(&file{})
 
-func newFile(p plugin.Group, e plugin.Entry) *file {
+func newFile(p plugin.Parent, e plugin.Entry) *file {
 	return &file{newFuseNode("f", p, e)}
 }
 

--- a/plugin/action.go
+++ b/plugin/action.go
@@ -29,7 +29,7 @@ func (a Action) IsSupportedOn(entry Entry) bool {
 	return false
 }
 
-var listAction = newAction("list", "Group")
+var listAction = newAction("list", "Parent")
 // ListAction represents the list action
 func ListAction() Action {
 	return listAction
@@ -81,7 +81,7 @@ func SupportedActionsOf(entry Entry) []string {
 		// We could use reflection to simplify this. In fact, a previous version
 		// of the code did do that. The reason we removed it was b/c type assertion's
 		// a lot faster, and the resulting code isn't that bad, if a little verbose.
-		if _, ok := entry.(Group); ok {
+		if _, ok := entry.(Parent); ok {
 			actions = append(actions, ListAction().Name)
 		}
 		if _, ok := entry.(Readable); ok {

--- a/plugin/cache.go
+++ b/plugin/cache.go
@@ -142,17 +142,17 @@ func (c DuplicateCNameErr) Error() string {
 	)
 }
 
-// CachedList caches a Group object's List method. It also sets the
+// CachedList caches a Parent's List method. It also sets the
 // children's IDs to <parent_id> + "/" + <child_cname>.
 //
 // CachedList returns a map of <entry_cname> => <entry_object> to optimize
 // querying a specific entry.
-func CachedList(ctx context.Context, g Group) (map[string]Entry, error) {
-	cachedEntries, err := cachedDefaultOp(ctx, ListOp, g, func() (interface{}, error) {
+func CachedList(ctx context.Context, p Parent) (map[string]Entry, error) {
+	cachedEntries, err := cachedDefaultOp(ctx, ListOp, p, func() (interface{}, error) {
 		// Including the entry's ID allows plugin authors to use any Cached* methods defined on the
 		// children after their creation. This is necessary when the child's Cached* methods are used
 		// to calculate its attributes. Note that the child's ID is set in cachedOp.
-		entries, err := g.List(context.WithValue(ctx, parentID, g.id()))
+		entries, err := p.List(context.WithValue(ctx, parentID, p.id()))
 		if err != nil {
 			return nil, err
 		}
@@ -163,7 +163,7 @@ func CachedList(ctx context.Context, g Group) (map[string]Entry, error) {
 
 			if duplicateEntry, ok := searchedEntries[cname]; ok {
 				return nil, DuplicateCNameErr{
-					ParentID:                        g.id(),
+					ParentID:                        p.id(),
 					FirstChildName:                  duplicateEntry.name(),
 					FirstChildSlashReplacementChar:  duplicateEntry.slashReplacementChar(),
 					SecondChildName:                 entry.name(),
@@ -175,7 +175,7 @@ func CachedList(ctx context.Context, g Group) (map[string]Entry, error) {
 
 			// Ensure ID is set on all entries so that we can use it for caching later in places
 			// where the context doesn't include the parent's ID.
-			id := strings.TrimRight(g.id(), "/") + "/" + cname
+			id := strings.TrimRight(p.id(), "/") + "/" + cname
 			entry.setID(id)
 		}
 

--- a/plugin/cache_test.go
+++ b/plugin/cache_test.go
@@ -262,7 +262,7 @@ func (suite *CacheTestSuite) TestCachedListDefaultOp() {
 	mockChildren := []Entry{newCacheTestsMockEntry("mockChild")}
 	mungedOpValue := toMap(mockChildren)
 	suite.testCachedDefaultOp(ListOp, "List", mockChildren, mungedOpValue, func(ctx context.Context, e Entry) (interface{}, error) {
-		return CachedList(ctx, e.(Group))
+		return CachedList(ctx, e.(Parent))
 	})
 }
 

--- a/plugin/entryAttributes.go
+++ b/plugin/entryAttributes.go
@@ -39,7 +39,7 @@ func ToJSONObject(v interface{}) JSONObject {
 /*
 EntryAttributes represents an entry's attributes. We use a struct
 instead of a map for efficient memory allocation/deallocation,
-which is needed to make Group#List fast.
+which is needed to make Parent#List fast.
 
 Each of the setters supports the builder pattern, which enables you
 to do something like

--- a/plugin/entryBase.go
+++ b/plugin/entryBase.go
@@ -9,7 +9,7 @@ import (
 type defaultOpCode int8
 
 const (
-	// ListOp represents Group#List
+	// ListOp represents Parent#List
 	ListOp defaultOpCode = iota
 	// OpenOp represents Readable#Open
 	OpenOp

--- a/plugin/helpers.go
+++ b/plugin/helpers.go
@@ -55,7 +55,7 @@ func CName(e Entry) string {
 
 // ID returns the entry's ID, which is just its path rooted at Wash's mountpoint.
 // An entry's ID is described as
-//     /<plugin_name>/<group1_cname>/<group2_cname>/.../<entry_cname>
+//     /<plugin_name>/<parent1_cname>/<parent2_cname>/.../<entry_cname>
 //
 // NOTE: <plugin_name> is really <plugin_cname>. However since <plugin_name>
 // can never contain a '/', <plugin_cname> reduces to <plugin_name>.

--- a/plugin/types.go
+++ b/plugin/types.go
@@ -12,14 +12,13 @@ type, and initialize it via NewEntry. For example
 EntryBase gives the resource a name - which is how it will be displayed in the filesystem
 or referenced via the API - and tools for controlling how its data is cached.
 
-The Group interface identifies the resource as a container for other things. Implementing it
-enables displaying it as a directory in the filesystem. Anything that does not implement
-Group will be displayed as a file.
+Implementing the Parent interface displays that resource as a directory on the filesystem.
+Anything that does not implement Parent will be displayed as a file.
 
 The Readable interface gives a file its contents when read via the filesystem.
 
-All of the above, as well as other types - Resource, Execable, Pipe - provide
-additional functionality via the HTTP API.
+All of the above, as well as other types - Execable, Stream - provide additional functionality
+via the HTTP API.
 */
 package plugin
 
@@ -49,16 +48,16 @@ type Entry interface {
 	getTTLOf(op defaultOpCode) time.Duration
 }
 
-// Group is an entry that can list its contents, an array of entries.
-// It will be represented as a directory in the wash filesystem.
-type Group interface {
+// Parent is an entry with children. It will be represented as a directory in the Wash
+// filesystem.
+type Parent interface {
 	Entry
 	List(context.Context) ([]Entry, error)
 }
 
-// Root is the root object of a plugin.
+// Root represents the plugin root
 type Root interface {
-	Group
+	Parent
 	Init() error
 }
 

--- a/volume/fs_test.go
+++ b/volume/fs_test.go
@@ -67,11 +67,11 @@ func (suite *fsTestSuite) createExec() *mockExecutor {
 	return exec
 }
 
-func (suite *fsTestSuite) find(grp plugin.Group, path string) plugin.Entry {
+func (suite *fsTestSuite) find(parent plugin.Parent, path string) plugin.Entry {
 	names := strings.Split(path, "/")
-	entry := plugin.Entry(grp)
+	entry := plugin.Entry(parent)
 	for _, name := range names {
-		entries, err := entry.(plugin.Group).List(context.Background())
+		entries, err := entry.(plugin.Parent).List(context.Background())
 		if !suite.NoError(err) {
 			suite.FailNow("Listing entries failed")
 		}
@@ -92,7 +92,7 @@ func (suite *fsTestSuite) TestFSList() {
 	// ID would normally be set when listing FS within the parent instance.
 	fs.SetTestID("/instance/fs")
 
-	entry := suite.find(fs, "var/log").(plugin.Group)
+	entry := suite.find(fs, "var/log").(plugin.Parent)
 	entries, err := entry.List(context.Background())
 	if !suite.NoError(err) {
 		suite.FailNow("Listing entries failed")
@@ -103,13 +103,13 @@ func (suite *fsTestSuite) TestFSList() {
 	suite.Equal("path1", plugin.Name(entries[1]))
 	suite.Equal("path2", plugin.Name(entries[2]))
 	for _, entry := range entries {
-		_, ok := entry.(plugin.Group)
+		_, ok := entry.(plugin.Parent)
 		if !suite.True(ok) {
 			suite.FailNow("Entry was not a Group")
 		}
 	}
 
-	entries1, err := entries[1].(plugin.Group).List(context.Background())
+	entries1, err := entries[1].(plugin.Parent).List(context.Background())
 	if suite.NoError(err) {
 		suite.Equal(1, len(entries1))
 		suite.Equal("a file", plugin.Name(entries1[0]))
@@ -117,11 +117,11 @@ func (suite *fsTestSuite) TestFSList() {
 		suite.True(ok)
 	}
 
-	entries2, err := entries[2].(plugin.Group).List(context.Background())
+	entries2, err := entries[2].(plugin.Parent).List(context.Background())
 	if suite.NoError(err) {
 		suite.Equal(1, len(entries2))
 		suite.Equal("dir", plugin.Name(entries2[0]))
-		_, ok := entries2[0].(plugin.Group)
+		_, ok := entries2[0].(plugin.Parent)
 		suite.True(ok)
 	}
 }


### PR DESCRIPTION
Latter's more general and is consistent with how we've been thinking
about "Group" entries throughout the code.

Signed-off-by: Enis Inan <enis.inan@puppet.com>

Contributions to this project require sign-off consistent with the [Developers Certificate of Origin](https://developercertificate.org). This can be as simple as using `git commit -s` on each commit.