### PR TITLE
Add .gitattributes file with github-linguist overrides

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+docs/* linguist-documentation
+website/* linguist-documentation


### PR DESCRIPTION
Prior to this commit, github-linguist detects the repository language as
HTML. This commit adds a .gitattributes file with overrides for the
repository's top-level `docs` and `website` directories, so
github-linguist appropriately detects the language (as go).

Signed-off-by: Geoff Nichols <geoff.nichols@puppet.com>

Contributions to this project require sign-off consistent with the [Developers Certificate of Origin](https://developercertificate.org). This can be as simple as using `git commit -s` on each commit.