### PR TITLE
Tighten up wording and formatting

### DIFF
--- a/cmd/clear.go
+++ b/cmd/clear.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	"github.com/puppetlabs/wash/api/client"
-	cmdutil "github.com/puppetlabs/wash/cmd/util"
 	"github.com/puppetlabs/wash/cmd/internal/config"
+	cmdutil "github.com/puppetlabs/wash/cmd/util"
 	"github.com/spf13/cobra"
 )
 
@@ -13,7 +13,7 @@ func clearCommand() *cobra.Command {
 	clearCmd := &cobra.Command{
 		Use:     "clear [<path>]",
 		Aliases: []string{"wclear"},
-		Short:   "Clears the cache at <path>, or the current directory if not specified",
+		Short:   "Clears the cache at <path>, or current directory if not specified",
 		Long: `Wash caches most operations. If the resource you're querying appears out-of-date, use this
 subcommand to reset the cache for resources at or contained within <path>. Defaults to the current
 directory if <path> is not specified.`,

--- a/cmd/ps.go
+++ b/cmd/ps.go
@@ -13,14 +13,14 @@ import (
 
 	"github.com/puppetlabs/wash/api/client"
 	apitypes "github.com/puppetlabs/wash/api/types"
-	cmdutil "github.com/puppetlabs/wash/cmd/util"
 	"github.com/puppetlabs/wash/cmd/internal/config"
+	cmdutil "github.com/puppetlabs/wash/cmd/util"
 )
 
 func psCommand() *cobra.Command {
 	psCmd := &cobra.Command{
 		Use:   "ps [<node>...]",
-		Short: "Lists the processes running on the indicated compute instances.",
+		Short: "Lists the processes running on the indicated compute instances",
 		Long: `Captures /proc/*/{cmdline,stat,statm} on each node by executing 'cat' on them. Collects the output
 to display running processes on all listed nodes. Errors on paths that don't implement exec.`,
 		RunE: toRunE(psMain),

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -41,8 +41,8 @@ func rootCommand() *cobra.Command {
 		Use:    "wash",
 		PreRun: bindServerArgs,
 		RunE:   toRunE(rootMain),
-		Long: `When invoked without arguments, enters a Wash shell. This starts the Wash daemon, then enters your
-current system shell with shortcuts configured for wash subcommands.`,
+		Long: `When invoked without arguments, enters a Wash shell. Starts the Wash daemon,
+then starts your system shell with shortcuts configured for wash subcommands.`,
 		// Need to set these so that Cobra will not output the usage +
 		// error object when Execute() returns an error, which will always
 		// happen in our case because the exitCode object is technically

--- a/cmd/rootMain.go
+++ b/cmd/rootMain.go
@@ -134,8 +134,9 @@ func rootMain(cmd *cobra.Command, args []string) exitCode {
 	}
 
 	fmt.Println(`Welcome to Wash!
-  Wash includes several built-in commands: wclear, wexec, find, list, meta, tail. Try 'help'.
-  Commands run with wash can be seen via 'whistory', and logs for those commands with 'whistory <id>'.`)
+  Wash includes several built-in commands: wexec, find, list, meta, tail.
+  See commands run with wash via 'whistory', and logs with 'whistory <id>'.
+Try 'help'`)
 
 	exit := runShell(cachedir, mountpath)
 

--- a/cmd/tail.go
+++ b/cmd/tail.go
@@ -12,15 +12,15 @@ import (
 	"github.com/hpcloud/tail"
 	"github.com/puppetlabs/wash/api/client"
 	apitypes "github.com/puppetlabs/wash/api/types"
-	cmdutil "github.com/puppetlabs/wash/cmd/util"
 	"github.com/puppetlabs/wash/cmd/internal/config"
+	cmdutil "github.com/puppetlabs/wash/cmd/util"
 	"github.com/spf13/cobra"
 )
 
 func tailCommand() *cobra.Command {
 	tailCmd := &cobra.Command{
 		Use:   "tail -f [<file>...]",
-		Short: "Displays new output of files or resources that support the stream action",
+		Short: "Displays new output of files or resources with the stream action",
 		Long: `Output any new updates to files and/or resources (that support the stream action). Currently
 requires the '-f' option to run. Attempts to mimic the functionality of 'tail -f' for remote logs.`,
 		RunE: toRunE(tailMain),


### PR DESCRIPTION
Attempt to shorten descriptions and sentences to fit better in an
80-character terminal and to use fewer lines. Makes the initial
experience prettier.

Signed-off-by: Michael Smith <michael.smith@puppet.com>