### PR TITLE
Fix FUSE, fallback to tail, and add '-c' argument for shell

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -53,6 +53,8 @@ then starts your system shell with shortcuts configured for wash subcommands.`,
 		Version:       version,
 	}
 	addServerArgs(rootCmd, "warn")
+	// rootCommandFlag is used in rootMain.go.
+	rootCmd.Flags().StringVarP(&rootCommandFlag, "command", "c", "", "Run the supplied string and exit")
 
 	rootCmd.AddCommand(versionCommand())
 	rootCmd.AddCommand(serverCommand())

--- a/cmd/rootMain.go
+++ b/cmd/rootMain.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"github.com/mattn/go-isatty"
 	"github.com/puppetlabs/wash/cmd/internal/server"
@@ -13,6 +14,9 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
+
+// rootCommandFlag is associated with the `-c` option of the root command, set in root.go.
+var rootCommandFlag string
 
 // Create an executable file at the given path that invokes the given wash subcommand.
 func writeAlias(path, subcommand string) error {
@@ -81,6 +85,8 @@ func runShell(rundir, mountpath, socketpath, execfile string) exitCode {
 		}
 		comm.Stdin = file
 		defer file.Close()
+	} else if rootCommandFlag != "" {
+		comm.Stdin = strings.NewReader(rootCommandFlag)
 	} else {
 		comm.Stdin = os.Stdin
 	}
@@ -155,7 +161,7 @@ func rootMain(cmd *cobra.Command, args []string) exitCode {
 		execfile = args[0]
 	}
 
-	if execfile == "" && isInteractive() {
+	if isInteractive(execfile) {
 		fmt.Println(`Welcome to Wash!
   Wash includes several built-in commands: wexec, find, list, meta, tail.
   See commands run with wash via 'whistory', and logs with 'whistory <id>'.
@@ -165,14 +171,15 @@ Try 'help'`)
 	exit := runShell(rundir, mountpath, socketpath, execfile)
 
 	srv.Stop()
-	if execfile == "" && isInteractive() {
+	if isInteractive(execfile) {
 		fmt.Println("Goodbye!")
 	}
 	return exit
 }
 
 // Returns true if both input and output are interactive.
-func isInteractive() bool {
-	return (isatty.IsTerminal(os.Stdin.Fd()) || isatty.IsCygwinTerminal(os.Stdin.Fd())) &&
+func isInteractive(execfile string) bool {
+	return execfile == "" && rootCommandFlag == "" &&
+		(isatty.IsTerminal(os.Stdin.Fd()) || isatty.IsCygwinTerminal(os.Stdin.Fd())) &&
 		(isatty.IsTerminal(os.Stdout.Fd()) || isatty.IsCygwinTerminal(os.Stdout.Fd()))
 }


### PR DESCRIPTION
Fix an issue with OSXFUSE where the mountpoint doesn't correctly unmount introduced by #303. Also make FUSE server shutdown more deterministic to avoid shutdown races.

Defer to `/usr/bin/tail` for plain `tail` calls to make it more useful.

Add `-c` argument for Wash shell, primarily for debugging.