### PR TITLE
Panic if EntrySchema#Label is not provided

### DIFF
--- a/cmd/stree.go
+++ b/cmd/stree.go
@@ -43,9 +43,6 @@ func streeMain(cmd *cobra.Command, args []string) exitCode {
 
 func fill(stree treeprint.Tree, schema apitypes.EntrySchema) treeprint.Tree {
 	value := schema.Label
-	if len(value) == 0 {
-		value = schema.Type
-	}
 	if !schema.Singleton {
 		value = fmt.Sprintf("[%v]", value)
 	}

--- a/plugin/registry.go
+++ b/plugin/registry.go
@@ -12,8 +12,8 @@ import (
 // Registry represents the plugin registry. It is also Wash's root.
 type Registry struct {
 	EntryBase
-	plugins           map[string]Root
-	pluginRoots       []Entry
+	plugins     map[string]Root
+	pluginRoots []Entry
 }
 
 // NewRegistry creates a new plugin registry object
@@ -23,6 +23,7 @@ func NewRegistry() *Registry {
 		plugins:   make(map[string]Root),
 	}
 	r.SetName("/")
+	r.SetLabel("mountpoint")
 	r.setID("/")
 	r.DisableDefaultCaching()
 

--- a/plugin/schema.go
+++ b/plugin/schema.go
@@ -1,6 +1,7 @@
 package plugin
 
 import (
+	"fmt"
 	"reflect"
 	"strings"
 )
@@ -58,6 +59,10 @@ func schema(e Entry, includeChildren bool) EntrySchema {
 		Singleton: e.entryBase().isSingleton,
 		Actions:   SupportedActionsOf(e),
 		entry:     e,
+	}
+	if len(s.Label) == 0 {
+		msg := fmt.Sprintf("Schema for type %v has an empty label. Use EntryBase#SetLabel to set the label.", s.Type)
+		panic(msg)
 	}
 	if includeChildren {
 		s.fillChildren(make(map[string]bool))


### PR DESCRIPTION
The Label's useful for stree. We previously defaulted to printing the
fully qualified type if Label was not provided, but there was no good
reason to do this.

Signed-off-by: Enis Inan <enis.inan@puppet.com>

Contributions to this project require sign-off consistent with the [Developers Certificate of Origin](https://developercertificate.org). This can be as simple as using `git commit -s` on each commit.