### PR TITLE
Bug fix setting ec2 User. Extend Identity type

### DIFF
--- a/plugin/aws/ec2Instance.go
+++ b/plugin/aws/ec2Instance.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"sync"
 	"time"
+	"os"
+	"path/filepath"
 
 	awsSDK "github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -219,7 +221,11 @@ func (inst *ec2Instance) Exec(ctx context.Context, cmd string, args []string, op
 
 	var identityfile string
 	if name, ok := meta["KeyName"]; ok {
-		identityfile = ("~/.ssh/" + name.(string) + ".pem")
+		homedir, err := os.UserHomeDir()
+		if err != nil {
+			return nil, err
+		}
+		identityfile = (filepath.Join(homedir, ".ssh", (name.(string) + ".pem")))
 	} else {
 		return nil, fmt.Errorf("No key name found for %v", inst)
 	}

--- a/plugin/aws/ec2Instance.go
+++ b/plugin/aws/ec2Instance.go
@@ -217,7 +217,13 @@ func (inst *ec2Instance) Exec(ctx context.Context, cmd string, args []string, op
 		return nil, fmt.Errorf("No public interface found for %v", inst)
 	}
 
+	var identityfile string
+	if name, ok := meta["KeyName"]; ok {
+		identityfile = ("~/.ssh/" + name.(string) + ".pem")
+	} else {
+		return nil, fmt.Errorf("No key name found for %v", inst)
+	}
 	// Use the default user for Amazon AMIs. See above for ideas on making this more general. Can be
 	// overridden in ~/.ssh/config.
-	return transport.ExecSSH(ctx, transport.Identity{Host: hostname, User: "ec2-user"}, append([]string{cmd}, args...), opts)
+	return transport.ExecSSH(ctx, transport.Identity{Host: hostname, FallbackUser: "ec2-user", IdentityFile: identityfile}, append([]string{cmd}, args...), opts)
 }

--- a/plugin/aws/ec2Instance.go
+++ b/plugin/aws/ec2Instance.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/session"
 	ec2Client "github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/puppetlabs/wash/activity"
 	"github.com/puppetlabs/wash/plugin"
 	"github.com/puppetlabs/wash/transport"
 	"github.com/puppetlabs/wash/volume"
@@ -207,7 +208,7 @@ func (inst *ec2Instance) Exec(ctx context.Context, cmd string, args []string, op
 		return nil, err
 	}
 
-	// TODO: scrape default user and authorized keys from console output. Probably only works for Amazon AMIs.
+	// TODO: scrape default user from console output.
 	// See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/connection-prereqs.html#connection-prereqs-fingerprint
 	// for some helpful defaults we could add.
 	var hostname string
@@ -220,14 +221,17 @@ func (inst *ec2Instance) Exec(ctx context.Context, cmd string, args []string, op
 	}
 
 	var identityfile string
-	if name, ok := meta["KeyName"]; ok {
-		homedir, err := os.UserHomeDir()
+	if keyname, ok := meta["KeyName"]; ok {
 		if err != nil {
-			return nil, err
+			activity.Record(ctx, "No key name found: %v but continuing anyway", err)
+		} else {
+			homedir, err := os.UserHomeDir()
+			if err != nil {
+				activity.Record(ctx, "Cannot determine home directory for location of key file. But key name is " + keyname.(string) + " %v", err)
+			} else {
+				identityfile = (filepath.Join(homedir, ".ssh", (keyname.(string) + ".pem")))
+			}
 		}
-		identityfile = (filepath.Join(homedir, ".ssh", (name.(string) + ".pem")))
-	} else {
-		return nil, fmt.Errorf("No key name found for %v", inst)
 	}
 	// Use the default user for Amazon AMIs. See above for ideas on making this more general. Can be
 	// overridden in ~/.ssh/config.

--- a/transport/ssh.go
+++ b/transport/ssh.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"io/ioutil"
 	"time"
 
 	"github.com/kballard/go-shellquote"
@@ -64,9 +65,23 @@ func sshConnect(host, port, user string, identityfile string, strictHostKeyCheck
 			}
 		}
 
+		var authmethod []ssh.AuthMethod
+		if key, err := ioutil.ReadFile(identityfile); err != nil {
+			return nil, fmt.Errorf("Unable to read private key, falling back to SSH agent: %v", err)
+			// activity.Record(ctx, "Unable to read private key, falling back to SSH agent: %v", err)
+		} else {
+			if signer, err := ssh.ParsePrivateKey(key); err != nil {
+				return nil, fmt.Errorf("Unable to parse private key, falling back to SSH agent: %v", err)
+				// activity.Record("Unable to parse private key, falling back to SSH agent: %v", err)
+			} else {
+				authmethod = append(authmethod, ssh.PublicKeys(signer))
+			}
+		}
+		// Append agent now so that it comes last in case we find another method to try.
+		authmethod = append(authmethod, agent)
 		sshConfig := &ssh.ClientConfig{
 			User:            user,
-			Auth:            []ssh.AuthMethod{agent},
+			Auth:            authmethod,
 			HostKeyCallback: hostKeyCallback,
 		}
 


### PR DESCRIPTION
Fixes a bug where setting User in .ssh/config wasn't working. 

Also extends the Identity type in transport/ssh.go. Currently, when using 'wash exec' on an ec2 instance, the hostname is derived automatically because it can be fetched from the instance metadata. Similarly, with these changes, the user often isn't required to define IdentityFile or User in ~/.ssh/config. The new fields in the Identity type are:

- IdentityFile. The ssh key name is fetched from metadata and appended to make an educated guess that the user's private key is ~/.ssh/keyname.pem

- FallbackUser, currently hardcoded to be the default user for Amazon Linux AMI instances, "ec2-user". (A further enhancement is planned to scrape the default user name from console output -- eg "centos" or "ubuntu" -- and use that for FallbackUser.)

Signed-off-by: Eric Boutilier <eric.boutilier@puppet.com>

Contributions to this project require sign-off consistent with the [Developers Certificate of Origin](https://developercertificate.org). This can be as simple as using `git commit -s` on each commit.