### PR TITLE
Update help to match environment when running in wash shell

### DIFF
--- a/cmd/clear.go
+++ b/cmd/clear.go
@@ -1,14 +1,19 @@
 package cmd
 
 import (
+	"github.com/puppetlabs/wash/cmd/internal/config"
 	cmdutil "github.com/puppetlabs/wash/cmd/util"
 	"github.com/spf13/cobra"
 )
 
 func clearCommand() *cobra.Command {
+	use, aliases := "clear", []string{"wclear"}
+	if config.Embedded {
+		use, aliases = "wclear", []string{}
+	}
 	clearCmd := &cobra.Command{
-		Use:     "clear [<path>]",
-		Aliases: []string{"wclear"},
+		Use:     use + " [<path>]",
+		Aliases: aliases,
 		Short:   "Clears the cache at <path>, or current directory if not specified",
 		Long: `Wash caches most operations. If the resource you're querying appears out-of-date, use this
 subcommand to reset the cache for resources at or contained within <path>. Defaults to the current

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -2,15 +2,21 @@ package cmd
 
 import (
 	"fmt"
+
 	apitypes "github.com/puppetlabs/wash/api/types"
+	"github.com/puppetlabs/wash/cmd/internal/config"
 	cmdutil "github.com/puppetlabs/wash/cmd/util"
 	"github.com/spf13/cobra"
 )
 
 func execCommand() *cobra.Command {
+	use, aliases := "exec", []string{"wexec"}
+	if config.Embedded {
+		use, aliases = "wexec", []string{}
+	}
 	execCmd := &cobra.Command{
-		Use:     "exec <path> <command> [<arg>...]",
-		Aliases: []string{"wexec"},
+		Use:     use + " <path> <command> [<arg>...]",
+		Aliases: aliases,
 		Short:   "Executes the given command on the indicated target",
 		Long: `For a Wash resource (specified by <path>) that implements the ability to execute a command, run the
 specified command and arguments. The results will be forwarded from the target on stdout, stderr,

--- a/cmd/history.go
+++ b/cmd/history.go
@@ -9,14 +9,19 @@ import (
 
 	"github.com/Benchkram/errz"
 	"github.com/kr/logfmt"
+	"github.com/puppetlabs/wash/cmd/internal/config"
 	cmdutil "github.com/puppetlabs/wash/cmd/util"
 	"github.com/spf13/cobra"
 )
 
 func historyCommand() *cobra.Command {
+	use, aliases := "history", []string{"whistory"}
+	if config.Embedded {
+		use, aliases = "whistory", []string{}
+	}
 	historyCmd := &cobra.Command{
-		Use:     "history [-f] [<id>]",
-		Aliases: []string{"whistory"},
+		Use:     use + " [-f] [<id>]",
+		Aliases: aliases,
 		Short:   "Prints the wash command history, or journal of a particular item",
 		Long: `Wash maintains a history of commands executed through it. Print that command history, or specify an
 <id> to print a log of activity related to a particular command.`,

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -1,14 +1,19 @@
 package cmd
 
 import (
+	"github.com/puppetlabs/wash/cmd/internal/config"
 	cmdutil "github.com/puppetlabs/wash/cmd/util"
 	"github.com/spf13/cobra"
 )
 
 func infoCommand() *cobra.Command {
+	use, aliases := "info", []string{"winfo"}
+	if config.Embedded {
+		use, aliases = "winfo", []string{}
+	}
 	infoCmd := &cobra.Command{
-		Use:     "info <path>",
-		Aliases: []string{"winfo"},
+		Use:     use + " <path>",
+		Aliases: aliases,
 		Short:   "Prints the entry's info at the specified path",
 		Long:    `Print all info Wash has about the specified path, including filesystem attributes and metadata.`,
 		Args:    cobra.ExactArgs(1),

--- a/cmd/internal/config/core.go
+++ b/cmd/internal/config/core.go
@@ -15,12 +15,14 @@ import (
 
 // Contains all the keys for Wash's shared config
 const (
-	SocketKey = "socket"
+	SocketKey   = "socket"
+	EmbeddedKey = "embedded"
 )
 
 // Socket is the path to the Wash server's UNIX
 // socket
 var Socket string
+var Embedded bool
 
 // Init initializes the config package. It loads Wash's defaults and
 // sets up viper
@@ -48,6 +50,7 @@ func Init() error {
 
 	// Load the shared config
 	Socket = viper.GetString(SocketKey)
+	Embedded = viper.GetBool(EmbeddedKey)
 
 	return nil
 }

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -7,14 +7,19 @@ import (
 	"github.com/spf13/cobra"
 
 	apitypes "github.com/puppetlabs/wash/api/types"
+	"github.com/puppetlabs/wash/cmd/internal/config"
 	cmdutil "github.com/puppetlabs/wash/cmd/util"
 	"github.com/puppetlabs/wash/plugin"
 )
 
 func listCommand() *cobra.Command {
+	aliases := []string{}
+	if !config.Embedded {
+		aliases = []string{"ls"}
+	}
 	listCmd := &cobra.Command{
 		Use:     "list [<file>]",
-		Aliases: []string{"ls"},
+		Aliases: aliases,
 		Short:   "Lists the resources at the indicated path",
 		Args:    cobra.MaximumNArgs(1),
 		RunE:    toRunE(listMain),

--- a/cmd/rootMain.go
+++ b/cmd/rootMain.go
@@ -23,7 +23,7 @@ func writeAlias(path, subcommand string) error {
 	if err != nil {
 		return err
 	}
-	_, err = f.WriteString("#!/bin/sh\nexec wash " + subcommand + " \"$@\"")
+	_, err = f.WriteString("#!/bin/sh\nWASH_EMBEDDED=1 exec wash " + subcommand + " \"$@\"")
 	f.Close()
 	return err
 }


### PR DESCRIPTION
When running in the `wash` shell, we alias several commands so they
don't override common shell builtins. However the `help` text wasn't
updated to reflect this, which can lead to unexpected errors like trying
to run `exec` and having it overwrite the shell process rather than
invoke a command on the target.

Update help output for aliased commands when run from within the shell
to refer to only command names that are setup in the shell.

Fixes #329.

Signed-off-by: Michael Smith <michael.smith@puppet.com>