### PR TITLE
Fix aliased commands in wash shell

### DIFF
--- a/cmd/rootMain.go
+++ b/cmd/rootMain.go
@@ -72,8 +72,8 @@ func runShell(subcommands []*cobra.Command, rundir, mountpath, socketpath, execf
 		}
 
 		for _, alias := range aliases {
-			if err := writeAlias(filepath.Join(rundir, alias), name); err != nil {
-				cmdutil.ErrPrintf("Error creating alias %v for subcommand %v: %v\n", name, subcommand, err)
+			if err := writeAlias(filepath.Join(rundir, alias), alias); err != nil {
+				cmdutil.ErrPrintf("Error creating alias %v for subcommand %v: %v\n", alias, subcommand, err)
 				return exitCode{1}
 			}
 		}


### PR DESCRIPTION
Commands that are renamed to avoid colliding with builtins also have the
original names omitted when run in the wash shell. This is so their help
output is consistent within the shell. However that results in the
commands now erroring because the original command name is unknown.

Since the commands are renamed so they display correctly in help, have
the executable wrappers call to the changed name.

Signed-off-by: Michael Smith <michael.smith@puppet.com>