### PR TITLE
Fail CI if the website has not been rebuilt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,9 @@ jobs:
     before_script:
     - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.15.0
     script: golangci-lint run -v
+  - name: Test website updated
+    install: curl -sfL https://github.com/gohugoio/hugo/releases/download/v0.55.6/hugo_0.55.6_Linux-64bit.tar.gz | tar -xzC $(go env GOPATH)/bin
+    script: rm -r docs && hugo -s website && test -z "$(git status --porcelain)"
   - stage: deploy
     name: Deploy to GitHub Releases
     if: tag IS present


### PR DESCRIPTION
Detect when the website needs a rebuild via `hugo -s website` and fail
the build. Also fail if the website needs a clean rebuild because some
contents was removed.

Signed-off-by: Michael Smith <michael.smith@puppet.com>