### PR TITLE
Resolve Issue #348: Scrape user name from the ec2 console output

### DIFF
--- a/plugin/aws/ec2Instance.go
+++ b/plugin/aws/ec2Instance.go
@@ -69,7 +69,13 @@ func newEC2Instance(ctx context.Context, inst *ec2Client.Instance, session *sess
 }
 
 func (inst *ec2Instance) cachedConsoleOutput(ctx context.Context, latest bool) (consoleOutput, error) {
-	output, err := plugin.CachedOp(ctx, "ConsoleOutput", inst, 30*time.Second, func() (interface{}, error) {
+	var opname string
+	if latest {
+		opname = "ConsoleOutputLatest"
+	} else {
+		opname = "ConsoleOutput"
+	}
+	output, err := plugin.CachedOp(ctx, opname, inst, 30*time.Second, func() (interface{}, error) {
 		request := &ec2Client.GetConsoleOutputInput{
 			InstanceId: awsSDK.String(inst.id),
 		}

--- a/plugin/aws/ec2Instance.go
+++ b/plugin/aws/ec2Instance.go
@@ -132,9 +132,13 @@ func (inst *ec2Instance) List(ctx context.Context) ([]plugin.Entry, error) {
 
 	consoleOutput, err := newEC2InstanceConsoleOutput(ctx, inst, false)
 	if err != nil {
-		return nil, err
+			return nil, err
 	}
 	entries = append(entries, consoleOutput)
+
+	// output, err := consoleOutput.cachedConsoleOutput(ctx)
+	output, err := inst.cachedConsoleOutput(ctx)
+	fmt.Println(string(output.content))
 
 	if inst.hasLatestConsoleOutput {
 		if latestConsoleOutput == nil {

--- a/plugin/aws/ec2Instance.go
+++ b/plugin/aws/ec2Instance.go
@@ -133,9 +133,10 @@ func (inst *ec2Instance) List(ctx context.Context) ([]plugin.Entry, error) {
 
 	consoleOutput, err := newEC2InstanceConsoleOutput(ctx, inst, false)
 	if err != nil {
-			return nil, err
+		return nil, err
 	}
 	entries = append(entries, consoleOutput)
+
 	if inst.hasLatestConsoleOutput {
 		if latestConsoleOutput == nil {
 			latestConsoleOutput, err = newEC2InstanceConsoleOutput(ctx, inst, true)
@@ -212,6 +213,7 @@ func (inst *ec2Instance) Exec(ctx context.Context, cmd string, args []string, op
 	} else {
 		return nil, fmt.Errorf("No public interface found for %v", inst)
 	}
+
 	var identityfile string
 	if keyname, ok := meta["KeyName"]; ok {
 		if homedir, err := os.UserHomeDir(); err != nil {

--- a/plugin/aws/ec2InstanceConsoleOutput.go
+++ b/plugin/aws/ec2InstanceConsoleOutput.go
@@ -27,7 +27,7 @@ func newEC2InstanceConsoleOutput(ctx context.Context, inst *ec2Instance, latest 
 		cl.EntryBase = plugin.NewEntry("console.out")
 	}
 
-	output, err := cl.inst.cachedConsoleOutput(ctx)
+	output, err := cl.inst.cachedConsoleOutput(ctx, cl.latest)
 	if err != nil {
 		return nil, err
 	}
@@ -52,7 +52,7 @@ func (cl *ec2InstanceConsoleOutput) Schema() *plugin.EntrySchema {
 }
 
 func (cl *ec2InstanceConsoleOutput) Open(ctx context.Context) (plugin.SizedReader, error) {
-	output, err := cl.inst.cachedConsoleOutput(ctx)
+	output, err := cl.inst.cachedConsoleOutput(ctx, cl.latest)
 	if err != nil {
 		return nil, err
 	}

--- a/plugin/aws/ec2InstanceConsoleOutput.go
+++ b/plugin/aws/ec2InstanceConsoleOutput.go
@@ -55,12 +55,10 @@ func (inst *ec2Instance) cachedConsoleOutput(ctx context.Context) (consoleOutput
 		request := &ec2Client.GetConsoleOutputInput{
 			InstanceId: awsSDK.String(inst.id),
 		}
-//		if cl.latest {
 		if inst.hasLatestConsoleOutput {
 			request.Latest = awsSDK.Bool(inst.hasLatestConsoleOutput)
 		}
 
-//		resp, err := cl.inst.client.GetConsoleOutputWithContext(ctx, request)
 		resp, err := inst.client.GetConsoleOutputWithContext(ctx, request)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Scan console output for the user name that the ec2 instance was provisioned with. if none is found, set it to a best guess, "ec2-user".
 
A change to the method cachedConsoleOutput was also needed... Makes it a function of ec2Instance instead of ec2InstanceConsoleOutput.