### PR TITLE
Fix file representation in volumes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,13 @@ env:
 jobs:
   include:
   - name: Test Go stable
+  - name: Test Docker plugin
+    before_script:
+    - go install
+    - docker pull busybox
+    - docker-compose -f examples/swarm/docker-compose.yml up -d
+    script:
+    - wash validate docker
   - name: Lint with golangci-lint
     before_script:
     - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.15.0

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -165,17 +165,20 @@ func validateMain(cmd *cobra.Command, args []string) exitCode {
 	return exitCode{0}
 }
 
-// If the entry has a schema providing a TypeID, use it to help further distinguish between
-// different things that behave the same.
+// If the entry has a schema, use it to help further distinguish between different things that
+// behave the same.
 type criteria struct {
-	typeID                   string
+	label, typeID            string
 	list, read, stream, exec bool
+	singleton                bool
 }
 
 func newCriteria(entry plugin.Entry) criteria {
 	var crit criteria
 	if schema := entry.Schema(); schema != nil {
+		crit.label = schema.Label
 		crit.typeID = schema.TypeID
+		crit.singleton = schema.Singleton
 	}
 	crit.list = plugin.ListAction().IsSupportedOn(entry)
 	crit.read = plugin.ReadAction().IsSupportedOn(entry)
@@ -203,8 +206,12 @@ func (c criteria) String() string {
 	}
 
 	result := string(s)
-	if c.typeID != "" {
-		result = fmt.Sprintf("%s %-30s", result, "["+c.typeID+"]")
+	if c.label != "" {
+		label := c.label
+		if !c.singleton {
+			label = "[" + label + "]"
+		}
+		result = fmt.Sprintf("%s %-20s", result, label)
 	}
 	return result
 }

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -102,11 +102,17 @@ func validateMain(cmd *cobra.Command, args []string) exitCode {
 
 	rand.Seed(time.Now().UnixNano())
 	plugin.InitCache()
+	var wg sync.WaitGroup
+	wg.Add(2)
 
 	pw := progress.NewWriter()
 	pw.SetUpdateFrequency(50 * time.Millisecond)
 	pw.Style().Colors = progress.StyleColorsExample
-	go pw.Render()
+
+	go func() {
+		pw.Render()
+		wg.Done()
+	}()
 
 	// On Ctrl-C cancel the context to ensure plugin calls have a chance to cleanup.
 	sigCh := make(chan os.Signal, 1)
@@ -124,8 +130,6 @@ func validateMain(cmd *cobra.Command, args []string) exitCode {
 	// with a worker pool.
 	erred := 0
 	errs := make(chan error)
-	var wg sync.WaitGroup
-	wg.Add(1)
 	go func() {
 		for err := range errs {
 			erred++

--- a/fuse/core.go
+++ b/fuse/core.go
@@ -82,6 +82,11 @@ func (f *fuseNode) applyAttr(a *fuse.Attr, attr *plugin.EntryAttributes, isdir b
 
 	if attr.HasMode() {
 		a.Mode = attr.Mode()
+		// bazil/fuse appears to assume that character device implies device, and requires
+		// device to be flagged to set char device.
+		if a.Mode&os.ModeCharDevice == os.ModeCharDevice {
+			a.Mode |= os.ModeDevice
+		}
 	} else if isdir {
 		a.Mode = os.ModeDir | 0550
 	} else {

--- a/munge/mode.go
+++ b/munge/mode.go
@@ -39,6 +39,7 @@ func ToFileMode(mode interface{}) (os.FileMode, error) {
 		return 0, err
 	}
 	fileMode := os.FileMode(intMode & 0777)
+	// Mapping from http://man7.org/linux/man-pages/man7/inode.7.html for stat output
 	for bits, mod := range map[uint64]os.FileMode{
 		0140000: os.ModeSocket,
 		0120000: os.ModeSymlink,

--- a/munge/mode_test.go
+++ b/munge/mode_test.go
@@ -44,6 +44,7 @@ func (suite *ModeTestSuite) TestToFileMode() {
 		// 33188 is 0x81a4 in decimal
 		nTC("0x81a4", toFM(0644)),
 		nTC(float64(33188), toFM(0644)),
+		nTC("0x21b6", toFM(0666|os.ModeCharDevice)),
 	)
 }
 

--- a/plugin/entryAttributes_test.go
+++ b/plugin/entryAttributes_test.go
@@ -49,19 +49,19 @@ func (suite *EntryAttributesTestSuite) TestEntryAttributes() {
 	}
 	attr := EntryAttributes{}
 	attr.meta = JSONObject{}
-	expectedMp := make(map[string]interface{})
-	expectedMp["meta"] = JSONObject{}
 	doUnmarshalJSONTests := func() {
-		attrJSON, err := json.Marshal(expectedMp)
-		if err != nil {
-			panic("assertUnmarshalJSON: could not marshal expectedMp, which is a map[string]interface{} object")
-		}
+		attrJSON, err := json.Marshal(attr)
+		suite.NoError(err)
 		unmarshaledAttr := EntryAttributes{}
 		err = json.Unmarshal(attrJSON, &unmarshaledAttr)
 		if suite.NoError(err) {
 			suite.Equal(attr, unmarshaledAttr)
 		}
 	}
+
+	// ToMap - used for listing attributes - and JSON marshaling may have different representations.
+	expectedMp := make(map[string]interface{})
+	expectedMp["meta"] = JSONObject{}
 
 	// Tests for Atime
 	suite.Equal(false, attr.HasAtime())
@@ -99,9 +99,9 @@ func (suite *EntryAttributesTestSuite) TestEntryAttributes() {
 	// Tests for Mode
 	suite.Equal(false, attr.HasMode())
 	suite.Equal(expectedMp, attr.ToMap(true))
-	m := os.FileMode(0777)
+	m := os.FileMode(0777 | os.ModeCharDevice | os.ModeDir)
 	attr.SetMode(m)
-	expectedMp["mode"] = m
+	expectedMp["mode"] = m.String()
 	suite.Equal(m, attr.Mode())
 	suite.Equal(true, attr.HasMode())
 	suite.Equal(expectedMp, attr.ToMap(true))

--- a/volume/stat.go
+++ b/volume/stat.go
@@ -122,7 +122,8 @@ func StatParseAll(output io.Reader, base string, start string, maxdepth int) (Di
 	dirmap := DirMap{RootPath: make(Dir)}
 	for scanner.Scan() {
 		text := strings.TrimSpace(scanner.Text())
-		if text != "" {
+		// Skip error lines in case we're running in a tty.
+		if text != "" && !strings.HasPrefix(text, "stat:") && !strings.HasPrefix(text, "find:") {
 			attr, fullpath, err := StatParse(text)
 			if err != nil {
 				return nil, err

--- a/volume/stat.go
+++ b/volume/stat.go
@@ -27,8 +27,10 @@ func StatCmd(path string, maxdepth int) []string {
 	// %Z - Time of last status change as seconds since Epoch
 	// %f - Raw mode in hex
 	// %n - File name
-	return []string{"find", path, "-mindepth", "1", "-maxdepth", strconv.Itoa(maxdepth),
-		"-exec", "stat", "-c", "%s %X %Y %Z %f %n", "{}", "+"}
+	// TODO: fix as part of https://github.com/puppetlabs/wash/issues/378. We don't currently handle
+	// showing symbolic links, instead representing them as the resolved target.
+	return []string{"find", "-L", path, "-mindepth", "1", "-maxdepth", strconv.Itoa(maxdepth),
+		"-exec", "stat", "-L", "-c", "%s %X %Y %Z %f %n", "{}", "+"}
 }
 
 // Keep as its own specialized function as it will be faster than munge.ToTime.

--- a/volume/stat_test.go
+++ b/volume/stat_test.go
@@ -31,16 +31,16 @@ const fixture = `
 
 func TestStatCmd(t *testing.T) {
 	cmd := StatCmd("", 1)
-	assert.Equal(t, []string{"find", "/", "-mindepth", "1", "-maxdepth", "1",
-		"-exec", "stat", "-c", "%s %X %Y %Z %f %n", "{}", "+"}, cmd)
+	assert.Equal(t, []string{"find", "-L", "/", "-mindepth", "1", "-maxdepth", "1",
+		"-exec", "stat", "-L", "-c", "%s %X %Y %Z %f %n", "{}", "+"}, cmd)
 
 	cmd = StatCmd("/", 1)
-	assert.Equal(t, []string{"find", "/", "-mindepth", "1", "-maxdepth", "1",
-		"-exec", "stat", "-c", "%s %X %Y %Z %f %n", "{}", "+"}, cmd)
+	assert.Equal(t, []string{"find", "-L", "/", "-mindepth", "1", "-maxdepth", "1",
+		"-exec", "stat", "-L", "-c", "%s %X %Y %Z %f %n", "{}", "+"}, cmd)
 
 	cmd = StatCmd("/var/log", 5)
-	assert.Equal(t, []string{"find", "/var/log", "-mindepth", "1", "-maxdepth", "5",
-		"-exec", "stat", "-c", "%s %X %Y %Z %f %n", "{}", "+"}, cmd)
+	assert.Equal(t, []string{"find", "-L", "/var/log", "-mindepth", "1", "-maxdepth", "5",
+		"-exec", "stat", "-L", "-c", "%s %X %Y %Z %f %n", "{}", "+"}, cmd)
 }
 
 func TestStatParse(t *testing.T) {


### PR DESCRIPTION
Fix symlinks so we get something usable. For now that means following symlinks for find/stat. Filed #378 to add representation of symlinks.

Fix mode serialization so we get the correct mode from the API. What we get from serializing an Entry now differs from what we get when requesting attributes/metadata; each uses a format that's appropriate for the use case (attributes/metadata gets a stringified representation similar to what `ls` outputs, Entries use the raw os.FileMode data). Find/stat now use a Tty when Wash does to better reflect the output a user would get when in a shell on the system. Mode is now included in `list` output.

Fix a few issues from `wash validate`:
- switch from TypeID to Label so we display something more human-readable
- wait for the progress writer to finish rendering before exiting
- skip trying to read things that we shouldn't, such as those without read permission or that would block or return infinite data

Adds Travis CI testing that exercises `wash validate` by using it to validate the Docker plugin using our Docker Swarm example.

Fixes #376.