### PR TITLE
Make setting size optional

### DIFF
--- a/api/cache_test.go
+++ b/api/cache_test.go
@@ -29,6 +29,10 @@ func newMockCache() *mockCache {
 	return &mockCache{items: make(map[string]interface{})}
 }
 
+func (m *mockCache) Get(cat, key string) (interface{}, error) {
+	return nil, nil
+}
+
 func (m *mockCache) GetOrUpdate(cat, key string, ttl time.Duration, resetTTLOnHit bool, generateValue func() (interface{}, error)) (interface{}, error) {
 	key = cat + "::" + key
 	if v, ok := m.items[key]; ok {

--- a/datastore/cache_test.go
+++ b/datastore/cache_test.go
@@ -99,6 +99,28 @@ func (suite *MemCacheTestSuite) TestGetOrUpdateWithReset() {
 	suite.thing.AssertNumberOfCalls(suite.T(), "update", 2)
 }
 
+func (suite *MemCacheTestSuite) TestGet() {
+	val, err := suite.mem.Get("foo", "bar")
+	suite.Nil(val)
+	suite.Nil(err)
+
+	suite.mem.instance.Set("foo::bar", nil, time.Second)
+	val, err = suite.mem.Get("foo", "bar")
+	suite.Nil(val)
+	suite.Nil(err)
+
+	item := struct{}{}
+	suite.mem.instance.Set("foo::bar", item, time.Second)
+	val, err = suite.mem.Get("foo", "bar")
+	suite.NoError(err)
+	suite.Equal(item, val)
+
+	suite.mem.instance.Set("foo::bar", errors.New("an error"), time.Second)
+	val, err = suite.mem.Get("foo", "bar")
+	suite.Nil(val)
+	suite.EqualError(err, "an error")
+}
+
 func (suite *MemCacheTestSuite) TestFlush() {
 	suite.mem.instance.Set("an entry", struct{}{}, time.Nanosecond)
 	time.Sleep(time.Nanosecond)

--- a/docs/docs/index.html
+++ b/docs/docs/index.html
@@ -241,6 +241,8 @@ to display running processes on all listed nodes. Errors on paths that don&rsquo
 </ul></li>
 </ul>
 
+<p>For entries that can be <code>read</code>, provide the size if you know it; otherwise Wash will provide a functional default and update the size when the entry has been <code>read</code>. Note that <code>find -size</code> will not include files with unknown size.</p>
+
 <p>Actions can be invoked programmatically via the Wash API, or on the CLI via <code>wash</code> commands and filesystem interactions.</p>
 
 <p>For more on implementing plugins, see:</p>

--- a/fuse/core.go
+++ b/fuse/core.go
@@ -93,8 +93,13 @@ func (f *fuseNode) applyAttr(a *fuse.Attr, attr *plugin.EntryAttributes, isdir b
 		a.Mode = 0440
 	}
 
+	const blockSize = 4096
 	if attr.HasSize() {
 		a.Size = attr.Size()
+	} else {
+		// Default to the block size to encourage tools to read the file to determine its actual size.
+		// We don't know the size, and cat at least ignores a file with size 0.
+		a.Size = blockSize
 	}
 
 	a.Mtime = startTime
@@ -110,7 +115,7 @@ func (f *fuseNode) applyAttr(a *fuse.Attr, attr *plugin.EntryAttributes, isdir b
 		a.Ctime = attr.Ctime()
 	}
 	a.Crtime = startTime
-	a.BlockSize = 4096
+	a.BlockSize = blockSize
 	a.Uid = uid
 	a.Gid = gid
 }

--- a/plugin/aws/ec2Instance.go
+++ b/plugin/aws/ec2Instance.go
@@ -68,6 +68,11 @@ func newEC2Instance(ctx context.Context, inst *ec2Client.Instance, session *sess
 	return ec2Instance
 }
 
+type consoleOutput struct {
+	mtime   time.Time
+	content []byte
+}
+
 func (inst *ec2Instance) cachedConsoleOutput(ctx context.Context, latest bool) (consoleOutput, error) {
 	var opname string
 	if latest {

--- a/plugin/aws/ec2InstanceConsoleOutput.go
+++ b/plugin/aws/ec2InstanceConsoleOutput.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"bytes"
 	"context"
-	"time"
 
 	"github.com/puppetlabs/wash/plugin"
 )
@@ -40,11 +39,6 @@ func newEC2InstanceConsoleOutput(ctx context.Context, inst *ec2Instance, latest 
 		SetSize(uint64(len(output.content)))
 
 	return cl, nil
-}
-
-type consoleOutput struct {
-	mtime   time.Time
-	content []byte
 }
 
 func (cl *ec2InstanceConsoleOutput) Schema() *plugin.EntrySchema {

--- a/plugin/cache_test.go
+++ b/plugin/cache_test.go
@@ -16,6 +16,11 @@ type cacheTestsMockCache struct {
 	mock.Mock
 }
 
+func (m *cacheTestsMockCache) Get(cat, key string) (interface{}, error) {
+	args := m.Called(cat, key)
+	return args.Get(0), args.Error(1)
+}
+
 func (m *cacheTestsMockCache) GetOrUpdate(cat, key string, ttl time.Duration, resetTTLOnHit bool, generateValue func() (interface{}, error)) (interface{}, error) {
 	args := m.Called(cat, key, ttl, resetTTLOnHit, generateValue)
 	return args.Get(0), args.Error(1)

--- a/plugin/docker/container-metadata.go
+++ b/plugin/docker/container-metadata.go
@@ -17,7 +17,6 @@ func newContainerMetadata(container *container) *containerMetadata {
 	cm := &containerMetadata{
 		EntryBase: plugin.NewEntry("metadata.json"),
 	}
-	cm.DisableDefaultCaching()
 	cm.container = container
 	return cm
 }

--- a/plugin/docker/container.go
+++ b/plugin/docker/container.go
@@ -77,18 +77,7 @@ func (c *container) List(ctx context.Context) ([]plugin.Entry, error) {
 	// TODO: May be worth creating a helper that makes it easy to create
 	// read-only files. Lots of shared code between these two.
 	cm := newContainerMetadata(c)
-	content, err := cm.Open(ctx)
-	if err != nil {
-		return nil, err
-	}
-	cm.Attributes().SetSize(uint64(content.Size()))
-
 	clf := newContainerLogFile(c)
-	content, err = clf.Open(ctx)
-	if err != nil {
-		return nil, err
-	}
-	clf.Attributes().SetSize(uint64(content.Size()))
 
 	// Include a view of the remote filesystem using volume.FS. Use a small maxdepth because
 	// VMs can have lots of files and Exec is fast.

--- a/plugin/helpers.go
+++ b/plugin/helpers.go
@@ -77,9 +77,23 @@ func TrackTime(start time.Time, name string) {
 	log.Infof("%s took %s", name, elapsed)
 }
 
-// Attributes returns the entry's attribtues
+// Attributes returns the entry's attributes. If size is unknown, it will check whether the entry
+// has locally cached content and if so set that for the size.
 func Attributes(e Entry) EntryAttributes {
-	return e.attributes()
+	// Sometimes an entry doesn't know its size unless it's already downloaded some content. Having
+	// to download content makes list slow, and is a burden for external plugin developers. Check if
+	// we already know the size. If not, FUSE will use a reasonable default so tools don't ignore it.
+	attr := e.attributes()
+	if !attr.HasSize() && cache != nil {
+		// We have no way to preserve this on the entry, and it likely wouldn't help because we often
+		// recreate the entry to ensure we have an accurate representation. So when the cache expires
+		// we revert to stating the size is unknown until the next read operation.
+		if val, _ := cache.Get(defaultOpCodeToNameMap[OpenOp], e.id()); val != nil {
+			rdr := val.(SizedReader)
+			attr.SetSize(uint64(rdr.Size()))
+		}
+	}
+	return attr
 }
 
 // IsPrefetched returns whether an entry has data that was added during creation that it would

--- a/website/content/docs/_index.md
+++ b/website/content/docs/_index.md
@@ -161,6 +161,8 @@ Wash entries can support the following actions:
 * `exec` - lets you execute a command against an entry
   - _e.g. run a shell command inside a container, or on an EC2 vm, or on a routerOS device, etc._
 
+For entries that can be `read`, provide the size if you know it; otherwise Wash will provide a functional default and update the size when the entry has been `read`. Note that `find -size` will not include files with unknown size.
+
 Actions can be invoked programmatically via the Wash API, or on the CLI via `wash` commands and filesystem interactions.
 
 For more on implementing plugins, see:


### PR DESCRIPTION
Previously an entry that didn't set its size would default to 0. Many common CLI tools will ignore an empty file rather than try to open it. Update to use a default of 4k, and when cached content is available use that to give a more accurate size. This allows plugin writers to only set the size when they actually know it without downloading the content.

Resolves #355.