### PR TITLE
Use Query Get method

### DIFF
--- a/api/error.go
+++ b/api/error.go
@@ -147,13 +147,11 @@ func invalidBoolParam(name, value string) *errorResponse {
 	)}
 }
 
-func invalidPathsResponse(paths []string) *errorResponse {
+func invalidPathsResponse() *errorResponse {
 	return &errorResponse{http.StatusBadRequest, newErrorObj(
 		apitypes.InvalidPaths,
-		fmt.Sprintf("Request must include one 'path' query parameter, not %v", len(paths)),
-		apitypes.ErrorFields{
-			"paths": paths,
-		},
+		fmt.Sprintf("Request must include one 'path' query parameter"),
+		apitypes.ErrorFields{},
 	)}
 }
 
@@ -175,12 +173,12 @@ func erroredActionResponse(path string, a plugin.Action, reason string) *errorRe
 
 func duplicateCNameResponse(e plugin.DuplicateCNameErr) *errorResponse {
 	fields := apitypes.ErrorFields{
-		"parent_id":                           e.ParentID,
-		"first_child_name":                    e.FirstChildName,
-		"first_child_slash_replacer":          e.FirstChildSlashReplacer,
-		"second_child_name":                   e.SecondChildName,
-		"second_child_slash_replacer":         e.SecondChildSlashReplacer,
-		"cname":                               e.CName,
+		"parent_id":                   e.ParentID,
+		"first_child_name":            e.FirstChildName,
+		"first_child_slash_replacer":  e.FirstChildSlashReplacer,
+		"second_child_name":           e.SecondChildName,
+		"second_child_slash_replacer": e.SecondChildSlashReplacer,
+		"cname":                       e.CName,
 	}
 
 	body := newErrorObj(

--- a/api/helpers.go
+++ b/api/helpers.go
@@ -52,14 +52,9 @@ func findEntry(ctx context.Context, root plugin.Entry, segments []string) (plugi
 
 // Common helper to get path query param from request and validate it.
 func getPathFromRequest(r *http.Request) (string, *errorResponse) {
-	paths := r.URL.Query()["path"]
-	if len(paths) != 1 {
-		return "", invalidPathsResponse(paths)
-	}
-	path := paths[0]
-
+	path := r.URL.Query().Get("path")
 	if path == "" {
-		panic("path should never be empty")
+		return "", invalidPathsResponse()
 	}
 	if !filepath.IsAbs(path) {
 		return "", relativePathResponse(path)
@@ -148,17 +143,8 @@ func getEntryFromRequest(r *http.Request) (plugin.Entry, string, *errorResponse)
 	return entry, path, err
 }
 
-func getScalarParam(u *url.URL, key string) string {
-	vals := u.Query()[key]
-	if len(vals) > 0 {
-		// Take last value
-		return vals[len(vals)-1]
-	}
-	return ""
-}
-
 func getBoolParam(u *url.URL, key string) (bool, *errorResponse) {
-	val := getScalarParam(u, key)
+	val := u.Query().Get(key)
 	if val != "" {
 		b, err := strconv.ParseBool(val)
 		if err != nil {

--- a/api/helpers_test.go
+++ b/api/helpers_test.go
@@ -120,17 +120,6 @@ func (suite *HelpersTestSuite) TestGetEntryFromPath() {
 	plug.AssertExpectations(suite.T())
 }
 
-func (suite *HelpersTestSuite) TestGetScalarParam() {
-	var u url.URL
-	suite.Empty(getScalarParam(&u, "param"))
-
-	u.RawQuery = "param=hello"
-	suite.Equal("hello", getScalarParam(&u, "param"))
-
-	u.RawQuery = "param=hello&param=goodbye"
-	suite.Equal("goodbye", getScalarParam(&u, "param"))
-}
-
 func (suite *HelpersTestSuite) TestGetBoolParam() {
 	var u url.URL
 	for query, expect := range map[string]bool{"": false, "param=true": true, "param=false": false} {


### PR DESCRIPTION
When I wrote this I missed that there was already a method for
retrieving a single value for a query parameter. Use it instead of my
custom code.

Signed-off-by: Michael Smith <michael.smith@puppet.com>