### PR TITLE
Move CODEOWNERS to a more visible location and use team alias

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,0 @@
-*         @MikaelSmith @ekinanp
-website/* @grimradical

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+*         @puppetlabs/wash
+website/* @grimradical


### PR DESCRIPTION
Switches from direct reference of team members to the team
@puppetlabs/wash.

Signed-off-by: Michael Smith <michael.smith@puppet.com>