### PR TITLE
Link to external plugins hosted elsewhere

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -276,6 +276,15 @@ root</pre></td></tr></table>
 <li>users interact with external plugins the exact same way as core plugins; they are first-class citizens</li>
 </ul>
 
+<p>Several external plugins have already been created:</p>
+
+<ul>
+<li><a href="https://github.com/timidri/washhub">Washhub</a> - navigate all your GitHub repositories at once</li>
+<li><a href="https://github.com/MikaelSmith/washreads">Washreads</a> - view your Goodreads bookshelves; also structured as an introduction to writing external plugins</li>
+</ul>
+
+<p>If you&rsquo;ve created an external plugin, please put up a pull request to add it to this list!</p>
+
 <p>For more information about future direction, see our <a href="https://github.com/puppetlabs/wash#roadmap">Roadmap</a>!</p>
 
 <h2 id="contributing">Contributing</h2>

--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -165,6 +165,13 @@ We've implemented a number of handy Wash commands ([docs](/wash/docs#wash-comman
 * Wash handles the plugin life-cycle. it invokes your plugin with a certain calling convention; all you have to do is supply the business logic
 * users interact with external plugins the exact same way as core plugins; they are first-class citizens
 
+Several external plugins have already been created:
+
+* [Washhub](https://github.com/timidri/washhub) - navigate all your GitHub repositories at once
+* [Washreads](https://github.com/MikaelSmith/washreads) - view your Goodreads bookshelves; also structured as an introduction to writing external plugins
+
+If you've created an external plugin, please put up a pull request to add it to this list!
+
 For more information about future direction, see our [Roadmap](https://github.com/puppetlabs/wash#roadmap)!
 
 ## Contributing


### PR DESCRIPTION
Start a section that links to external plugins. There's no library of
them yet, so for now we'll just gather them here.

Signed-off-by: Michael Smith <michael.smith@puppet.com>