### PR TITLE
Fix CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,3 @@
 *         @puppetlabs/wash
-website/* @grimradical
+/docs/    @puppetlabs/wash @grimradical
+/website/ @puppetlabs/wash @grimradical


### PR DESCRIPTION
The previous file didn't match all files in the `/website` directory,
and may not have been specific enough that changes to both `/website`
and `/docs` should notify the website list. Try updating it, and include
@puppetlabs/wash in the website list.

Signed-off-by: Michael Smith <michael.smith@puppet.com>