### PR TITLE
Expose important errors more visibly

### DIFF
--- a/activity/helper_test.go
+++ b/activity/helper_test.go
@@ -16,5 +16,5 @@ func TestPIDToJournalEntry(t *testing.T) {
 	journal = JournalForPID(os.Getpid())
 	expected := strconv.Itoa(os.Getpid()) + "-activity\\.test-[0-9]+"
 	assert.Regexp(t, expected, journal.ID)
-	assert.Contains(t, journal.Description, "/activity.test -test.testlogfile=")
+	assert.Contains(t, journal.Description, "/activity.test")
 }

--- a/activity/journal_test.go
+++ b/activity/journal_test.go
@@ -3,6 +3,7 @@ package activity
 import (
 	"context"
 	"io/ioutil"
+	"regexp"
 	"testing"
 	"time"
 
@@ -46,13 +47,16 @@ func TestHistoryWithJournal(t *testing.T) {
 
 	// Log to a journal
 	journal := Journal{ID: "anything"}
-	Record(context.WithValue(context.Background(), JournalKey, journal), "hello there")
+	ctx := context.WithValue(context.Background(), JournalKey, journal)
+	Record(ctx, "hello there")
+	Warnf(ctx, "not good")
 	rdr, err := journal.Open()
 	if assert.Nil(t, err) {
 		defer rdr.Close()
 		bits, err := ioutil.ReadAll(rdr)
 		if assert.Nil(t, err) {
-			assert.Contains(t, string(bits), "hello there")
+			assert.Regexp(t, regexp.MustCompile("info.*hello there"), string(bits))
+			assert.Regexp(t, regexp.MustCompile("warn.*not good"), string(bits))
 		}
 	}
 }

--- a/api/server.go
+++ b/api/server.go
@@ -46,7 +46,7 @@ func (handle handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	activity.Record(r.Context(), "API: %v %v", r.Method, r.URL)
 
 	if err := handle(w, r); err != nil {
-		activity.Record(r.Context(), "API: %v %v: %v", r.Method, r.URL, err)
+		activity.Warnf(r.Context(), "API: %v %v: %v", r.Method, r.URL, err)
 		w.WriteHeader(err.statusCode)
 
 		// NOTE: Do not set these headers in the middleware because not

--- a/docs/docs/core_plugins/index.html
+++ b/docs/docs/core_plugins/index.html
@@ -55,7 +55,7 @@
 
 <p>Each entry that implements the <code>Parent</code> interface must provide a schema for its children.</p>
 
-<p>Use <a href="https://godoc.org/github.com/puppetlabs/wash/activity">activity.Record</a> for all plugin-related logging. Each plugin method that Wash calls is passed a <code>context.Context</code> object that is initialized with a Journal ID for use with <code>activity.Record</code>.</p>
+<p>Use <a href="https://godoc.org/github.com/puppetlabs/wash/activity">activity</a> for all plugin-related logging. Each plugin method that Wash calls is passed a <code>context.Context</code> object that is initialized with a Journal ID for use with <code>activity.Record</code> and <code>activity.Warnf</code>.</p>
 
 <p>TIP: The <a href="https://godoc.org/github.com/puppetlabs/wash/transport">transport</a> package contains useful helpers for common methods of executing commands on a remote system. Currently it only supports SSH.</p>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -93,6 +93,10 @@
 
 <h3 id="known-issues">Known issues</h3>
 
+<p>Wash uses your system shell to provide the shell environment. It determines this using the SHELL environment variable or falls back to <code>/bin/sh</code>, so if you&rsquo;d like to specify a particular shell set the SHELL environment variable before starting Wash.</p>
+
+<p>If Wash appears to hang, there&rsquo;s a good chance it&rsquo;s attempting to prompt for input while another command - such as <code>ls</code> - is running. You can usually get out of it by running <code>fg</code>, then hitting <code>&lt;Enter&gt;</code>. When starting Wash from the <code>fish</code> shell in particular, the prompt for input is often hidden.</p>
+
 <h4 id="on-macos">On macOS</h4>
 
 <p>If using iTerm2, we recommend installing <a href="https://www.iterm2.com/documentation-shell-integration.html">iTerm2&rsquo;s shell integration</a> to avoid <a href="https://github.com/puppetlabs/wash/issues/84">issue#84</a>.</p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -95,8 +95,6 @@
 
 <p>Wash uses your system shell to provide the shell environment. It determines this using the SHELL environment variable or falls back to <code>/bin/sh</code>, so if you&rsquo;d like to specify a particular shell set the SHELL environment variable before starting Wash.</p>
 
-<p>If Wash appears to hang, there&rsquo;s a good chance it&rsquo;s attempting to prompt for input while another command - such as <code>ls</code> - is running. You can usually get out of it by running <code>fg</code>, then hitting <code>&lt;Enter&gt;</code>. When starting Wash from the <code>fish</code> shell in particular, the prompt for input is often hidden.</p>
-
 <h4 id="on-macos">On macOS</h4>
 
 <p>If using iTerm2, we recommend installing <a href="https://www.iterm2.com/documentation-shell-integration.html">iTerm2&rsquo;s shell integration</a> to avoid <a href="https://github.com/puppetlabs/wash/issues/84">issue#84</a>.</p>

--- a/fuse/core.go
+++ b/fuse/core.go
@@ -156,7 +156,7 @@ func (f *fuseNode) Attr(ctx context.Context, a *fuse.Attr) error {
 	// parent to ensure it has updated attributes.
 	updatedEntry, err := f.refind(ctx)
 	if err != nil {
-		activity.Record(ctx, "FUSE: Attr errored %v, %v", f, err)
+		activity.Warnf(ctx, "FUSE: Attr errored %v, %v", f, err)
 		return err
 	}
 	attr := plugin.Attributes(updatedEntry)

--- a/fuse/dir.go
+++ b/fuse/dir.go
@@ -28,7 +28,7 @@ func (d *dir) children(ctx context.Context) (map[string]plugin.Entry, error) {
 	// Check for an updated entry in case it has static state.
 	updatedEntry, err := d.refind(ctx)
 	if err != nil {
-		activity.Record(ctx, "FUSE: List errored %v, %v", d, err)
+		activity.Warnf(ctx, "FUSE: List errored %v, %v", d, err)
 		return nil, err
 	}
 
@@ -48,7 +48,7 @@ func (d *dir) Lookup(ctx context.Context, req *fuse.LookupRequest, resp *fuse.Lo
 
 	entries, err := d.children(ctx)
 	if err != nil {
-		activity.Record(ctx, "FUSE: Find %v in %v errored: %v", req.Name, d, err)
+		activity.Warnf(ctx, "FUSE: Find %v in %v errored: %v", req.Name, d, err)
 		return nil, fuse.ENOENT
 	}
 
@@ -75,7 +75,7 @@ func (d *dir) ReadDirAll(ctx context.Context) ([]fuse.Dirent, error) {
 
 	entries, err := d.children(ctx)
 	if err != nil {
-		activity.Record(ctx, "FUSE: List %v errored: %v", d, err)
+		activity.Warnf(ctx, "FUSE: List %v errored: %v", d, err)
 		return nil, err
 	}
 

--- a/fuse/file.go
+++ b/fuse/file.go
@@ -30,7 +30,7 @@ func (f *file) Open(ctx context.Context, req *fuse.OpenRequest, resp *fuse.OpenR
 	// Check for an updated entry in case it has static state.
 	updatedEntry, err := f.refind(ctx)
 	if err != nil {
-		activity.Record(ctx, "FUSE: Open errored %v, %v", f, err)
+		activity.Warnf(ctx, "FUSE: Open errored %v, %v", f, err)
 		return nil, err
 	}
 
@@ -38,7 +38,7 @@ func (f *file) Open(ctx context.Context, req *fuse.OpenRequest, resp *fuse.OpenR
 	if plugin.ReadAction().IsSupportedOn(updatedEntry) {
 		content, err := plugin.CachedOpen(ctx, updatedEntry.(plugin.Readable))
 		if err != nil {
-			activity.Record(ctx, "FUSE: Open %v errored: %v", f, err)
+			activity.Warnf(ctx, "FUSE: Open %v errored: %v", f, err)
 			return nil, err
 		}
 

--- a/go.mod
+++ b/go.mod
@@ -78,6 +78,7 @@ require (
 	golang.org/x/net v0.0.0-20190110200230-915654e7eabc // indirect
 	golang.org/x/oauth2 v0.0.0-20181203162652-d668ce993890 // indirect
 	golang.org/x/sync v0.0.0-20181108010431-42b317875d0f // indirect
+	golang.org/x/sys v0.0.0-20190712062909-fae7ac547cb7
 	golang.org/x/time v0.0.0-20181108054448-85acf8d2951c // indirect
 	google.golang.org/appengine v1.3.0 // indirect
 	google.golang.org/genproto v0.0.0-20181219182458-5a97ab628bfb // indirect

--- a/go.sum
+++ b/go.sum
@@ -237,6 +237,9 @@ golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223 h1:DH4skfRX4EBpamg7iV4ZlCpblAHI6s6TDM39bFZumv8=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190425145619-16072639606e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190712062909-fae7ac547cb7 h1:LepdCS8Gf/MVejFIt8lsiexZATdoGVyp5bcyS+rYoUI=
+golang.org/x/sys v0.0.0-20190712062909-fae7ac547cb7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c h1:fqgJT0MGcGpPgpWU7VRdRjuArfcOvC4AoJmILihzhDg=

--- a/plugin/aws/root.go
+++ b/plugin/aws/root.go
@@ -157,7 +157,7 @@ func (r *Root) List(ctx context.Context) ([]plugin.Entry, error) {
 
 		profile, err := newProfile(ctx, name)
 		if err != nil {
-			activity.Record(ctx, err.Error())
+			activity.Warnf(ctx, err.Error())
 			continue
 		}
 

--- a/plugin/interactive.go
+++ b/plugin/interactive.go
@@ -3,8 +3,10 @@ package plugin
 import (
 	"fmt"
 	"os"
+	"unsafe"
 
 	"github.com/mattn/go-isatty"
+	"golang.org/x/sys/unix"
 )
 
 var isInteractive bool = (isatty.IsTerminal(os.Stdin.Fd()) || isatty.IsCygwinTerminal(os.Stdin.Fd())) &&
@@ -22,13 +24,51 @@ func IsInteractive() bool {
 	return isInteractive
 }
 
+func tcGetpgrp(fd int) (pgrp int, err error) {
+	return unix.IoctlGetInt(fd, unix.TIOCGPGRP)
+}
+
+func tcSetpgrp(fd int, pgrp int) (err error) {
+	// Mimic IoctlSetPointerInt, which is not available on macOS.
+	v := int32(pgrp)
+	return unix.IoctlSetInt(fd, unix.TIOCSPGRP, int(uintptr(unsafe.Pointer(&v))))
+}
+
 // Prompt prints the supplied message, then waits for input on stdin.
 func Prompt(msg string) (string, error) {
 	if !IsInteractive() {
-		return "", fmt.Errorf("Not an interactive session")
+		return "", fmt.Errorf("not an interactive session")
 	}
-	fmt.Fprintf(os.Stderr, "%s: ", msg)
+
+	// Even if Wash is running interactively, it will not have control of STDIN while another command
+	// is running within the shell environment. If it doesn't have control and tries to read from it,
+	// the read will fail. If we have control, read normally. If not, temporarily acquire control for
+	// the current process group while we're prompting, then return it afterward so the triggering
+	// command can continue.
+	inFd := int(os.Stdin.Fd())
+	inGrp, err := tcGetpgrp(inFd)
+	if err != nil {
+		return "", fmt.Errorf("error getting process group controlling stdin: %v", err)
+	}
+	curGrp := unix.Getpgrp()
+
 	var v string
-	_, err := fmt.Scanln(&v)
+	if inGrp == curGrp {
+		// We control stdin
+		fmt.Fprintf(os.Stderr, "%s: ", msg)
+		_, err = fmt.Scanln(&v)
+	} else {
+		// Need to get control, prompt, then return control.
+		if err := tcSetpgrp(inFd, curGrp); err != nil {
+			return "", fmt.Errorf("error getting control of stdin: %v", err)
+		}
+		fmt.Fprintf(os.Stderr, "%s: ", msg)
+		_, err = fmt.Scanln(&v)
+		if err := tcSetpgrp(inFd, inGrp); err != nil {
+			// Panic if we can't return control. A messed up environment that they 'kill -9' is worse.
+			panic(err.Error())
+		}
+	}
+	// Return the error set by Scanln.
 	return v, err
 }

--- a/plugin/kubernetes/root.go
+++ b/plugin/kubernetes/root.go
@@ -57,7 +57,7 @@ func (r *Root) Init(map[string]interface{}) error {
 	for name := range raw.Contexts {
 		ctx, err := createContext(raw, name, config.ConfigAccess())
 		if err != nil {
-			activity.Record(context.Background(), "loading context %v failed: %+v", name, err)
+			activity.Warnf(context.Background(), "loading context %v failed: %+v", name, err)
 			continue
 		}
 		contexts = append(contexts, ctx)

--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -52,8 +52,6 @@ At this point, if you haven't already, you should start some resources that Wash
 
 Wash uses your system shell to provide the shell environment. It determines this using the SHELL environment variable or falls back to `/bin/sh`, so if you'd like to specify a particular shell set the SHELL environment variable before starting Wash.
 
-If Wash appears to hang, there's a good chance it's attempting to prompt for input while another command - such as `ls` - is running. You can usually get out of it by running `fg`, then hitting `<Enter>`. When starting Wash from the `fish` shell in particular, the prompt for input is often hidden.
-
 #### On macOS
 
 If using iTerm2, we recommend installing [iTerm2's shell integration](https://www.iterm2.com/documentation-shell-integration.html) to avoid [issue#84](https://github.com/puppetlabs/wash/issues/84).

--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -50,6 +50,10 @@ At this point, if you haven't already, you should start some resources that Wash
 
 ### Known issues
 
+Wash uses your system shell to provide the shell environment. It determines this using the SHELL environment variable or falls back to `/bin/sh`, so if you'd like to specify a particular shell set the SHELL environment variable before starting Wash.
+
+If Wash appears to hang, there's a good chance it's attempting to prompt for input while another command - such as `ls` - is running. You can usually get out of it by running `fg`, then hitting `<Enter>`. When starting Wash from the `fish` shell in particular, the prompt for input is often hidden.
+
 #### On macOS
 
 If using iTerm2, we recommend installing [iTerm2's shell integration](https://www.iterm2.com/documentation-shell-integration.html) to avoid [issue#84](https://github.com/puppetlabs/wash/issues/84).

--- a/website/content/docs/core_plugins/_index.md
+++ b/website/content/docs/core_plugins/_index.md
@@ -14,7 +14,7 @@ Each entry must implement [plugin.Entry](https://godoc.org/github.com/puppetlabs
 
 Each entry that implements the `Parent` interface must provide a schema for its children.
 
-Use [activity.Record](https://godoc.org/github.com/puppetlabs/wash/activity) for all plugin-related logging. Each plugin method that Wash calls is passed a `context.Context` object that is initialized with a Journal ID for use with `activity.Record`.
+Use [activity](https://godoc.org/github.com/puppetlabs/wash/activity) for all plugin-related logging. Each plugin method that Wash calls is passed a `context.Context` object that is initialized with a Journal ID for use with `activity.Record` and `activity.Warnf`.
 
 TIP: The [transport] package contains useful helpers for common methods of executing commands on a remote system. Currently it only supports SSH.
 


### PR DESCRIPTION
Add an `activity.Warnf` function that bumps the severity up on messages in journals and logs them at warning level so they should appear in the shell. Also document some known issues about using Wash with particular shell environments.

Fixes #171.