### PR TITLE
Document that STDIN's at EOF if stdin exec opt. isn't set

### DIFF
--- a/docs/docs/external_plugins/index.html
+++ b/docs/docs/external_plugins/index.html
@@ -384,7 +384,7 @@ myplugin:
 
 <h2 id="exec">exec</h2>
 
-<p><code>exec</code> is invoked as <code>&lt;plugin_script&gt; exec &lt;path&gt; &lt;state&gt; &lt;opts&gt; &lt;cmd&gt; &lt;args...&gt;</code>. If the <code>input</code> key is included as part of <code>opts</code> in a request to the <code>exec</code> endpoint, then its content is passed-in as stdin to the plugin script. <code>&lt;opts&gt;</code> is the JSON serialization of the remaining options.</p>
+<p><code>exec</code> is invoked as <code>&lt;plugin_script&gt; exec &lt;path&gt; &lt;state&gt; &lt;opts&gt; &lt;cmd&gt; &lt;args...&gt;</code>. If the <code>input</code> key is included as part of <code>opts</code> in a request to the <code>exec</code> endpoint, then its content is passed-in as stdin to the plugin script. Otherwise, the invocation&rsquo;s stdin will be at EOF. Note that <code>&lt;opts&gt;</code> is the JSON serialization of the remaining options.</p>
 
 <p>When <code>exec</code> is invoked, the plugin script&rsquo;s stdout and stderr must be connected to <code>cmd</code>&rsquo;s stdout and stderr, and it must exit the <code>exec</code> invocation with <code>cmd</code>&rsquo;s exit code.</p>
 

--- a/website/content/docs/external_plugins/_index.md
+++ b/website/content/docs/external_plugins/_index.md
@@ -216,7 +216,7 @@ Below is an example that includes pre-fetched method results for a static direct
 `stream` adopts the standard error convention described in the [Errors](#errors) section.
 
 ## exec
-`exec` is invoked as `<plugin_script> exec <path> <state> <opts> <cmd> <args...>`. If the `input` key is included as part of `opts` in a request to the `exec` endpoint, then its content is passed-in as stdin to the plugin script. `<opts>` is the JSON serialization of the remaining options.
+`exec` is invoked as `<plugin_script> exec <path> <state> <opts> <cmd> <args...>`. If the `input` key is included as part of `opts` in a request to the `exec` endpoint, then its content is passed-in as stdin to the plugin script. Otherwise, the invocation's stdin will be at EOF. Note that `<opts>` is the JSON serialization of the remaining options.
 
 When `exec` is invoked, the plugin script's stdout and stderr must be connected to `cmd`'s stdout and stderr, and it must exit the `exec` invocation with `cmd`'s exit code.
 


### PR DESCRIPTION
Resolves https://github.com/puppetlabs/wash/issues/407

Signed-off-by: Enis Inan <enis.inan@puppet.com>

Contributions to this project require sign-off consistent with the [Developers Certificate of Origin](https://developercertificate.org). This can be as simple as using `git commit -s` on each commit.