### PR TITLE
Fix typo in example using old container name

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -211,7 +211,7 @@ metadata.json   &lt;unknown&gt;             read</pre></td></tr></table>
 </span><span style="margin-right:0.4em;padding:0 0.4em 0 0.4em;color:#7f7f7f">6
 </span></pre></td>
 <td style="vertical-align:top;padding:0;margin:0;border:0;">
-<pre style="background-color:#fff;-moz-tab-size:4;-o-tab-size:4;tab-size:4">wash$ meta 382776912d9373e6c4dc1350894b5290b22c36893a8fed08e2ba53fbb680c8a6 -o yaml
+<pre style="background-color:#fff;-moz-tab-size:4;-o-tab-size:4;tab-size:4">wash$ meta swarm_web_1 -o yaml
 AppArmorProfile: &#34;&#34;
 Args:
 - app.py

--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -113,7 +113,7 @@ Notice that tab-completion makes it easy to find the containers you want to expl
 
 The list earlier also noted that the container "directories" support the *metadata* action. We can get structured metadata in ether YAML or JSON with `wash meta`
 ```
-wash$ meta 382776912d9373e6c4dc1350894b5290b22c36893a8fed08e2ba53fbb680c8a6 -o yaml
+wash$ meta swarm_web_1 -o yaml
 AppArmorProfile: ""
 Args:
 - app.py


### PR DESCRIPTION
Signed-off-by: Michael Smith <michael.smith@puppet.com>