### PR TITLE
Add case for the plugin.Registry in plugin.Schema

### DIFF
--- a/plugin/registry.go
+++ b/plugin/registry.go
@@ -55,31 +55,14 @@ func (r *Registry) RegisterPlugin(root Root, config map[string]interface{}) erro
 	return nil
 }
 
-// ChildSchemas returns the child schemas of the plugin registry
+// ChildSchemas only makes sense for core plugin roots
 func (r *Registry) ChildSchemas() []*EntrySchema {
-	var childSchemas []*EntrySchema
-	for _, root := range r.pluginRoots {
-		s := root.Schema()
-		if s == nil {
-			// s doesn't have a schema, which means it's an external plugin.
-			// Create a schema for s so that `stree <mountpoint>` can still
-			// display it.
-			s = NewEntrySchema(root, CName(root))
-		}
-		s.IsSingleton()
-		if len(s.Label) == 0 {
-			s.Label = CName(root)
-		}
-		childSchemas = append(childSchemas, s)
-	}
-	return childSchemas
+	return nil
 }
 
-const registrySchemaLabel = "mountpoint"
-
-// Schema returns the plugin registry's schema
+// Schema only makes sense for core plugin roots
 func (r *Registry) Schema() *EntrySchema {
-	return NewEntrySchema(r, registrySchemaLabel).IsSingleton()
+	return nil
 }
 
 // List all of Wash's loaded plugins


### PR DESCRIPTION
Previously, the plugin.Registry's child schemas were obtained by
invoking its ChildSchemas() method. This did not work because it would
call Entry#Schema which, for external plugins, returns nil (since it is
only there for core plugins) so stree would showcase the stub schema for
external plugins instead of their full schema. Calling plugin.Schema in the registry's
ChildSchemas is also bad because that means we'd have to swallow any external
plugin schema-generation errors.

Thus, the easiest fix is to add an extra case for the plugin.Registry in
plugin.Schema

Signed-off-by: Enis Inan <enis.inan@puppet.com>