### PR TITLE
Mark external plugin roots as singleton + generate stub type ID for schema-less roots

### DIFF
--- a/plugin/entrySchema.go
+++ b/plugin/entrySchema.go
@@ -35,6 +35,7 @@ func Schema(e Entry) (*EntrySchema, error) {
 				// it.
 				childSchema = NewEntrySchema(root, CName(root))
 			}
+			childSchema.IsSingleton()
 			schema.Children = append(schema.Children, childSchema.TypeID)
 			childGraph := childSchema.graph
 			if childGraph == nil {

--- a/plugin/entrySchema.go
+++ b/plugin/entrySchema.go
@@ -34,6 +34,9 @@ func Schema(e Entry) (*EntrySchema, error) {
 				// Create a schema for root so that `stree <mountpoint>` can still display
 				// it.
 				childSchema = NewEntrySchema(root, CName(root))
+				// TODO: Namespace these to something like <root_name>::Root once
+				// https://github.com/puppetlabs/wash/issues/396 is resolved.
+				childSchema.TypeID = "__" + root.name() + "__"
 			}
 			childSchema.IsSingleton()
 			schema.Children = append(schema.Children, childSchema.TypeID)


### PR DESCRIPTION
This was a regression from a previous PR.

Signed-off-by: Enis Inan <enis.inan@puppet.com>

Contributions to this project require sign-off consistent with the [Developers Certificate of Origin](https://developercertificate.org). This can be as simple as using `git commit -s` on each commit.