### PR TITLE
Ensure that config is always a map when invoking init

### DIFF
--- a/plugin/externalPluginRoot.go
+++ b/plugin/externalPluginRoot.go
@@ -17,6 +17,9 @@ type externalPluginRoot struct {
 
 // Init initializes the external plugin root
 func (r *externalPluginRoot) Init(cfg map[string]interface{}) error {
+	if cfg == nil {
+		cfg = make(map[string]interface{})
+	}
 	cfgJSON, err := json.Marshal(cfg)
 	if err != nil {
 		return fmt.Errorf("could not marshal plugin config %v into JSON: %v", cfg, err)

--- a/plugin/externalPluginRoot_test.go
+++ b/plugin/externalPluginRoot_test.go
@@ -28,7 +28,7 @@ func (suite *ExternalPluginRootTestSuite) TestInit() {
 			mock.Anything,
 			"init",
 			nil,
-			"null",
+			"{}",
 		).Return(mockInvocation(stdout), err).Once()
 	}
 
@@ -89,7 +89,7 @@ func (suite *ExternalPluginRootTestSuite) TestInitWithSchema_SetsSchemaKnownVari
 		mock.Anything,
 		"init",
 		nil,
-		"null",
+		"{}",
 	).Return(mockInvocation([]byte("{\"type_id\":\"root\",\"methods\":[\"schema\",\"list\"]}")), nil).Once()
 
 	suite.NoError(root.Init(nil))
@@ -107,7 +107,7 @@ func (suite *ExternalPluginRootTestSuite) TestInitWithSchema_PrefetchedSchema_Re
 		mock.Anything,
 		"init",
 		nil,
-		"null",
+		"{}",
 	).Return(mockInvocation([]byte("{\"type_id\":\"root\",\"methods\":[[\"schema\", \"foo\"],\"list\"]}")), nil).Once()
 
 	err := root.Init(nil)
@@ -149,7 +149,7 @@ func (suite *ExternalPluginRootTestSuite) TestInitWithSchema_PrefetchedSchema_Pa
 		mock.Anything,
 		"init",
 		nil,
-		"null",
+		"{}",
 	).Return(mockInvocation(stdout), nil).Once()
 
 	// Perform the test


### PR DESCRIPTION
Signed-off-by: Enis Inan <enis.inan@puppet.com>

Contributions to this project require sign-off consistent with the [Developers Certificate of Origin](https://developercertificate.org). This can be as simple as using `git commit -s` on each commit.