### PR TITLE
Move wash gem reference to plugin script section

### DIFF
--- a/docs/docs/external_plugins/index.html
+++ b/docs/docs/external_plugins/index.html
@@ -110,7 +110,7 @@ if (!doNotTrack) {
 <li><code>&lt;args...&gt;</code> are the method&rsquo;s arguments.</li>
 </ul>
 
-<p><code>&lt;path&gt;</code> and <code>&lt;state&gt;</code> can be a bit confusing. To understand them, we recommend reading the <a href="#aside">Aside</a>, and to look at the provided <a href="#bash-example">Bash</a> + Ruby external plugin examples to see how they&rsquo;re used. <strong>TODO: Link a Ruby example</strong></p>
+<p><code>&lt;path&gt;</code> and <code>&lt;state&gt;</code> can be a bit confusing. To understand them, we recommend reading the <a href="#aside">Aside</a>, and to look at the provided <a href="#bash-example">Bash</a> example + the <a href="https://github.com/puppetlabs/wash-ruby">wash</a> gem to see how they are used. Note that the latter provides a framework for implementing external plugins in Ruby.</p>
 
 <p>The remaining sections describe all the possible Wash methods that can be passed-in, including their calling and error conventions, and the expected results.</p>
 
@@ -386,8 +386,6 @@ myplugin:
 <p><code>metadata</code> adopts the standard error convention described in the <a href="#errors">Errors</a> section.</p>
 
 <p><strong>NOTE:</strong> Only implement <code>metadata</code> if there is additional information about your entry that is not provided by the <code>meta</code> attribute.</p>
-
-<p><strong>NOTE:</strong> Check out the <a href="https://github.com/puppetlabs/wash-ruby">wash</a> gem. It provides a framework for implementing external plugins in Ruby.</p>
 
 <h2 id="stream">stream</h2>
 

--- a/website/content/docs/external_plugins/_index.md
+++ b/website/content/docs/external_plugins/_index.md
@@ -42,7 +42,7 @@ where
 * `<state>` consists of the minimum amount of information required to reconstruct the entry inside the plugin
 * `<args...>` are the method's arguments.
 
-`<path>` and `<state>` can be a bit confusing. To understand them, we recommend reading the [Aside](#aside), and to look at the provided [Bash](#bash-example) + Ruby external plugin examples to see how they're used. **TODO: Link a Ruby example**
+`<path>` and `<state>` can be a bit confusing. To understand them, we recommend reading the [Aside](#aside), and to look at the provided [Bash](#bash-example) example + the [wash](https://github.com/puppetlabs/wash-ruby) gem to see how they are used. Note that the latter provides a framework for implementing external plugins in Ruby.
 
 The remaining sections describe all the possible Wash methods that can be passed-in, including their calling and error conventions, and the expected results.
 
@@ -209,8 +209,6 @@ Below is an example that includes pre-fetched method results for a static direct
 `metadata` adopts the standard error convention described in the [Errors](#errors) section.
 
 **NOTE:** Only implement `metadata` if there is additional information about your entry that is not provided by the `meta` attribute.
-
-**NOTE:** Check out the [wash](https://github.com/puppetlabs/wash-ruby) gem. It provides a framework for implementing external plugins in Ruby.
 
 ## stream
 `stream` is invoked as `<plugin_script> stream <path> <state>`. When `stream` is invoked, the first line of the script's output must contain the `200` header. This header tells Wash that the entry's data is about to the streamed. After it outputs the header, the script must then stream the entry's data. Wash will continue to poll stdout for any updates until either the streaming process exits, or the user cancels the request.


### PR DESCRIPTION
I have no idea how I missed this being in the metadata section.

Signed-off-by: Enis Inan <enis.inan@puppet.com>

Contributions to this project require sign-off consistent with the [Developers Certificate of Origin](https://developercertificate.org). This can be as simple as using `git commit -s` on each commit.