### PR TITLE
Document where to watch for releases and how to do them

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,3 +45,11 @@ For example, the Docker plugin has multiple files implenting components of a con
 - container-log.go
 - container-metadata.go
 - container.go
+
+### Releases
+
+Releases are done through the GitHub's [Draft a new release](https://github.com/puppetlabs/wash/releases/new). Assets are automatically built. https://github.com/puppetlabs/homebrew-puppet needs to be manually updated to use the new release (in the future we hope to automate this with GitHub Actions).
+
+Release announcements are:
+- posted in [Slack #puppet](https://puppetcommunity.slack.com/app_redirect?channel=puppet); ask a moderator to re-post into #announcements
+- Puppet internal [release announcement process](https://confluence.puppetlabs.com/display/PM/Sending+Product+Release+Announcements)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,14 +18,6 @@ Open a "[Feature request](https://github.com/puppetlabs/wash/issues/new?template
 
 ## Development Environment
 
-### Requirements
-
-* Golang 1.11
-
-### Building
-
-You can build a native binary with `go build`. The resulting `wash` binary will be placed in the current directory.
-
 ### Updating Dependencies
 
 Versioning for the kubernetes and docker projects don't work well with Go modules. The best way to update dependencies is to update specific packages to a specific version using `go get <mod>@<tag>`.

--- a/docs/index.html
+++ b/docs/index.html
@@ -104,6 +104,10 @@ if (!doNotTrack) {
 
 <p><strong>NOTE:</strong> Wash collects anonymous data about how you use it. See the <a href="/wash/docs#analytics">analytics docs</a> for more details.</p>
 
+<h3 id="release-announcements">Release announcements</h3>
+
+<p>You can watch for new releases of Wash on <a href="https://puppetcommunity.slack.com/app_redirect?channel=announcements">Slack #announcements</a>, the <a href="https://groups.google.com/forum/#!forum/puppet-announce">puppet-announce</a> mailing list, or by subscribing to new releases on <a href="https://github.com/puppetlabs/wash">GitHub</a>.</p>
+
 <h3 id="known-issues">Known issues</h3>
 
 <p>Wash uses your system shell to provide the shell environment. It determines this using the SHELL environment variable or falls back to <code>/bin/sh</code>, so if you&rsquo;d like to specify a particular shell set the SHELL environment variable before starting Wash.</p>

--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -50,6 +50,10 @@ At this point, if you haven't already, you should start some resources that Wash
 
 **NOTE:** Wash collects anonymous data about how you use it. See the [analytics docs](/wash/docs#analytics) for more details.
 
+### Release announcements
+
+You can watch for new releases of Wash on [Slack #announcements](https://puppetcommunity.slack.com/app_redirect?channel=announcements), the [puppet-announce](https://groups.google.com/forum/#!forum/puppet-announce) mailing list, or by subscribing to new releases on [GitHub](https://github.com/puppetlabs/wash).
+
 ### Known issues
 
 Wash uses your system shell to provide the shell environment. It determines this using the SHELL environment variable or falls back to `/bin/sh`, so if you'd like to specify a particular shell set the SHELL environment variable before starting Wash.


### PR DESCRIPTION
Documents where to watch for releases on the website so folks can stay up-to-date and find what's in new releases. Also document how to send release announcements (currently includes a process that's only available to Puppet employees).

Resolves #445.