### PR TITLE
Limit analytics from CI and local testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
   global:
   - GO111MODULE=on
   - PROJECT_NAME=wash
+  - WASH_DISABLE_ANALYTICS=true
 jobs:
   include:
   - name: Test Go stable

--- a/analytics/client.go
+++ b/analytics/client.go
@@ -41,9 +41,16 @@ type Client interface {
 // NewClient returns a new Google Analytics client for submitting Wash analytics.
 func NewClient(config Config) Client {
 	if config.Disabled {
-		log.Debugf("Analytics opt-out is set, analytics will be disabled")
+		log.Debug("Analytics opt-out is set, analytics will be disabled")
 		return &noopClient{}
 	}
+
+	// Don't submit analytics for untagged builds
+	if version.BuildVersion == "unknown" {
+		log.Debug("Analytics disabled for unreleased version")
+		return &noopClient{}
+	}
+
 	client := &client{
 		userID: config.UserID,
 	}

--- a/analytics/client_test.go
+++ b/analytics/client_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/puppetlabs/wash/cmd/version"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 )
@@ -18,6 +20,7 @@ type ClientTestSuite struct {
 	oldHTTPClient  httpClientI
 	mockHTTPClient *mockHTTPClient
 	c              *client
+	savedVersion   string
 }
 
 type mockHTTPClient struct {
@@ -37,11 +40,16 @@ func (s *ClientTestSuite) SetupTest() {
 		Disabled: false,
 		UserID:   uuid.New(),
 	}
+
+	// Set version to a valid version so we get a real client
+	s.savedVersion = version.BuildVersion
+	version.BuildVersion = "1.0.0"
 	s.c = NewClient(config).(*client)
 }
 
 func (s *ClientTestSuite) TearDownTest() {
 	httpClient = s.oldHTTPClient
+	version.BuildVersion = s.savedVersion
 }
 
 func (s *ClientTestSuite) TestNewClient_AnalyticsDisabled_ReturnsNoopClient() {
@@ -262,6 +270,16 @@ func (s *ClientTestSuite) TestBaseParams() {
 	for _, param := range variableBaseParams {
 		s.Contains(baseParams, param)
 	}
+}
+
+func TestNewClient_UnknownVersion_ReturnsNoopClient(t *testing.T) {
+	config := Config{
+		Disabled: false,
+		UserID:   uuid.New(),
+	}
+	c := NewClient(config)
+	_, ok := c.(*noopClient)
+	assert.True(t, ok, "NewClient does not return a noopClient when version is unknown")
 }
 
 func TestClient(t *testing.T) {


### PR DESCRIPTION
Disable analytics in Travis CI.

Skips sending analytics when Wash version is "unknown". This avoids sending analytics data when running tests or otherwise working from source.