### PR TITLE
Fix loading Zsh config

### DIFF
--- a/cmd/internal/shell/zsh.go
+++ b/cmd/internal/shell/zsh.go
@@ -1,6 +1,7 @@
 package shell
 
 import (
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -18,47 +19,46 @@ func (z zsh) Command(subcommands []string, rundir string) (*exec.Cmd, error) {
 	//   then load ~/.washrc (if present).
 
 	cmd := exec.Command(z.sh)
+	// Override ZDOTDIR so zsh looks for our configs, but save the original ZDOTDIR so we can use it
+	// when loading zsh-specific config that may rely on it being set.
 	cmd.Env = append(os.Environ(), "ZDOTDIR="+rundir)
+	zdotdir := os.Getenv("ZDOTDIR")
 
-	zshenv, err := os.Create(filepath.Join(rundir, ".zshenv"))
-	if err != nil {
-		return nil, err
-	}
-	defer zshenv.Close()
-
-	_, err = zshenv.WriteString("[[ -s ~/.zshenv && ! -s ~/.washenv ]] && source ~/.zshenv\n")
-	if err != nil {
-		return nil, err
-	}
+	content := `if [[ ! -s ~/.washenv ]]; then
+	# Reset ZDOTDIR for zsh config, then set it back so we load Wash's zshrc
+  ZDOTDIR='` + zdotdir + `'
+  if [[ -s "${ZDOTDIR:-$HOME}/.zshenv" ]]; then
+    source "${ZDOTDIR:-$HOME}/.zshenv"
+	fi
+	ZDOTDIR='` + rundir + `'
+fi
+`
 	for _, alias := range subcommands {
-		_, err = zshenv.WriteString("alias " + alias + "='WASH_EMBEDDED=1 wash " + alias + "'\n")
-		if err != nil {
-			return nil, err
-		}
+		content += "alias " + alias + "='WASH_EMBEDDED=1 wash " + alias + "'\n"
 	}
-	_, err = zshenv.WriteString("[[ -s ~/.washenv ]] && source ~/.washenv\n")
-	if err != nil {
+	content += "if [[ -s ~/.washenv ]]; then source ~/.washenv; fi\n"
+	if err := ioutil.WriteFile(filepath.Join(rundir, ".zshenv"), []byte(content), 0644); err != nil {
 		return nil, err
 	}
 
-	zshrc, err := os.Create(filepath.Join(rundir, ".zshrc"))
-	if err != nil {
-		return nil, err
-	}
-	defer zshrc.Close()
-
-	_, err = zshrc.WriteString(`source $ZDOTDIR/.zshenv
-[[ -s ~/.zshrc && ! -s ~/.washrc ]] && source ~/.zshrc
+	content = `if [[ ! -s ~/.washrc ]]; then
+	ZDOTDIR='` + zdotdir + `'
+  if [[ -s "${ZDOTDIR:-$HOME}/.zprofile" ]]; then source "${ZDOTDIR:-$HOME}/.zprofile"; fi
+  if [[ -s "${ZDOTDIR:-$HOME}/.zshrc" ]]; then source "${ZDOTDIR:-$HOME}/.zshrc"; fi
+fi
 
 WASH_BASE=$(pwd)
 function prompter() {
-	PROMPT="%F{cyan}wash $(realpath --relative-to=$WASH_BASE $(pwd))%F{green} ❯%f "
+  PROMPT="%F{cyan}wash $(realpath --relative-to=$WASH_BASE $(pwd))%F{green} ❯%f "
 }
 
 autoload -Uz add-zsh-hook
 add-zsh-hook precmd prompter
 
-[[ -s ~/.washrc ]] && source ~/.washrc
-`)
-	return cmd, err
+if [[ -s ~/.washrc ]]; then source ~/.washrc; fi
+`
+	if err := ioutil.WriteFile(filepath.Join(rundir, ".zshrc"), []byte(content), 0644); err != nil {
+		return nil, err
+	}
+	return cmd, nil
 }


### PR DESCRIPTION
Some Zsh config in my environment did not properly load because it relied on looking up config in `${ZDOTDIR:-$HOME}`, so it wouldn't find the rest of the config because we'd overridden ZDOTDIR. Ensures ZDOTDIR is correctly reset when loading Zsh config.

Also refactor's Bash and Zsh to require less error checking by writing each file all at once.

Signed-off-by: Michael Smith <michael.smith@puppet.com>