### PR TITLE
Use different analytics properties for Wash vs its website

### DIFF
--- a/website/config.toml
+++ b/website/config.toml
@@ -9,7 +9,7 @@ paginate = 100
 paginatePath = "page"
 
 # Google analytics
-googleAnalytics = "UA-144580607-1"
+googleAnalytics = "UA-144580607-2"
 
 # Copyright
 copyright = "© 2019 — the wash maintainers"


### PR DESCRIPTION
Wash the app and the website have different use models, and we'd like to
analyze them separately. Use different tracking IDs to capture them.

Signed-off-by: Michael Smith <michael.smith@puppet.com>