### PR TITLE
Capture OS and architecture of wash execution

### DIFF
--- a/analytics/client.go
+++ b/analytics/client.go
@@ -41,16 +41,9 @@ type Client interface {
 // NewClient returns a new Google Analytics client for submitting Wash analytics.
 func NewClient(config Config) Client {
 	if config.Disabled {
-		log.Debug("Analytics opt-out is set, analytics will be disabled")
+		log.Debugf("Analytics opt-out is set, analytics will be disabled")
 		return &noopClient{}
 	}
-
-	// Don't submit analytics for untagged builds
-	if version.BuildVersion == "unknown" {
-		log.Debug("Analytics disabled for unreleased version")
-		return &noopClient{}
-	}
-
 	client := &client{
 		userID: config.UserID,
 	}

--- a/analytics/client.go
+++ b/analytics/client.go
@@ -161,7 +161,7 @@ func (c *client) baseParams() Params {
 		// aip => Anonymize IPs
 		"aip": "true",
 		// cd1 => Custom Dimension 1 (Architecture)
-		"cd1": runtime.GOARCH,
+		"cd1": runtime.GOOS + "/" + runtime.GOARCH,
 	}
 	locale, err := jibber_jabber.DetectIETF()
 	if err != nil {

--- a/analytics/client_test.go
+++ b/analytics/client_test.go
@@ -9,8 +9,6 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/puppetlabs/wash/cmd/version"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 )
@@ -20,7 +18,6 @@ type ClientTestSuite struct {
 	oldHTTPClient  httpClientI
 	mockHTTPClient *mockHTTPClient
 	c              *client
-	savedVersion   string
 }
 
 type mockHTTPClient struct {
@@ -40,16 +37,11 @@ func (s *ClientTestSuite) SetupTest() {
 		Disabled: false,
 		UserID:   uuid.New(),
 	}
-
-	// Set version to a valid version so we get a real client
-	s.savedVersion = version.BuildVersion
-	version.BuildVersion = "1.0.0"
 	s.c = NewClient(config).(*client)
 }
 
 func (s *ClientTestSuite) TearDownTest() {
 	httpClient = s.oldHTTPClient
-	version.BuildVersion = s.savedVersion
 }
 
 func (s *ClientTestSuite) TestNewClient_AnalyticsDisabled_ReturnsNoopClient() {
@@ -270,16 +262,6 @@ func (s *ClientTestSuite) TestBaseParams() {
 	for _, param := range variableBaseParams {
 		s.Contains(baseParams, param)
 	}
-}
-
-func TestNewClient_UnknownVersion_ReturnsNoopClient(t *testing.T) {
-	config := Config{
-		Disabled: false,
-		UserID:   uuid.New(),
-	}
-	c := NewClient(config)
-	_, ok := c.(*noopClient)
-	assert.True(t, ok, "NewClient does not return a noopClient when version is unknown")
 }
 
 func TestClient(t *testing.T) {

--- a/analytics/client_test.go
+++ b/analytics/client_test.go
@@ -255,7 +255,7 @@ func (s *ClientTestSuite) TestBaseParams() {
 		"tid": "UA-144580607-1",
 		"an":  "Wash",
 		"aip": "true",
-		"cd1": runtime.GOARCH,
+		"cd1": runtime.GOOS + "/" + runtime.GOARCH,
 	}
 	for param, value := range constantBaseParams {
 		if s.Contains(baseParams, param) {


### PR DESCRIPTION
Combines these as a single custom dimension because we're limited on how many we can add, and in most cases we view this is a specific build target.

Signed-off-by: Michael Smith <michael.smith@puppet.com>