### PR TITLE
Move details of where journals are stored to docs

### DIFF
--- a/website/content/docs/_index.md
+++ b/website/content/docs/_index.md
@@ -64,6 +64,8 @@ Recursively descends the directory tree of the specified paths, evaluating an `e
 
 Wash maintains a history of commands executed through it. Print that command history, or specify an `id` to print a log of activity related to a particular command.
 
+Journals are stored in `wash/activity` under your user cache directory, identified by process ID and executable name. The user cache directory is `$XDG_CACHE_HOME` or `$HOME/.cache` on Unix systems, `$HOME/Library/Caches` on macOS, and `%LocalAppData%` on Windows.
+
 ### wash info
 
 Print all info Wash has about the specified path, including filesystem attributes and metadata.

--- a/website/content/tutorial.md
+++ b/website/content/tutorial.md
@@ -161,5 +161,3 @@ echo S3 $buckets
 ## Record of activity
 
 All operations have their activity recorded to journals. You can see a record of activity with `whistory`, and look at logs of individual entries with `whistory <id>`.
-
-Journals are stored in `wash/activity` under your user cache directory, identified by process ID and executable name. The user cache directory is `$XDG_CACHE_HOME` or `$HOME/.cache` on Unix systems, `$HOME/Library/Caches` on macOS, and `%LocalAppData%` on Windows.


### PR DESCRIPTION
They seem more relevant as documentation than part of the tutorial.

Signed-off-by: Michael Smith <michael.smith@puppet.com>