### PR TITLE
Fix publishing to gh-pages

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -11,23 +11,36 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v1
+    - name: Prepare destination
+      run: |
+        set -e
+        git remote set-url origin "https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+        git worktree add -B gh-pages website/public origin/gh-pages
+        cd website/public
+        git rm -r '*'
+        touch .nojekyll
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Checkout latest tag
       run: git checkout $(git describe --tags $(git rev-list --tags --max-count=1))
     - name: Build release website
       uses: docker://peaceiris/hugo:v0.57.1
       with:
-        args: -s website -d public --gc -b https://puppetlabs.github.io/wash --minify --cleanDestinationDir
+        args: -s website -d public --gc -b https://puppetlabs.github.io/wash --minify
     - name: Checkout master
       run: git checkout $GITHUB_SHA
-    - name: Add nojekyll file
-      run: sudo touch website/public/.nojekyll && git add website/public/.nojekyll
     - name: Add dev website
       uses: docker://peaceiris/hugo:v0.57.1
       with:
-        args: -s website -d public/dev --gc -b https://puppetlabs.github.io/wash/dev --minify --cleanDestinationDir
+        args: -s website -d public/dev --gc -b https://puppetlabs.github.io/wash/dev --minify
     - name: Deploy
-      uses: peaceiris/actions-gh-pages@v1.1.0
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        PUBLISH_BRANCH: gh-pages
-        PUBLISH_DIR: ./website/public
+      run: |
+        set -e
+        cd website/public
+        git config user.name "${GITHUB_ACTOR}"
+        git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+        git add --all
+        if [ -n "$(git status --porcelain)" ]; then
+          git commit -s -m "Publish $(git describe --tags $(git rev-list --tags --max-count=1)) + ${GITHUB_SHA}"
+          git push origin gh-pages
+        fi


### PR DESCRIPTION
Uses the workflow described at https://gohugo.io/hosting-and-deployment/hosting-on-github/#put-it-into-a-script-1 to publish using git worktrees. Manually clears old files because `--cleanDestinationDir` erases the worktree's .git as well.

Signed-off-by: Michael Smith <michael.smith@puppet.com>