### PR TITLE
Add W environment variable for Wash root

### DIFF
--- a/cmd/internal/shell/bash.go
+++ b/cmd/internal/shell/bash.go
@@ -38,9 +38,8 @@ func (b bash) Command(subcommands []string, rundir string) (*exec.Cmd, error) {
 	content = `source ` + envpath + `
 [[ -s ~/.bashrc && ! -s ~/.washrc ]] && source ~/.bashrc
 
-WASH_BASE=$(pwd)
 function prompter() {
-	export PS1="\e[0;36mwash $(realpath --relative-to=$WASH_BASE $(pwd))\e[0;32m ❯\e[m "
+	export PS1="\e[0;36mwash $(realpath --relative-to=$W $(pwd))\e[0;32m ❯\e[m "
 }
 export PROMPT_COMMAND=prompter
 

--- a/cmd/internal/shell/core.go
+++ b/cmd/internal/shell/core.go
@@ -10,8 +10,9 @@ import (
 type Shell interface {
 	// Command constructs the command to invoke the shell. Subcommands should be made available in the
 	// shell environment as `env WASH_EMBEDDED=1 wash <subcommand>`. Rundir is a temporary directory
-	// that will be added to PATH when the command is invoked; you can use it to add new executables
-	// or store other temporary files.
+	// that will be added to `PATH` when the command is invoked; you can use it to add new executables
+	// or store other temporary files. A `W` environment will also be set to the path where the shell
+	// starts.
 	//
 	// Implementations should support their native interactive and non-interactive config, as well as
 	// Wash's (.washrc and .washenv, respectively). They should:

--- a/cmd/internal/shell/zsh.go
+++ b/cmd/internal/shell/zsh.go
@@ -47,9 +47,8 @@ fi
   if [[ -s "${ZDOTDIR:-$HOME}/.zshrc" ]]; then source "${ZDOTDIR:-$HOME}/.zshrc"; fi
 fi
 
-WASH_BASE=$(pwd)
 function prompter() {
-  PROMPT="%F{cyan}wash $(realpath --relative-to=$WASH_BASE $(pwd))%F{green} ❯%f "
+  PROMPT="%F{cyan}wash $(realpath --relative-to=$W $(pwd))%F{green} ❯%f "
 }
 
 autoload -Uz add-zsh-hook

--- a/cmd/rootMain.go
+++ b/cmd/rootMain.go
@@ -117,6 +117,7 @@ Try 'help'`)
 	}
 	comm.Env = append(comm.Env,
 		"WASH_SOCKET="+socketpath,
+		"W="+mountpath,
 		"PATH="+rundir+string(os.PathListSeparator)+os.Getenv("PATH"),
 	)
 	comm.Dir = mountpath


### PR DESCRIPTION
Wash sets the `W` environment variable to the root of its filesystem on
startup to make it easy to return to and reference.

Resolves #313.

Signed-off-by: Michael Smith <michael.smith@puppet.com>