### PR TITLE
Make displaying meta optional in winfo

### DIFF
--- a/cmd/info.go
+++ b/cmd/info.go
@@ -1,8 +1,10 @@
 package cmd
 
 import (
+	"github.com/emirpasic/gods/maps/linkedhashmap"
 	cmdutil "github.com/puppetlabs/wash/cmd/util"
 	"github.com/spf13/cobra"
+	goyaml "gopkg.in/yaml.v2"
 )
 
 func infoCommand() *cobra.Command {
@@ -11,17 +13,22 @@ func infoCommand() *cobra.Command {
 		Use:     use + " <path>",
 		Aliases: aliases,
 		Short:   "Prints the entry's info at the specified path",
-		Long:    `Print all info Wash has about the specified path, including filesystem attributes and metadata.`,
+		Long:    `Print all info Wash has about the specified path.`,
 		Args:    cobra.ExactArgs(1),
 		RunE:    toRunE(infoMain),
 	}
-	infoCmd.Flags().StringP("output", "o", "yaml", "Set the output format (json or yaml)")
+	infoCmd.Flags().StringP("output", "o", "yaml", "Set the output format (json, yaml, or text)")
+	infoCmd.Flags().BoolP("include-meta", "", false, "Include the meta attribute")
 	return infoCmd
 }
 
 func infoMain(cmd *cobra.Command, args []string) exitCode {
 	path := args[0]
 	output, err := cmd.Flags().GetString("output")
+	if err != nil {
+		panic(err.Error())
+	}
+	includeMeta, err := cmd.Flags().GetBool("include-meta")
 	if err != nil {
 		panic(err.Error())
 	}
@@ -40,7 +47,15 @@ func infoMain(cmd *cobra.Command, args []string) exitCode {
 		return exitCode{1}
 	}
 
-	marshalledEntry, err := marshaller.Marshal(entry)
+	// Use a sorted map so that we can control how the information's displayed.
+	entryMap := orderedMap{linkedhashmap.New()}
+	entryMap.Put("Path", entry.Path)
+	entryMap.Put("Name", entry.Name)
+	entryMap.Put("CName", entry.CName)
+	entryMap.Put("Actions", entry.Actions)
+	entryMap.Put("Attributes", entry.Attributes.ToMap(includeMeta))
+
+	marshalledEntry, err := marshaller.Marshal(entryMap)
 	if err != nil {
 		cmdutil.ErrPrintf("%v\n", err)
 		return exitCode{1}
@@ -49,4 +64,26 @@ func infoMain(cmd *cobra.Command, args []string) exitCode {
 	cmdutil.Println(marshalledEntry)
 
 	return exitCode{0}
+}
+
+// This wrapped type's here because linkedhashmap doesn't implement the
+// json.Marshaler and yaml.Marshaler interfaces.
+type orderedMap struct {
+	*linkedhashmap.Map
+}
+
+func (mp orderedMap) MarshalJSON() ([]byte, error) {
+	return mp.ToJSON()
+}
+
+// We implement MarshalYAML to preserve each key's ordering.
+func (mp orderedMap) MarshalYAML() (interface{}, error) {
+	var yamlMap goyaml.MapSlice
+	mp.Each(func(key interface{}, value interface{}) {
+		yamlMap = append(yamlMap, goyaml.MapItem{
+			Key:   key,
+			Value: value,
+		})
+	})
+	return yamlMap, nil
 }

--- a/cmd/meta.go
+++ b/cmd/meta.go
@@ -15,7 +15,7 @@ metadata endpoint. Specify the --attribute flag to instead print the meta attrib
 		Args: cobra.ExactArgs(1),
 		RunE: toRunE(metaMain),
 	}
-	metaCmd.Flags().StringP("output", "o", "yaml", "Set the output format (json or yaml)")
+	metaCmd.Flags().StringP("output", "o", "yaml", "Set the output format (json, yaml, or text)")
 	metaCmd.Flags().BoolP("attribute", "a", false, "Print the meta attribute instead of the full metadata")
 	return metaCmd
 }

--- a/cmd/util/marshal.go
+++ b/cmd/util/marshal.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/ghodss/yaml"
+	goyaml "gopkg.in/yaml.v2"
 )
 
 const (
@@ -33,13 +34,13 @@ func NewMarshaller(format string) (Marshaller, error) {
 		}), nil
 	case YAML:
 		return Marshaller(func(v interface{}) ([]byte, error) {
-			// Use a JSONToYAML style encoding so that objects do not
-			// have to implement multiple Marshal* interfaces.
-			jsonBytes, err := json.Marshal(v)
-			if err != nil {
-				return nil, err
+			switch t := v.(type) {
+			case goyaml.Marshaler:
+				return goyaml.Marshal(t)
+			default:
+				// yaml.Marshal marshals v to JSON then converts that JSON to YAML.
+				return yaml.Marshal(v)
 			}
-			return yaml.JSONToYAML(jsonBytes)
 		}), nil
 	case TEXT:
 		return Marshaller(toText), nil


### PR DESCRIPTION

This makes it easier for people to view a Wash entry's info., especially
its attributes. We'll also be telling people to use 'meta --attribute'
if they want to view an entry's meta attribute, so that's another reason
to remove it from winfo's default output.

Resolves #484

Signed-off-by: Enis Inan <enis.inan@puppet.com>