### PR TITLE
Fix formatting on website

### DIFF
--- a/website/content/docs/_index.md
+++ b/website/content/docs/_index.md
@@ -192,8 +192,9 @@ Host *.compute.amazonaws.com
 ### GCP
 
 The GCP plugin follows https://cloud.google.com/docs/authentication/production to find your credentials:
+
 - it will try `GOOGLE_APPLICATION_CREDENTIALS` as a service account file
-- use your credentials in `$HOME/.config/gcloud/application_default_credentials.json`
+- otherwise it will use your credentials in `$HOME/.config/gcloud/application_default_credentials.json`
 
 The simplest way to set this up is with
 ```


### PR DESCRIPTION
Hugo markdown requires an empty line before list items or they get
appended to the previous paragraph. GitHub markdown does not, so this
looked correct when reviewing.

Signed-off-by: Michael Smith <michael.smith@puppet.com>