### PR TITLE
Fallback to basename if realpath isn't present

### DIFF
--- a/cmd/internal/shell/bash.go
+++ b/cmd/internal/shell/bash.go
@@ -44,7 +44,13 @@ func (b bash) Command(subcommands []string, rundir string) (*exec.Cmd, error) {
 	content += common
 	content += `
 function prompter() {
-	export PS1="\e[0;36mwash $(realpath --relative-to=$W $(pwd))\e[0;32m ❯\e[m "
+  local prompt_path
+  if [ -x "$(command -v realpath)" ]; then
+    prompt_path=$(realpath --relative-to=$W $(pwd))
+  else
+    prompt_path=$(basename $(pwd))
+  fi
+  export PS1="\e[0;36mwash ${prompt_path}\e[0;32m ❯\e[m "
 }
 export PROMPT_COMMAND=prompter
 

--- a/cmd/internal/shell/zsh.go
+++ b/cmd/internal/shell/zsh.go
@@ -54,7 +54,13 @@ fi
 	content += common
 	content += `
 function prompter() {
-  PROMPT="%F{cyan}wash $(realpath --relative-to=$W $(pwd))%F{green} ❯%f "
+  local prompt_path
+  if [ -x "$(command -v realpath)" ]; then
+    prompt_path=$(realpath --relative-to=$W $(pwd))
+  else
+    prompt_path=$(basename $(pwd))
+  fi
+  PROMPT="%F{cyan}wash ${prompt_path}%F{green} ❯%f "
 }
 
 autoload -Uz add-zsh-hook


### PR DESCRIPTION
On macOS and Ubuntu 14.04, realpath isn't a default part of the OS. Fall
back to basename if that's the case and provide a slightly less cool
prompt.

Manually tested on macOS 10.14 with
```
SHELL=bash PATH=/usr/bin:/bin:/usr/sbin wash
```
and `SHELL=/usr/local/bin/zsh`.

Fixes #492.

Signed-off-by: Michael Smith <michael.smith@puppet.com>