### PR TITLE
Fix concurrency issue with submitting journal invocations

### DIFF
--- a/activity/core_test.go
+++ b/activity/core_test.go
@@ -107,7 +107,7 @@ func TestSubmitMethodInvocation_SubmittedMethodInvocation_DoesNotSubmitToGA(t *t
 		// Use a different journal ID so that we get a different recorder
 		ID: "bar",
 	}
-	journal.recorder().recordMethodInvocation("foo::file", "List")
+	journal.recorder().submitMethodInvocation("foo::file", "List", func() {})
 	ctx = context.WithValue(ctx, JournalKey, journal)
 	analyticsClient := &mockAnalyticsClient{}
 	analyticsClient.On("Event", mock.Anything, mock.Anything, mock.Anything).Return(nil)

--- a/activity/journal.go
+++ b/activity/journal.go
@@ -198,9 +198,13 @@ func newRecorder() recorder {
 }
 
 // methodInvoked returns true if "method" was invoked by an instance
-// of "entryType". methodInvoked is not thread-safe.
+// of "entryType". methodInvoked is not thread-safe and should be called
+// with `r.mIMux.RLock()`.
 func (r recorder) methodInvoked(entryType string, method string) bool {
-	methodInvocations := r.methodInvocationsOf(entryType)
+	methodInvocations, ok := r.methodInvocations[entryType]
+	if !ok {
+		return false
+	}
 	return methodInvocations[method]
 }
 


### PR DESCRIPTION
Recording a method on an entry type to analytics via the Journal can
have concurrent reads and writes. We use a mutex to guard them. However
the first time we would check whether a submission had been done, we
would use a read-lock but add initialize a new entry in
`methodInvocations`, which could result in `concurrent map writes` and
`concurrent map read and map write` errors.

Separate the implementation of `methodInvoked` so it does not update
`methodInvocations`, and capture all the mutex operation in a new
`submitMethodInvocation` function that encapsulates recording and
performing the submit.

Fixes #496.

Signed-off-by: Michael Smith <michael.smith@puppet.com>