### PR TITLE
Change to posting in the cloudnative channel

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,5 +51,7 @@ For example, the Docker plugin has multiple files implementing components of a c
 Releases are done through the GitHub's [Draft a new release](https://github.com/puppetlabs/wash/releases/new). Assets are automatically built and a [GitHub Action](https://github.com/puppetlabs/wash/blob/master/.github/workflows/release.yml) will open a PR against https://github.com/puppetlabs/homebrew-puppet to update to the new release.
 
 Release announcements are:
-- posted in [Slack #wash](https://puppetcommunity.slack.com/app_redirect?channel=wash); ask a moderator to re-post into #announcements
+
+- posted in [Slack #cloudnative](https://puppetcommunity.slack.com/app_redirect?channel=cloudnative) (the release is automatically posted to #wash by the GitHub App); ask a moderator to re-post into #announcements. Example announcement:
+  > Wash x.y.z is now available. This release added ... Detailed release notes are available at https://github.com/puppetlabs/wash/releases/tag/x.y.z.
 - Puppet internal [release announcement process](https://confluence.puppetlabs.com/display/PM/Sending+Product+Release+Announcements) sends to puppet-announce@ and puppet-users@


### PR DESCRIPTION
Since the GitHub App automatically mirrors the release notes, it's
redundant to post again in the wash channel. But we don't want to repost
the full release notes to the announcements channel. Create an
announcement in cloudnative for a broader but still appropriate audience
to repost to announcements.

Signed-off-by: Michael Smith <michael.smith@puppet.com>