### PR TITLE
Add attributes to GCP entries

### DIFF
--- a/plugin/gcp/computeInst.go
+++ b/plugin/gcp/computeInst.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/puppetlabs/wash/activity"
 	"github.com/puppetlabs/wash/plugin"
@@ -33,9 +34,15 @@ func newComputeInstance(inst *compute.Instance, c computeProjectService) *comput
 		instance:  inst,
 		service:   c,
 	}
+	crtime, err := time.Parse(time.RFC3339, inst.CreationTimestamp)
+	if err != nil {
+		panic(fmt.Sprintf("Timestamp for %v was not expected format RFC3339: %v", comp, inst.CreationTimestamp))
+	}
 	comp.
 		DisableCachingFor(plugin.MetadataOp).
-		Attributes().SetMeta(inst)
+		Attributes().
+		SetCrtime(crtime).
+		SetMeta(inst)
 	return comp
 }
 

--- a/plugin/gcp/computeInst_test.go
+++ b/plugin/gcp/computeInst_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/puppetlabs/wash/plugin"
 	"github.com/stretchr/testify/assert"
@@ -14,7 +15,7 @@ import (
 )
 
 func TestComputeInstance(t *testing.T) {
-	inst := compute.Instance{Name: "foo"}
+	inst := compute.Instance{Name: "foo", CreationTimestamp: time.Now().Format(time.RFC3339) }
 	compInst := newComputeInstance(&inst, computeProjectService{})
 	assert.Equal(t, "foo", compInst.Name())
 	assert.Implements(t, (*plugin.Parent)(nil), compInst)

--- a/plugin/gcp/storageBucket.go
+++ b/plugin/gcp/storageBucket.go
@@ -17,7 +17,11 @@ type storageBucket struct {
 
 func newStorageBucket(client storageProjectClient, bucket *storage.BucketAttrs) *storageBucket {
 	stor := &storageBucket{EntryBase: plugin.NewEntry(bucket.Name), storageProjectClient: client}
-	stor.Attributes().SetMeta(bucket)
+	stor.Attributes().
+		SetCrtime(bucket.Created).
+		SetCtime(bucket.Created).
+		SetMtime(bucket.Created).
+		SetMeta(bucket)
 	return stor
 }
 

--- a/plugin/gcp/storageObject.go
+++ b/plugin/gcp/storageObject.go
@@ -15,7 +15,12 @@ type storageObject struct {
 
 func newStorageObject(name string, object *storage.ObjectHandle, attrs *storage.ObjectAttrs) *storageObject {
 	obj := &storageObject{EntryBase: plugin.NewEntry(name), ObjectHandle: object}
-	obj.Attributes().SetMtime(attrs.Updated).SetSize(uint64(attrs.Size)).SetMeta(attrs)
+	obj.Attributes().
+		SetCrtime(attrs.Created).
+		SetCtime(attrs.Updated).
+		SetMtime(attrs.Updated).
+		SetSize(uint64(attrs.Size)).
+		SetMeta(attrs)
 	return obj
 }
 

--- a/plugin/gcp/storageObjectPrefix.go
+++ b/plugin/gcp/storageObjectPrefix.go
@@ -23,7 +23,12 @@ func newStorageObjectPrefix(bucket *storage.BucketHandle,
 		prefix:    prefix,
 	}
 	if attrs != nil {
-		pre.Attributes().SetMtime(attrs.Updated).SetSize(uint64(attrs.Size)).SetMeta(attrs)
+		pre.Attributes().
+			SetCrtime(attrs.Created).
+			SetCtime(attrs.Updated).
+			SetMtime(attrs.Updated).
+			SetSize(uint64(attrs.Size)).
+			SetMeta(attrs)
 	}
 	return pre
 }


### PR DESCRIPTION
They were accidentally omitted in initial creation and adding crtime.

Fixes #501.

Signed-off-by: Michael Smith <michael.smith@puppet.com>