### PR TITLE
PrivateIpAddress as failover target for SSH connections to AWS EC2 instance

### DIFF
--- a/plugin/aws/ec2Instance.go
+++ b/plugin/aws/ec2Instance.go
@@ -264,8 +264,10 @@ func (inst *ec2Instance) Exec(ctx context.Context, cmd string, args []string, op
 		hostname = name.(string)
 	} else if ipaddr, ok := meta["PublicIpAddress"]; ok && ipaddr != nil {
 		hostname = ipaddr.(string)
+	} else if ipaddr, ok := meta["PrivateIpAddress"]; ok && ipaddr != nil {
+		hostname = ipaddr.(string)
 	} else {
-		return nil, fmt.Errorf("No public interface found for %v", inst)
+		return nil, fmt.Errorf("No available interface found for %v", inst)
 	}
 
 	var identityfile string


### PR DESCRIPTION
This adds `PrivateIpAddress` as a last option for `hostname` when attempting to connect to an EC2 instance. If PrivateIpAddress is not available (which admittedly, it almost always is), then the `Exec` method will still throw an Error. 

This addresses one potential solution to the problem identified in issue #504 