### PR TITLE
Omit extra newline when printing winfo and meta output

### DIFF
--- a/cmd/info.go
+++ b/cmd/info.go
@@ -61,7 +61,7 @@ func infoMain(cmd *cobra.Command, args []string) exitCode {
 		return exitCode{1}
 	}
 
-	cmdutil.Println(marshalledEntry)
+	cmdutil.Print(marshalledEntry)
 
 	return exitCode{0}
 }

--- a/cmd/meta.go
+++ b/cmd/meta.go
@@ -61,7 +61,7 @@ func metaMain(cmd *cobra.Command, args []string) exitCode {
 		return exitCode{1}
 	}
 
-	cmdutil.Println(prettyMetadata)
+	cmdutil.Print(prettyMetadata)
 
 	return exitCode{0}
 }


### PR DESCRIPTION
Signed-off-by: Enis Inan <enis.inan@puppet.com>