### PR TITLE
Cleanup Travis CI, increase lint deadline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ services:
 - docker
 env:
   global:
-  - GO111MODULE=on
   - PROJECT_NAME=wash
   - WASH_DISABLE_ANALYTICS=true
   - HUGO_VERSION=0.57.1
@@ -25,7 +24,7 @@ jobs:
   - name: Lint with golangci-lint
     before_script:
     - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin $GOLANGCI_LINT_VERSION
-    script: golangci-lint run -v
+    script: GOGC=20 golangci-lint run -v --concurrency 1 --deadline 3m # https://github.com/golangci/golangci-lint/issues/337#issuecomment-510136513
   - name: Test that website builds
     install: curl -sfL https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_Linux-64bit.tar.gz | tar -xzC $(go env GOPATH)/bin
     script: hugo -s website


### PR DESCRIPTION
The latest version of golangci-lint is running slower and runs out of memory. See https://github.com/golangci/golangci-lint/issues/337 for ongoing work on improving it.

Triple the deadline to allow more time, and only run a single thread for testing to avoid running out of memory. Also make the garbage collector more aggressive to avoid holding onto excess memory.