### PR TITLE
Change munge.parseMode => munge.ToUintMode

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	github.com/gobwas/glob v0.2.3
 	github.com/gogo/protobuf v1.2.1 // indirect
 	github.com/golang-collections/collections v0.0.0-20130729185459-604e922904d3
+	github.com/google/btree v1.0.0 // indirect
 	github.com/google/uuid v1.1.1
 	github.com/googleapis/gnostic v0.2.2 // indirect
 	github.com/gorilla/context v1.1.1 // indirect

--- a/munge/mode.go
+++ b/munge/mode.go
@@ -6,7 +6,10 @@ import (
 	"strconv"
 )
 
-func parseMode(mode interface{}) (uint64, error) {
+// ToUintMode converts a given mode to a uint64.
+// The mode can be either an integer or a string
+// representing an octal/hex/decimal number.
+func ToUintMode(mode interface{}) (uint64, error) {
 	switch t := mode.(type) {
 	case uint64:
 		return t, nil
@@ -14,16 +17,16 @@ func parseMode(mode interface{}) (uint64, error) {
 		return uint64(t), nil
 	case float64:
 		if t != float64(uint64(t)) {
-			return 0, fmt.Errorf("could not parse mode: the provided mode %v is a decimal number", t)
+			return 0, fmt.Errorf("the provided mode %v is a decimal number", t)
 		}
 		return uint64(t), nil
 	case string:
 		if intMode, err := strconv.ParseUint(t, 0, 32); err == nil {
 			return intMode, nil
 		}
-		return 0, fmt.Errorf("could not parse mode: the provided mode %v is not a octal/hex/decimal number", t)
+		return 0, fmt.Errorf("the provided mode %v is not a octal/hex/decimal number", t)
 	default:
-		return 0, fmt.Errorf("could not parse mode: the provided mode %v is not a uint64, int64, float64, or string", mode)
+		return 0, fmt.Errorf("the provided mode %v is not a uint64, int64, float64, or string", mode)
 	}
 }
 
@@ -34,7 +37,7 @@ func ToFileMode(mode interface{}) (os.FileMode, error) {
 	if fileMode, ok := mode.(os.FileMode); ok {
 		return fileMode, nil
 	}
-	intMode, err := parseMode(mode)
+	intMode, err := ToUintMode(mode)
 	if err != nil {
 		return 0, err
 	}

--- a/munge/mode_test.go
+++ b/munge/mode_test.go
@@ -11,9 +11,9 @@ type ModeTestSuite struct {
 	MungeTestSuite
 }
 
-func (suite *ModeTestSuite) TestParseMode() {
+func (suite *ModeTestSuite) TestToUintMode() {
 	suite.mungeFunc = func(v interface{}) (interface{}, error) {
-		return parseMode(v)
+		return ToUintMode(v)
 	}
 	suite.runTestCases(
 		nTC(uint64(10), uint64(10)),

--- a/plugin/entryAttributes.go
+++ b/plugin/entryAttributes.go
@@ -285,13 +285,11 @@ func (a *EntryAttributes) UnmarshalJSON(data []byte) error {
 		a.SetCrtime(t)
 	}
 	if mode, ok := mp["mode"]; ok {
-		// Even though os.FileModes are uint32 types, json.Unmarshal unmarshals them as float64.
-		// That's ok, because float64 has sufficient precision to represent all uint32 types.
-		if raw, ok := mode.(float64); ok {
-			a.SetMode(os.FileMode(raw))
-		} else {
-			return attrMungeError("mode", fmt.Errorf("mode was unexpected type %T: %v", mode, mode))
+		md, err := munge.ToUintMode(mode)
+		if err != nil {
+			return attrMungeError("mode", err)
 		}
+		a.SetMode(os.FileMode(md))
 	}
 	if size, ok := mp["size"]; ok {
 		sz, err := munge.ToSize(size)

--- a/volume/stat_test.go
+++ b/volume/stat_test.go
@@ -83,7 +83,7 @@ func TestStatParse(t *testing.T) {
 
 	_, _, err = StatParse("96 1550611510 1550611448 1550611448 zebra mnt/path")
 	if assert.NotNil(t, err) {
-		assert.Regexp(t, regexp.MustCompile("parse.*mode.*zebra"), err.Error())
+		assert.Regexp(t, regexp.MustCompile("mode.*zebra"), err.Error())
 	}
 }
 


### PR DESCRIPTION
This makes mode serialization more flexible for external plugin authors
while also preserving the correctness of the individual bits.

Signed-off-by: Enis Inan <enis.inan@puppet.com>