### PR TITLE
Feature: Kubernetes pods now have containers.

### DIFF
--- a/plugin/kubernetes/container.go
+++ b/plugin/kubernetes/container.go
@@ -1,0 +1,150 @@
+package kubernetes
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/pkg/errors"
+	"github.com/puppetlabs/wash/activity"
+	"github.com/puppetlabs/wash/plugin"
+	corev1 "k8s.io/api/core/v1"
+	k8s "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/remotecommand"
+	k8exec "k8s.io/client-go/util/exec"
+)
+
+type container struct {
+	plugin.EntryBase
+	client *k8s.Clientset
+	config *rest.Config
+	ns	 string
+	pod *corev1.Pod
+}
+
+func newContainer(ctx context.Context, client *k8s.Clientset, config *rest.Config, ns string, c *corev1.Container, p *corev1.Pod) (*container, error) {
+	cntnr := &container{
+		EntryBase: plugin.NewEntry(c.Name),
+	}
+	cntnr.client = client
+	cntnr.config = config
+	cntnr.ns = ns
+	cntnr.pod = p
+
+	// TODO: Get container startup time from ContainerStatus from the parent Pod
+	cntnr.
+		Attributes().
+		SetMeta(plugin.ToJSONObject(c))
+
+	return cntnr, nil
+}
+
+func (c *container) Schema() *plugin.EntrySchema {
+	return plugin.
+		NewEntrySchema(c, "container").
+		SetMetaAttributeSchema(corev1.Container{})
+}
+
+func (c *container) Open(ctx context.Context) (plugin.SizedReader, error) {
+	logOptions := corev1.PodLogOptions{
+		Container: c.Name(),
+	}
+	req := c.client.CoreV1().Pods(c.ns).GetLogs(c.pod.Name, &logOptions)
+	rdr, err := req.Stream()
+	if err != nil {
+		return nil, err
+	}
+	var buf bytes.Buffer
+	var n int64
+	if n, err = buf.ReadFrom(rdr); err != nil {
+		return nil, fmt.Errorf("unable to read logs: %v", err)
+	}
+	activity.Record(ctx, "Read %v bytes of %v log", n, c.Name())
+
+	return bytes.NewReader(buf.Bytes()), nil
+}
+
+func (c *container) Stream(ctx context.Context) (io.ReadCloser, error) {
+	var tailLines int64 = 10
+	logOptions := corev1.PodLogOptions{
+		Container: c.Name(),
+		Follow: true,
+		TailLines: &tailLines,
+	}
+	req := c.client.CoreV1().Pods(c.ns).GetLogs(c.pod.Name, &logOptions)
+	return req.Stream()
+}
+
+func (c *container) Exec(ctx context.Context, cmd string, args []string, opts plugin.ExecOptions) (plugin.ExecCommand, error) {
+	execRequest := c.client.CoreV1().RESTClient().Post().
+		Resource("pods").
+		Name(c.pod.Name).
+		Namespace(c.ns).
+		SubResource("exec").
+		Param("command", cmd).
+		Param("container", c.Name()).
+		Param("stderr", "true").
+		Param("stdout", "true")
+
+	for _, arg := range args {
+		execRequest = execRequest.Param("command", arg)
+	}
+
+	if opts.Stdin != nil {
+		execRequest = execRequest.Param("stdin", "true")
+	}
+
+	executor, err := remotecommand.NewSPDYExecutor(c.config, "POST", execRequest.URL())
+	if err != nil {
+		return nil, errors.Wrap(err, "kubernetes.container.Exec request")
+	}
+
+	execCmd := plugin.NewExecCommand(ctx)
+
+	// If using a Tty, create an input stream that allows us to send Ctrl-C to end execution;
+	// when a Tty is allocated commands expect user input and will respond to control signals.
+	stdin := opts.Stdin
+	if opts.Tty {
+		r, w := io.Pipe()
+		if stdin != nil {
+			stdin = io.MultiReader(stdin, r)
+		} else {
+			stdin = r
+		}
+
+		execCmd.SetStopFunc(func() {
+			// Close the response on context cancellation. Copying will block until there's more to
+			// read from the exec output. For an action with no more output it may never return.
+			// Append Ctrl-C to input to signal end of execution.
+			_, err := w.Write([]byte{0x03})
+			activity.Record(ctx, "Sent ETX on context termination: %v", err)
+			w.Close()
+		})
+	}
+
+	go func() {
+		streamOpts := remotecommand.StreamOptions{
+			Stdout: execCmd.Stdout(),
+			Stderr: execCmd.Stderr(),
+			Stdin:  stdin,
+			Tty:    opts.Tty,
+		}
+		err = executor.Stream(streamOpts)
+		activity.Record(ctx, "Exec on %v complete: %v", c.Name(), err)
+		if err == nil {
+			execCmd.SetExitCode(0)
+		} else if exerr, ok := err.(k8exec.ExitError); ok {
+			execCmd.SetExitCode(exerr.ExitStatus())
+			err = nil
+		} else {
+			// Set the exit code error so that callers don't block
+			// when trying to retrieve the command's exit code
+			execCmd.SetExitCodeErr(err)
+		}
+		execCmd.CloseStreamsWithError(err)
+	}()
+
+	return execCmd, nil
+}

--- a/plugin/kubernetes/container.go
+++ b/plugin/kubernetes/container.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"time"
 
 	"github.com/pkg/errors"
 	"github.com/puppetlabs/wash/activity"
@@ -35,19 +34,20 @@ func newContainer(ctx context.Context, client *k8s.Clientset, config *rest.Confi
 	cntnr.pod = p
 
 	// Find when the container was started; set this as the creation time
-	creationTimestamp := time.Now()
 	for _, ecs := range cntnr.pod.Status.ContainerStatuses {
 		if ecs.Name == cntnr.EntryBase.Name() {
-			creationTimestamp = ecs.State.Running.StartedAt.Time
+			creationTimestamp := ecs.State.Running.StartedAt.Time
+			cntnr.
+				Attributes().
+				SetAtime(creationTimestamp).
+				SetCrtime(creationTimestamp).
+				SetMtime(creationTimestamp)
 			break
 		}
 	}
 
 	cntnr.
 		Attributes().
-		SetAtime(creationTimestamp).
-		SetCrtime(creationTimestamp).
-		SetMtime(creationTimestamp).
 		SetMeta(plugin.ToJSONObject(c))
 
 	return cntnr, nil

--- a/plugin/kubernetes/pod.go
+++ b/plugin/kubernetes/pod.go
@@ -1,19 +1,13 @@
 package kubernetes
 
 import (
-	"bytes"
 	"context"
-	"fmt"
-	"io"
 
-	"github.com/pkg/errors"
-	"github.com/puppetlabs/wash/activity"
 	"github.com/puppetlabs/wash/plugin"
+	"k8s.io/client-go/rest"
 	corev1 "k8s.io/api/core/v1"
 	k8s "k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/remotecommand"
-	k8exec "k8s.io/client-go/util/exec"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type pod struct {
@@ -46,94 +40,28 @@ func (p *pod) Schema() *plugin.EntrySchema {
 		SetMetaAttributeSchema(corev1.Pod{})
 }
 
-func (p *pod) Open(ctx context.Context) (plugin.SizedReader, error) {
-	req := p.client.CoreV1().Pods(p.ns).GetLogs(p.Name(), &corev1.PodLogOptions{})
-	rdr, err := req.Stream()
+func (p *pod) ChildSchemas() []*plugin.EntrySchema {
+	return []*plugin.EntrySchema{
+		(&container{}).Schema(),
+	}
+}
+
+func (p *pod) List(ctx context.Context) ([]plugin.Entry, error) {
+	pd, err := p.client.CoreV1().Pods(p.ns).Get(p.Name(), metav1.GetOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("unable to access logs: %v", err)
-	}
-	var buf bytes.Buffer
-	var n int64
-	if n, err = buf.ReadFrom(rdr); err != nil {
-		return nil, fmt.Errorf("unable to read logs: %v", err)
-	}
-	activity.Record(ctx, "Read %v bytes of %v log", n, p.Name())
-	return bytes.NewReader(buf.Bytes()), nil
-}
-
-func (p *pod) Stream(ctx context.Context) (io.ReadCloser, error) {
-	var tailLines int64 = 10
-	req := p.client.CoreV1().Pods(p.ns).GetLogs(p.Name(), &corev1.PodLogOptions{Follow: true, TailLines: &tailLines})
-	return req.Stream()
-}
-
-func (p *pod) Exec(ctx context.Context, cmd string, args []string, opts plugin.ExecOptions) (plugin.ExecCommand, error) {
-	execRequest := p.client.CoreV1().RESTClient().Post().
-		Resource("pods").
-		Name(p.Name()).
-		Namespace(p.ns).
-		SubResource("exec").
-		Param("stdout", "true").
-		Param("stderr", "true").
-		Param("command", cmd)
-
-	for _, arg := range args {
-		execRequest = execRequest.Param("command", arg)
+		return nil, err
 	}
 
-	if opts.Stdin != nil {
-		execRequest = execRequest.Param("stdin", "true")
-	}
-
-	executor, err := remotecommand.NewSPDYExecutor(p.config, "POST", execRequest.URL())
-	if err != nil {
-		return nil, errors.Wrap(err, "kubernetes.pod.Exec request")
-	}
-
-	execCmd := plugin.NewExecCommand(ctx)
-
-	// If using a Tty, create an input stream that allows us to send Ctrl-C to end execution;
-	// when a Tty is allocated commands expect user input and will respond to control signals.
-	stdin := opts.Stdin
-	if opts.Tty {
-		r, w := io.Pipe()
-		if stdin != nil {
-			stdin = io.MultiReader(stdin, r)
-		} else {
-			stdin = r
+	entries := make([]plugin.Entry, len(pd.Spec.Containers))
+	for i, c := range pd.Spec.Containers {
+		c, err := newContainer(ctx, p.client, p.config, p.ns, &c, pd)
+		if err != nil {
+			return nil, err
 		}
 
-		execCmd.SetStopFunc(func() {
-			// Close the response on context cancellation. Copying will block until there's more to
-			// read from the exec output. For an action with no more output it may never return.
-			// Append Ctrl-C to input to signal end of execution.
-			_, err := w.Write([]byte{0x03})
-			activity.Record(ctx, "Sent ETX on context termination: %v", err)
-			w.Close()
-		})
+		entries[i] = c
 	}
 
-	go func() {
-		streamOpts := remotecommand.StreamOptions{
-			Stdout: execCmd.Stdout(),
-			Stderr: execCmd.Stderr(),
-			Stdin:  stdin,
-			Tty:    opts.Tty,
-		}
-		err = executor.Stream(streamOpts)
-		activity.Record(ctx, "Exec on %v complete: %v", p.Name(), err)
-		if err == nil {
-			execCmd.SetExitCode(0)
-		} else if exerr, ok := err.(k8exec.ExitError); ok {
-			execCmd.SetExitCode(exerr.ExitStatus())
-			err = nil
-		} else {
-			// Set the exit code error so that callers don't block
-			// when trying to retrieve the command's exit code
-			execCmd.SetExitCodeErr(err)
-		}
-		execCmd.CloseStreamsWithError(err)
-	}()
-
-	return execCmd, nil
+	return entries, nil
 }
+

--- a/plugin/kubernetes/podsDir.go
+++ b/plugin/kubernetes/podsDir.go
@@ -4,9 +4,9 @@ import (
 	"context"
 
 	"github.com/puppetlabs/wash/plugin"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8s "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type podsDir struct {


### PR DESCRIPTION
* Kubernetes pods are now represented as directories holding containers.
* Individual containers within a pod can be logged and executed on.

@MikaelSmith You pretty much called it. I created a `container` struct and put most of the logic from 'pod.go` into `container.go`.

To test this I ran `wexec` on the containers within a pod to exercise `Exec`, and ran `cat` to exercise `Open` and `tail -f` to exercise `Stream` on the container files. I used the following Kubernetes manifest file to spawn the Pods:

```yaml
apiVersion: v1
kind: Pod
metadata:
  name: moon
spec:
  containers:
  - image: alpine:latest
    name: face
    command: ["/bin/sh", "-c", "apk -U add curl && curl https://raw.githubusercontent.com/puppetlabs/wash/master/plugin/kubernetes/pod.go && sleep 10000"]
  - image: alpine:latest
    name: dark-side
    command: ["/bin/sh", "-c", "apk -U add curl && curl https://raw.githubusercontent.com/puppetlabs/wash/master/plugin/kubernetes/podsDir.go"]

---

apiVersion: v1
kind: Pod
metadata:
  name: sun
spec:
  containers:
  - image: alpine:latest
    name: shine 
    command: ["/bin/sh", "-c", "apk -U add curl && curl https://raw.githubusercontent.com/puppetlabs/wash/master/README.md && sleep 12345"]
```

Let me know if anything should be tweaked or implemented differently. I'm glad to make changes.

Since there weren't any automated tests in that part of the project I didn't add any. I'm feel like Kubernetes has to have some mocking framework we can use for stuff like this...

Fixes #228 