### PR TITLE
Update find examples to be a bit more idiomatic with plugin usage

### DIFF
--- a/cmd/internal/find/parser/parseExpression.go
+++ b/cmd/internal/find/parser/parseExpression.go
@@ -132,8 +132,13 @@ find . -path "docker*containers*" \( -name "*c" -o -name "*d" \) -mtime -1h
     have been parsed as '-name "*c" OR ( -name "*d" AND -mtime -1h)',
     which is a completely different predicate.
 
-find kubernetes -daystart -k '*pod' -m .status.startTime -{1d}
-    Print out all the Kubernetes pods that started today.
+find kubernetes/docker-for-desktop -daystart -k '*pod' -m .status.startTime -{1d}
+    Print out all the Kubernetes pods that started today in the docker-for-desktop
+    context. To see why this is correct, note that the -daystart option sets the
+    reference time to the start of the current day w.r.t your location. -{1d} returns
+    true if the given time value is less than 24 hours _past_ the reference time
+    (daystart). Hence, it will return true if the given time value (start time)
+    is within the current day (today).
 
 find docker/containers -daystart -fullmeta -m .state.startedAt -{1d}
     Prints out all the Docker containers that were started today. Note that the

--- a/cmd/internal/find/primary/kind.go
+++ b/cmd/internal/find/primary/kind.go
@@ -98,14 +98,6 @@ find docker -k '*container'
     with '*' makes the query less dependent on a plugin's hierarchy (and hence more
     expressive).
 
-find -kind 'docker/*container'
-find -k 'docker/*container'
-    This also prints out all Docker containers. Here, the cwd is assumed to be the
-    mountpoint. Note that the reason we write 'docker/' instead of '*docker' or
-    'docker*' is because one could have multiple plugins containing the name "docker"
-    (e.g. "mock_docker", "docker_two"). Writing the pattern as 'docker/' ensures that
-    only the "docker" plugin's entries are checked.
-
 find docker aws -kind '*metadata.json'
 find docker aws -k '*metadata.json'
     This prints out all the metadata.json entries in the docker and aws plugins. Here, the
@@ -113,23 +105,23 @@ find docker aws -k '*metadata.json'
     conceptual example. It is meant to showcase how the kind primary works when multiple
     paths are passed into find.
 
-find aws -kind '*s3*bucket'
-find aws -k '*s3*bucket'
-    This prints out all S3 buckets.
+find aws/demo -kind '*s3*bucket'
+find aws/demo -k '*s3*bucket'
+    This prints out all S3 buckets in the demo profile.
 
 find docker -kind '*volumes*dir'
 find docker -k '*volumes*dir'
-	This prints out all Docker volume directories.
+    This prints out all Docker volume directories.
 
 find docker -kind '*container' -mtime -1h
 find docker -k '*container' -mtime -1h
-	This prints out all Docker containers that were modified within the last hour. Note that
-	without the kind primary, find would have visited all entries in the Docker plugin.
+    This prints out all Docker containers that were modified within the last hour. Note that
+    without the kind primary, find would have visited all entries in the Docker plugin.
 
 find -kind 'docker/*container' -o -k 'aws/*ec2*instance' -mtime -1h
 find -k 'docker/*container' -o -k 'aws/*ec2*instance' -mtime -1h
-	This prints out all Docker containers and EC2 instances that were modified within the
-	last hour.
+    This prints out all Docker containers and EC2 instances that were modified within the
+    last hour.
 
 NOTE: You can use 'stree <path>' to determine an entry's kind. For example, if <path>
 is "docker", then

--- a/cmd/internal/find/primary/meta.go
+++ b/cmd/internal/find/primary/meta.go
@@ -522,33 +522,33 @@ In these examples, let "m" be the value of the entry's 'meta' attribute.
     and o['value'] has expired. In the real world, this example could be combined with the
     kind primary to filter out all EC2 instances whose termination_date tag expired. The
     expression would look something like
-        find aws -k '*ec2*instance' -m '.tags[?]' .key termination_date -a .value +0h
+        find aws/demo -k '*ec2*instance' -m '.tags[?]' .key termination_date -a .value +0h
 
 -m '.tags[?]' .key termination_date -a .value -{1w}
     Same as the previous example, except this returns true if o['value'] will expire within
     the current week. In the real world, this example could be combined with the kind primary
     to filter out all EC2 instances whose termination_date tag will expire within the current
     week. The expression would look something like
-        find aws -k '*ec2*instance' -m '.tags[?]' .key termination_date -a .value -{1w}
+        find aws/demo -k '*ec2*instance' -m '.tags[?]' .key termination_date -a .value -{1w}
 
 -m '.tags[?]' .key \( sales -o product \)
     Returns true if m['tags'] has at least one object o s.t. o['key'] == sales OR product.
     In the real world, this example could be combined with the kind primary to filter out all
     EC2 instances that have a "sales" or "product" tag. The expression would look something
     like
-        find aws -k '*ec2*instance' -m '.tags[?]' .key \( sales -o product \)
+        find aws/demo -k '*ec2*instance' -m '.tags[?]' .key \( sales -o product \)
 
 -m .state.name pending -o running
     Returns true if m['state']['name'] == pending OR running. In the real world, this
     example could be combined with the kind primary to filter out pending/running EC2 instances.
     The expression would look something like
-        find aws -k '*ec2*instance' -m .state.name pending -o running
+        find aws/demo -k '*ec2*instance' -m .state.name pending -o running
 
 -m .vpcid vpc-0eb70f7f626d3db84
     Returns true if m['vpcid'] == vpc-0eb70f7f626d3db84. In the real world, this example
     could be combined with the kind primary to filter out EC2 instances attached to the VPC with ID
     vpc-0eb70f7f626d3db84. The expression would look something like
-        find aws -k '*ec2*instance' -m .vpcid vpc-0eb70f7f626d3db84
+        find aws/demo -k '*ec2*instance' -m .vpcid vpc-0eb70f7f626d3db84
 
     NOTE: With regex/glob support, this example could be shortened to something like
     "-m .vpcid vpc-0eb.*"

--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,6 @@ require (
 	github.com/gobwas/glob v0.2.3
 	github.com/gogo/protobuf v1.2.1 // indirect
 	github.com/golang-collections/collections v0.0.0-20130729185459-604e922904d3
-	github.com/google/btree v1.0.0 // indirect
 	github.com/google/uuid v1.1.1
 	github.com/googleapis/gnostic v0.2.2 // indirect
 	github.com/gorilla/context v1.1.1 // indirect


### PR DESCRIPTION
For example, AWS users will likely filter stuff in a given profile,
_not_ over the entire plugin.

Signed-off-by: Enis Inan <enis.inan@puppet.com>