### PR TITLE
Allow Docker API version negotiation

### DIFF
--- a/plugin/docker/root.go
+++ b/plugin/docker/root.go
@@ -21,7 +21,7 @@ type Root struct {
 
 // Init for root
 func (r *Root) Init(map[string]interface{}) error {
-	dockerCli, err := client.NewClientWithOpts(client.FromEnv)
+	dockerCli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Users shouldn't need to know the Docker API version they're using.
Default to negotiating the version.

Fixes #526.

Signed-off-by: Michael Smith <michael.smith@puppet.com>