### PR TITLE
Fix unit test that assumed Wash binary existed

### DIFF
--- a/cmd/internal/shell/basic_test.go
+++ b/cmd/internal/shell/basic_test.go
@@ -4,7 +4,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -18,10 +17,12 @@ func TestBasic(t *testing.T) {
 	defer os.RemoveAll(tmpdir)
 
 	sh := basic{sh: "/bin/sh"}
-	comm, err := sh.Command([]string{"help"}, tmpdir)
+	_, err = sh.Command([]string{"help"}, tmpdir)
 	assert.NoError(t, err)
-	comm.Stdin = strings.NewReader(filepath.Join(tmpdir, "help"))
-	output, err := comm.Output()
+
+	helpfile := filepath.Join(tmpdir, "help")
+	assert.FileExists(t, helpfile)
+	bits, err := ioutil.ReadFile(helpfile)
 	assert.NoError(t, err)
-	assert.Contains(t, string(output), "Available Commands")
+	assert.Contains(t, string(bits), "#!/bin/sh\nWASH_EMBEDDED=1 exec wash help \"$@\"")
 }


### PR DESCRIPTION
Unit tests shouldn't assume that a `wash` binary exists. Switch to
verifying that a shell script exists where we expect it.

Signed-off-by: Michael Smith <michael.smith@puppet.com>