### PR TITLE
Fix GCS and S3 bucket object read on Linux

### DIFF
--- a/plugin/aws/s3Object.go
+++ b/plugin/aws/s3Object.go
@@ -122,7 +122,7 @@ func (s *s3ObjectReader) ReadAt(p []byte, off int64) (int, error) {
 	}
 	defer s.closeContent(content)
 
-	return io.ReadFull(content, p)
+	return content.Read(p)
 }
 
 func (s *s3ObjectReader) Size() int64 {

--- a/plugin/gcp/storageObject.go
+++ b/plugin/gcp/storageObject.go
@@ -2,7 +2,6 @@ package gcp
 
 import (
 	"context"
-	"io"
 
 	"cloud.google.com/go/storage"
 	"github.com/puppetlabs/wash/plugin"
@@ -48,7 +47,7 @@ func (r *objectReader) ReadAt(p []byte, off int64) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	return io.ReadFull(rdr, p)
+	return rdr.Read(p)
 }
 
 func (r *objectReader) Size() int64 {


### PR DESCRIPTION
The fuse implementation on Linux attempts to perform block aligned
reads; this behavior conflicts with Go's `io.ReadFull`. `ReadFull`
will produce an error when the read is shorter than the buffer and does
not account for non-block aligned files.

This commit fixes the issue by performing a simple `Read` to allow for
read lengths that don't match the block size.

This fixes #532.