### PR TITLE
Only use relative path when in Wash tree

### DIFF
--- a/cmd/internal/shell/bash.go
+++ b/cmd/internal/shell/bash.go
@@ -46,7 +46,7 @@ func (b bash) Command(subcommands []string, rundir string) (*exec.Cmd, error) {
 function prompter() {
   local prompt_path
   if [ -x "$(command -v realpath)" ]; then
-    prompt_path=$(realpath --relative-to=$W $(pwd))
+    prompt_path=$(realpath --relative-base=$W $(pwd))
   else
     prompt_path=$(basename $(pwd))
   fi

--- a/cmd/internal/shell/zsh.go
+++ b/cmd/internal/shell/zsh.go
@@ -56,7 +56,7 @@ fi
 function prompter() {
   local prompt_path
   if [ -x "$(command -v realpath)" ]; then
-    prompt_path=$(realpath --relative-to=$W $(pwd))
+    prompt_path=$(realpath --relative-base=$W $(pwd))
   else
     prompt_path=$(basename $(pwd))
   fi


### PR DESCRIPTION
When navigating out of the Wash tree, using relative path is confusing.
Use `--relative-base` instead of `--relative-to` so that we only use a
relative path within Wash when we're in that tree, otherwise it will use
an absolute local path.

Resolves #535.

Signed-off-by: Michael Smith <michael.smith@puppet.com>