### PR TITLE
Provide context when the underlying fuse commands fail

### DIFF
--- a/fuse/core.go
+++ b/fuse/core.go
@@ -193,7 +193,7 @@ func ServeFuseFS(
 	log.Infof("FUSE: Mounting at %v", mountpoint)
 	fuseConn, err := fuse.Mount(mountpoint)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, mountFailedErr(err)
 	}
 
 	// Start the FUSE server. We use the serverExitedCh to catch externally triggered unmounts.

--- a/fuse/fuseExit_darwin.go
+++ b/fuse/fuseExit_darwin.go
@@ -1,0 +1,22 @@
+package fuse
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+
+	"bazil.org/fuse"
+)
+
+func mountFailedErr(err error) error {
+	if exited, ok := err.(*exec.ExitError); ok {
+		// load_osxfuse or mount_osxfuse failed. We can't determine which here.
+		// Determine which would have been used so we can return the full path.
+		for _, loc := range []fuse.OSXFUSEPaths{fuse.OSXFUSELocationV3, fuse.OSXFUSELocationV2} {
+			if _, err := os.Stat(loc.Mount); !os.IsNotExist(err) {
+				return fmt.Errorf("Received %v running %v or %v", exited, loc.Load, loc.Mount)
+			}
+		}
+	}
+	return err
+}

--- a/fuse/fuseExit_freebsd.go
+++ b/fuse/fuseExit_freebsd.go
@@ -1,0 +1,13 @@
+package fuse
+
+import (
+	"fmt"
+	"os/exec"
+)
+
+func mountFailedErr(err error) error {
+	if exited, ok := err.(*exec.ExitError); ok {
+		return fmt.Errorf("Received %v running /sbin/mount_fusefs", exited)
+	}
+	return err
+}

--- a/fuse/fuseExit_linux.go
+++ b/fuse/fuseExit_linux.go
@@ -1,0 +1,13 @@
+package fuse
+
+import (
+	"fmt"
+	"os/exec"
+)
+
+func mountFailedErr(err error) error {
+	if exited, ok := err.(*exec.ExitError); ok {
+		return fmt.Errorf("Received %v running fusermount", exited)
+	}
+	return err
+}


### PR DESCRIPTION
Our FUSE library execs out to fuse commands to initialize FUSE (on
macOS) and mount the filesystem. If these fail with a non-zero exit
code, the error returned doesn't provide useful context about what
failed. Add that context so it's easier for someone to debug.

Fixes #540.

Signed-off-by: Michael Smith <michael.smith@puppet.com>