### PR TITLE
Omit restricted resource types in GCP and AWS

### DIFF
--- a/cmd/stree.go
+++ b/cmd/stree.go
@@ -15,7 +15,11 @@ func streeCommand() *cobra.Command {
 		Use:   "stree [<path>...]",
 		Short: "Displays the entry's stree (schema-tree)",
 		Long: `Displays the entry's stree (schema-tree), which is a high-level overview of the entry's
-hierarchy. Non-singleton types are bracketed with "[]".`,
+hierarchy. Non-singleton types are bracketed with "[]".
+
+If a subdirectory is listed in 'stree' but not visible in your directory then you are
+likely lacking permissions to enumerate that type of resource. View the 'whistory' entry
+for listing the directory to see why it's not included.`,
 		RunE: toRunE(streeMain),
 	}
 	return streeCmd

--- a/docs/docs/external-plugins.md
+++ b/docs/docs/external-plugins.md
@@ -270,6 +270,8 @@ This section describes the JSON object representing a serialized entry. An entry
 
 * `slash_replacer` is a single character that overrides the default slash replacer.
 
+* `inaccessible_reason` is a string specifying why the entry is inaccessible. The current plugin configuration may not provide sufficient permissions to access a particular resource. Rather than triggering an error in Wash, this resource can be omitted when listing available resources. The `inaccessible_reason` attribute provides a place to flag that the resource should be omitted from list results and log a reason for its omission.
+
 Below is an example entry JSON object showcasing all the possible keys at once.
 
 ```
@@ -285,7 +287,8 @@ Below is an example entry JSON object showcasing all the possible keys at once.
   "cache_ttls": {
     "read": 10
   },
-  "slash_replacer": ":"
+  "slash_replacer": ":",
+  "inaccessible_reason": "permission denied"
 }
 ```
 

--- a/plugin/aws/ec2Dir.go
+++ b/plugin/aws/ec2Dir.go
@@ -14,7 +14,6 @@ type ec2Dir struct {
 	plugin.EntryBase
 	session *session.Session
 	client  *ec2Client.EC2
-	entries []plugin.Entry
 }
 
 func newEC2Dir(session *session.Session) *ec2Dir {
@@ -24,11 +23,6 @@ func newEC2Dir(session *session.Session) *ec2Dir {
 	ec2Dir.DisableDefaultCaching()
 	ec2Dir.session = session
 	ec2Dir.client = ec2Client.New(session)
-
-	ec2Dir.entries = []plugin.Entry{
-		newEC2InstancesDir(ec2Dir.session, ec2Dir.client),
-	}
-
 	return ec2Dir
 }
 
@@ -43,5 +37,5 @@ func (e *ec2Dir) ChildSchemas() []*plugin.EntrySchema {
 }
 
 func (e *ec2Dir) List(ctx context.Context) ([]plugin.Entry, error) {
-	return e.entries, nil
+	return []plugin.Entry{newEC2InstancesDir(ctx, e.session, e.client)}, nil
 }

--- a/plugin/aws/ec2InstancesDir.go
+++ b/plugin/aws/ec2InstancesDir.go
@@ -21,12 +21,15 @@ type ec2InstancesDir struct {
 	client  *ec2Client.EC2
 }
 
-func newEC2InstancesDir(session *session.Session, client *ec2Client.EC2) *ec2InstancesDir {
+func newEC2InstancesDir(ctx context.Context, session *session.Session, client *ec2Client.EC2) *ec2InstancesDir {
 	ec2InstancesDir := &ec2InstancesDir{
 		EntryBase: plugin.NewEntry("instances"),
 	}
 	ec2InstancesDir.session = session
 	ec2InstancesDir.client = client
+	if _, err := plugin.List(ctx, ec2InstancesDir); err != nil {
+		ec2InstancesDir.MarkInaccessible(ctx, err)
+	}
 	return ec2InstancesDir
 }
 

--- a/plugin/aws/resourcesDir.go
+++ b/plugin/aws/resourcesDir.go
@@ -10,8 +10,7 @@ import (
 // resourcesDir represents the <profile>/resources directory
 type resourcesDir struct {
 	plugin.EntryBase
-	session   *session.Session
-	resources []plugin.Entry
+	session *session.Session
 }
 
 func newResourcesDir(session *session.Session) *resourcesDir {
@@ -20,12 +19,6 @@ func newResourcesDir(session *session.Session) *resourcesDir {
 	}
 	resourcesDir.DisableDefaultCaching()
 	resourcesDir.session = session
-
-	resourcesDir.resources = []plugin.Entry{
-		newS3Dir(resourcesDir.session),
-		newEC2Dir(resourcesDir.session),
-	}
-
 	return resourcesDir
 }
 
@@ -42,5 +35,8 @@ func (r *resourcesDir) ChildSchemas() []*plugin.EntrySchema {
 
 // List lists the available AWS resources
 func (r *resourcesDir) List(ctx context.Context) ([]plugin.Entry, error) {
-	return r.resources, nil
+	return []plugin.Entry{
+		newS3Dir(ctx, r.session),
+		newEC2Dir(r.session),
+	}, nil
 }

--- a/plugin/aws/s3Dir.go
+++ b/plugin/aws/s3Dir.go
@@ -18,12 +18,15 @@ type s3Dir struct {
 	client  *s3Client.S3
 }
 
-func newS3Dir(session *session.Session) *s3Dir {
+func newS3Dir(ctx context.Context, session *session.Session) *s3Dir {
 	s3Dir := &s3Dir{
 		EntryBase: plugin.NewEntry("s3"),
 	}
 	s3Dir.session = session
 	s3Dir.client = s3Client.New(session)
+	if _, err := plugin.List(ctx, s3Dir); err != nil {
+		s3Dir.MarkInaccessible(ctx, err)
+	}
 	return s3Dir
 }
 

--- a/plugin/cache.go
+++ b/plugin/cache.go
@@ -27,9 +27,9 @@ func InitCache() {
 	}
 }
 
-// SetTestCache sets the cache to the provided mock. It can only be called
-// by the tests
-func SetTestCache(c datastore.Cache) {
+// SetTestCache sets the cache to the provided mock. It can only be called by the tests.
+// Returns a context that includes a parent ID so later cache operations will succeed.
+func SetTestCache(c datastore.Cache) context.Context {
 	if notRunningTests() {
 		panic("SetTestCache can only be called when running the tests")
 	}
@@ -39,6 +39,7 @@ func SetTestCache(c datastore.Cache) {
 	}
 
 	cache = c
+	return context.WithValue(context.Background(), parentID, "/")
 }
 
 // UnsetTestCache unsets the test cache. It can only be called
@@ -172,6 +173,11 @@ func cachedList(ctx context.Context, p Parent) (map[string]Entry, error) {
 					SecondChildSlashReplacer: entry.slashReplacer(),
 					CName:                    cname,
 				}
+			}
+
+			if entry.isInaccessible() {
+				// Skip entries that are expected to be inaccessible.
+				continue
 			}
 			searchedEntries[cname] = entry
 

--- a/plugin/entryBase.go
+++ b/plugin/entryBase.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"flag"
 	"time"
+
+	"github.com/puppetlabs/wash/activity"
 )
 
 type defaultOpCode int8
@@ -43,6 +45,7 @@ type EntryBase struct {
 	ttl             [3]time.Duration
 	wrappedTypesMap SchemaMap
 	prefetched      bool
+	inaccessible    bool
 }
 
 // NewEntry creates a new entry
@@ -131,6 +134,17 @@ func (e *EntryBase) Attributes() *EntryAttributes {
 func (e *EntryBase) SetAttributes(attr EntryAttributes) *EntryBase {
 	e.attr = attr
 	return e
+}
+
+func (e *EntryBase) isInaccessible() bool {
+	return e.inaccessible
+}
+
+// MarkInaccessible sets the inaccessible attribute and logs a message about why the entry is
+// inaccessible.
+func (e *EntryBase) MarkInaccessible(ctx context.Context, err error) {
+	activity.Record(ctx, "Omitting %v: %v", e.id(), err)
+	e.inaccessible = true
 }
 
 // Prefetched marks the entry as a prefetched entry. A prefetched entry

--- a/plugin/externalPluginEntry_test.go
+++ b/plugin/externalPluginEntry_test.go
@@ -67,15 +67,15 @@ type ExternalPluginEntryTestSuite struct {
 func (suite *ExternalPluginEntryTestSuite) TestDecodeExternalPluginEntryRequiredFields() {
 	decodedEntry := decodedExternalPluginEntry{}
 
-	_, err := decodedEntry.toExternalPluginEntry(false, false)
+	_, err := decodedEntry.toExternalPluginEntry(context.Background(), false, false)
 	suite.Regexp("name", err)
 	decodedEntry.Name = "decodedEntry"
 
-	_, err = decodedEntry.toExternalPluginEntry(false, false)
+	_, err = decodedEntry.toExternalPluginEntry(context.Background(), false, false)
 	suite.Regexp("methods", err)
 	decodedEntry.Methods = []interface{}{"list"}
 
-	entry, err := decodedEntry.toExternalPluginEntry(false, false)
+	entry, err := decodedEntry.toExternalPluginEntry(context.Background(), false, false)
 	if suite.NoError(err) {
 		suite.Equal(decodedEntry.Name, entry.name())
 		suite.Equal(1, len(entry.methods))
@@ -90,7 +90,7 @@ func (suite *ExternalPluginEntryTestSuite) TestDecodeExternalPluginEntryExtraFie
 		Methods: []interface{}{"list", "stream"},
 	}
 
-	entry, err := decodedEntry.toExternalPluginEntry(false, false)
+	entry, err := decodedEntry.toExternalPluginEntry(context.Background(), false, false)
 	if suite.NoError(err) {
 		suite.Equal(decodedEntry.Name, entry.name())
 		suite.Contains(entry.methods, "list")
@@ -112,7 +112,7 @@ func (suite *ExternalPluginEntryTestSuite) TestDecodeExternalPluginEntry_Support
 		Methods: []interface{}{},
 	}
 
-	entry, err := decodedEntry.toExternalPluginEntry(false, false)
+	entry, err := decodedEntry.toExternalPluginEntry(context.Background(), false, false)
 	if suite.NoError(err) {
 		suite.Equal(decodedEntry.Name, entry.name())
 	}
@@ -125,7 +125,7 @@ func (suite *ExternalPluginEntryTestSuite) TestDecodeExternalPluginEntryWithMeth
 		Methods: []interface{}{[]interface{}{"list", []interface{}{childEntry}}, "read"},
 	}
 
-	entry, err := decodedEntry.toExternalPluginEntry(false, false)
+	entry, err := decodedEntry.toExternalPluginEntry(context.Background(), false, false)
 	if suite.NoError(err) {
 		suite.Equal(decodedEntry.Name, entry.name())
 		suite.Contains(entry.methods, "list")
@@ -146,7 +146,7 @@ func newMockDecodedEntry(name string) decodedExternalPluginEntry {
 func (suite *ExternalPluginEntryTestSuite) TestDecodeExternalPluginEntryWithState() {
 	decodedEntry := newMockDecodedEntry("name")
 	decodedEntry.State = "some state"
-	entry, err := decodedEntry.toExternalPluginEntry(false, false)
+	entry, err := decodedEntry.toExternalPluginEntry(context.Background(), false, false)
 	if suite.NoError(err) {
 		suite.Equal(decodedEntry.State, entry.state)
 	}
@@ -155,7 +155,7 @@ func (suite *ExternalPluginEntryTestSuite) TestDecodeExternalPluginEntryWithStat
 func (suite *ExternalPluginEntryTestSuite) TestDecodeExternalPluginEntryWithCacheTTLs() {
 	decodedEntry := newMockDecodedEntry("name")
 	decodedEntry.CacheTTLs = decodedCacheTTLs{List: 1}
-	entry, err := decodedEntry.toExternalPluginEntry(false, false)
+	entry, err := decodedEntry.toExternalPluginEntry(context.Background(), false, false)
 	if suite.NoError(err) {
 		expectedTTLs := NewEntry("foo").ttl
 		expectedTTLs[ListOp] = decodedEntry.CacheTTLs.List * time.Second
@@ -167,11 +167,11 @@ func (suite *ExternalPluginEntryTestSuite) TestDecodeExternalPluginEntryWithSlas
 	decodedEntry := newMockDecodedEntry("name")
 	decodedEntry.SlashReplacer = "a string"
 	suite.Panics(
-		func() { _, _ = decodedEntry.toExternalPluginEntry(false, false) },
+		func() { _, _ = decodedEntry.toExternalPluginEntry(context.Background(), false, false) },
 		"e.SlashReplacer: received string a string instead of a character",
 	)
 	decodedEntry.SlashReplacer = ":"
-	entry, err := decodedEntry.toExternalPluginEntry(false, false)
+	entry, err := decodedEntry.toExternalPluginEntry(context.Background(), false, false)
 	if suite.NoError(err) {
 		suite.Equal(':', entry.slashReplacer())
 	}
@@ -181,7 +181,7 @@ func (suite *ExternalPluginEntryTestSuite) TestDecodeExternalPluginEntryWithAttr
 	decodedEntry := newMockDecodedEntry("name")
 	t := time.Now()
 	decodedEntry.Attributes.SetCtime(t)
-	entry, err := decodedEntry.toExternalPluginEntry(false, false)
+	entry, err := decodedEntry.toExternalPluginEntry(context.Background(), false, false)
 	if suite.NoError(err) {
 		expectedAttr := EntryAttributes{}
 		expectedAttr.SetCtime(t)
@@ -194,7 +194,7 @@ func (suite *ExternalPluginEntryTestSuite) TestDecodeExternalPluginEntryWithSche
 		Name:    "decodedEntry",
 		Methods: []interface{}{"list"},
 	}
-	entry, err := decodedEntry.toExternalPluginEntry(false, false)
+	entry, err := decodedEntry.toExternalPluginEntry(context.Background(), false, false)
 	if suite.NoError(err) {
 		suite.False(entry.schemaKnown)
 	}
@@ -205,7 +205,7 @@ func (suite *ExternalPluginEntryTestSuite) TestDecodeExternalPluginEntryWithSche
 		Name:    "decodedEntry",
 		Methods: []interface{}{"list", "schema"},
 	}
-	_, err := decodedEntry.toExternalPluginEntry(false, false)
+	_, err := decodedEntry.toExternalPluginEntry(context.Background(), false, false)
 	suite.Regexp("decodedEntry.*implements.*schema.*no.*type.*ID", err)
 }
 
@@ -215,7 +215,7 @@ func (suite *ExternalPluginEntryTestSuite) TestDecodeExternalPluginEntryWithSche
 		Methods: []interface{}{"list", "schema"},
 		TypeID:  "foo",
 	}
-	_, err := decodedEntry.toExternalPluginEntry(false, false)
+	_, err := decodedEntry.toExternalPluginEntry(context.Background(), false, false)
 	suite.Regexp("decodedEntry.*foo.*implements.*schema.*root", err)
 }
 
@@ -225,7 +225,7 @@ func (suite *ExternalPluginEntryTestSuite) TestDecodeExternalPluginEntryWithSche
 		Methods: []interface{}{"list"},
 		TypeID:  "foo",
 	}
-	_, err := decodedEntry.toExternalPluginEntry(true, false)
+	_, err := decodedEntry.toExternalPluginEntry(context.Background(), true, false)
 	suite.Regexp("decodedEntry.*foo.*must.*implement.*schema", err)
 }
 
@@ -234,7 +234,7 @@ func (suite *ExternalPluginEntryTestSuite) TestDecodeExternalPluginEntryWithSche
 		Name:    "decodedEntry",
 		Methods: []interface{}{"list", "schema"},
 	}
-	_, err := decodedEntry.toExternalPluginEntry(true, false)
+	_, err := decodedEntry.toExternalPluginEntry(context.Background(), true, false)
 	suite.Regexp("decodedEntry.*implements.*schema.*no.*type.*ID", err)
 }
 
@@ -247,7 +247,7 @@ func (suite *ExternalPluginEntryTestSuite) TestDecodeExternalPluginEntryWithSche
 		},
 		TypeID: "foo",
 	}
-	_, err := decodedEntry.toExternalPluginEntry(true, false)
+	_, err := decodedEntry.toExternalPluginEntry(context.Background(), true, false)
 	suite.Regexp("decodedEntry.*foo.*plugin.*roots.*support.*prefetching", err)
 }
 
@@ -257,10 +257,23 @@ func (suite *ExternalPluginEntryTestSuite) TestDecodeExternalPluginEntryWithSche
 		Methods: []interface{}{"list", "schema"},
 		TypeID:  "foo",
 	}
-	entry, err := decodedEntry.toExternalPluginEntry(true, false)
+	entry, err := decodedEntry.toExternalPluginEntry(context.Background(), true, false)
 	if suite.NoError(err) {
 		suite.True(entry.schemaKnown)
 		suite.Equal("foo", rawTypeID(entry))
+	}
+}
+
+func (suite *ExternalPluginEntryTestSuite) TestDecodeExternalPluginEntryWithInaccessibleReason() {
+	decodedEntry := decodedExternalPluginEntry{
+		Name:               "decodedEntry",
+		Methods:            []interface{}{"list", "stream"},
+		InaccessibleReason: "permission denied",
+	}
+
+	entry, err := decodedEntry.toExternalPluginEntry(context.Background(), false, false)
+	if suite.NoError(err) {
+		suite.True(entry.isInaccessible())
 	}
 }
 

--- a/plugin/externalPluginRoot.go
+++ b/plugin/externalPluginRoot.go
@@ -59,7 +59,7 @@ it's safe to omit name from the response to 'init'`, r.script.Path()))
 	if decodedRoot.Methods == nil {
 		decodedRoot.Methods = []interface{}{"list"}
 	}
-	entry, err := decodedRoot.toExternalPluginEntry(false, true)
+	entry, err := decodedRoot.toExternalPluginEntry(context.Background(), false, true)
 	if err != nil {
 		return err
 	}

--- a/plugin/gcp/computeDir.go
+++ b/plugin/gcp/computeDir.go
@@ -21,15 +21,19 @@ type computeDir struct {
 
 const computeScope = compute.CloudPlatformScope
 
-func newComputeDir(client *http.Client, projID string) (*computeDir, error) {
+func newComputeDir(ctx context.Context, client *http.Client, projID string) (*computeDir, error) {
 	svc, err := compute.NewService(context.Background(), option.WithHTTPClient(client))
 	if err != nil {
 		return nil, err
 	}
-	return &computeDir{
+	c := &computeDir{
 		EntryBase: plugin.NewEntry("compute"),
 		service:   computeProjectService{Service: svc, projectID: projID},
-	}, nil
+	}
+	if _, err := plugin.List(ctx, c); err != nil {
+		c.MarkInaccessible(ctx, err)
+	}
+	return c, nil
 }
 
 // List all services as dirs.

--- a/plugin/gcp/computeDir_test.go
+++ b/plugin/gcp/computeDir_test.go
@@ -3,12 +3,16 @@ package gcp
 import (
 	"testing"
 
+	"github.com/puppetlabs/wash/datastore"
 	"github.com/puppetlabs/wash/plugin"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestComputeDir(t *testing.T) {
-	dir, err := newComputeDir(nil, "dummy")
+	ctx := plugin.SetTestCache(datastore.NewMemCache())
+	defer plugin.UnsetTestCache()
+
+	dir, err := newComputeDir(ctx, nil, "dummy")
 	if assert.NoError(t, err) {
 		assert.Implements(t, (*plugin.Parent)(nil), dir)
 	}

--- a/plugin/gcp/project.go
+++ b/plugin/gcp/project.go
@@ -27,12 +27,12 @@ func newProject(p *crm.Project, client *http.Client) *project {
 
 // List all services as dirs.
 func (p *project) List(ctx context.Context) ([]plugin.Entry, error) {
-	comp, err := newComputeDir(p.client, p.id)
+	comp, err := newComputeDir(ctx, p.client, p.id)
 	if err != nil {
 		return nil, err
 	}
 
-	stor, err := newStorageDir(p.client, p.id)
+	stor, err := newStorageDir(ctx, p.client, p.id)
 	if err != nil {
 		return nil, err
 	}

--- a/plugin/gcp/storageDir.go
+++ b/plugin/gcp/storageDir.go
@@ -22,15 +22,19 @@ type storageDir struct {
 
 const storageScope = storage.ScopeReadOnly
 
-func newStorageDir(client *http.Client, projID string) (*storageDir, error) {
+func newStorageDir(ctx context.Context, client *http.Client, projID string) (*storageDir, error) {
 	cli, err := storage.NewClient(context.Background(), option.WithHTTPClient(client))
 	if err != nil {
 		return nil, err
 	}
-	return &storageDir{
+	s := &storageDir{
 		EntryBase:            plugin.NewEntry("storage"),
 		storageProjectClient: storageProjectClient{Client: cli, projectID: projID},
-	}, nil
+	}
+	if _, err := plugin.List(ctx, s); err != nil {
+		s.MarkInaccessible(ctx, err)
+	}
+	return s, nil
 }
 
 // List all storage buckets as dirs.

--- a/plugin/types.go
+++ b/plugin/types.go
@@ -52,6 +52,7 @@ type Entry interface {
 	wrappedTypes() map[interface{}]*JSONSchema
 	setWrappedTypes(map[interface{}]*JSONSchema)
 	isPrefetched() bool
+	isInaccessible() bool
 }
 
 /*


### PR DESCRIPTION
GCP and AWS access controls can limit what types of APIs a user has
access to. A common one is to limit users to certain subsets of the API,
such as only Compute or Storage. When that happens, any operations on
the representative directory will fail.

Create a new Inaccessible attribute that entries set when they are
inaccessible due to lack of permissions. Inaccessible entries will be
hidden from list and find commands, with the failure reason logged to
the relevant activity journal.

In practice, you would see
```
$ cd gcp/Storage-Only-Project
$ ls
storage
$ stree
.
├── compute
│   └── ...
└── storage
└── ...
$ whistory
...
7   2019-10-14 16:13  ls
$ whistory 7
Oct 14 16:13:12.752 FUSE: List /gcp/Storage-Only-Project
Oct 14 16:13:13.654 Omitting Storage-Only-Project/compute: googleapi:
Error 403: user@example.com does not have compute.list access to p...
```

Fixes #534.

Signed-off-by: Michael Smith <michael.smith@puppet.com>