### PR TITLE
Allow users to escape ".", "[", or "]" in the meta primary

### DIFF
--- a/cmd/internal/find/primary/meta.go
+++ b/cmd/internal/find/primary/meta.go
@@ -172,8 +172,8 @@ matches 'foo'.
       Returns true if some element in m['foo'] is an object o s.t.
       p(o['bar']) returns true.
 
-NOTE: You can use a backslash "\" to escape ".", "[", or "]". For example,
-'.foo\.bar p' returns p(m['foo.bar']).
+NOTE: You can use a backslash "\" to escape ".", "[", "]", or "\". For
+example, '.foo\.bar p' returns p(m['foo.bar']).
 
 PREDICATE EXPRESSIONS:
 Predicate expression syntax is structurally identical to the top-level

--- a/cmd/internal/find/primary/meta.go
+++ b/cmd/internal/find/primary/meta.go
@@ -172,6 +172,9 @@ matches 'foo'.
       Returns true if some element in m['foo'] is an object o s.t.
       p(o['bar']) returns true.
 
+NOTE: You can use a backslash "\" to escape ".", "[", or "]". For example,
+'.foo\.bar p' returns p(m['foo.bar']).
+
 PREDICATE EXPRESSIONS:
 Predicate expression syntax is structurally identical to the top-level
 expression syntax (type "wash find -h syntax" to get an overview of the

--- a/cmd/internal/find/primary/meta/objectPredicate.go
+++ b/cmd/internal/find/primary/meta/objectPredicate.go
@@ -28,7 +28,7 @@ func parseObjectP(tokens []string, baseCaseParser, keySequenceParser predicate.P
 		return nil, nil, errz.NewMatchError("expected a key sequence")
 	}
 	tk := tokens[0]
-	key, rem, err := parseKeySequence(tk)
+	key, rem, err := parseKey(tk)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -63,7 +63,7 @@ func parseObjectP(tokens []string, baseCaseParser, keySequenceParser predicate.P
 // NOTE: Users can still specify ".", "[", or "]" by escaping
 // them with a backslash "\". For example, '.com\.docker\.compose'
 // would be parsed as the key "com.docker.compose".
-func parseKeySequence(tk string) (string, string, error) {
+func parseKey(tk string) (string, string, error) {
 	isTerminatingChar := func(char byte) bool {
 		return char == '.' || char == '[' || char == ']'
 	}

--- a/cmd/internal/find/primary/meta/objectPredicate.go
+++ b/cmd/internal/find/primary/meta/objectPredicate.go
@@ -67,6 +67,9 @@ func parseKey(tk string) (string, string, error) {
 	isTerminatingChar := func(char byte) bool {
 		return char == '.' || char == '[' || char == ']'
 	}
+	isEscapableChar := func(char byte) bool {
+		return isTerminatingChar(char) || char == '\\'
+	}
 
 	if len(tk) <= 0 || tk[0] != '.' {
 		return "", "", errz.NewMatchError("key sequences must begin with a '.'")
@@ -81,13 +84,11 @@ func parseKey(tk string) (string, string, error) {
 			break
 		}
 		if rem[0] == '\\' {
-			// Lookahead and check for an escaped character
-			if len(rem) > 1 && isTerminatingChar(rem[1]) {
-				key += string(rem[1])
-				rem = rem[2:]
-				continue
+			// Lookahead and check for an escapable character
+			if len(rem) <= 1 || !isEscapableChar(rem[1]) {
+				return "", "", fmt.Errorf("no escapable character specified after the '\\'")
 			}
-			// Otherwise, include "\" as part of the key
+			rem = rem[1:]
 		}
 		key += string(rem[0])
 		rem = rem[1:]

--- a/cmd/internal/find/primary/meta/objectPredicate_test.go
+++ b/cmd/internal/find/primary/meta/objectPredicate_test.go
@@ -26,6 +26,9 @@ func (s *ObjectPredicateTestSuite) TestParseKeySequence() {
 		{"[", "", "", "key sequences must begin with a '.'"},
 		{"]", "", "", "key sequences must begin with a '.'"},
 		{".", "", "", "expected a key sequence after '.'"},
+		{"\\.", "", "", "key sequences must begin with a '.'"},
+		{"\\[", "", "", "key sequences must begin with a '.'"},
+		{"\\]", "", "", "key sequences must begin with a '.'"},
 		// Happy cases
 		{".k", "k", "", ""},
 		{".key", "key", "", ""},
@@ -33,6 +36,16 @@ func (s *ObjectPredicateTestSuite) TestParseKeySequence() {
 		{".key1[]", "key1", "[]", ""},
 		{".key1]", "key1", "]", ""},
 		{".key1[", "key1", "[", ""},
+		{".k\\ey", "k\\ey", "", ""},
+		{".\\.", ".", "", ""},
+		{".\\[", "[", "", ""},
+		{".\\]", "]", "", ""},
+		{".foo\\.bar\\[baz\\].", "foo.bar[baz]", ".", ""},
+		{".foo\\.bar\\[baz\\][", "foo.bar[baz]", "[", ""},
+		{".foo\\.bar\\[baz\\]]", "foo.bar[baz]", "]", ""},
+		{".k\\\\ey", "k\\\\ey", "", ""},
+		{".k\\\\.ey", "k\\.ey", "", ""},
+		{".k\\\\\\.ey", "k\\\\.ey", "", ""},
 	}
 
 	for _, testCase := range testCases {

--- a/cmd/internal/find/primary/meta/objectPredicate_test.go
+++ b/cmd/internal/find/primary/meta/objectPredicate_test.go
@@ -12,7 +12,7 @@ type ObjectPredicateTestSuite struct {
 	parserTestSuite
 }
 
-func (s *ObjectPredicateTestSuite) TestParseKeySequence() {
+func (s *ObjectPredicateTestSuite) TestParseKey() {
 	type testCase struct {
 		input    string
 		key      string
@@ -49,7 +49,7 @@ func (s *ObjectPredicateTestSuite) TestParseKeySequence() {
 	}
 
 	for _, testCase := range testCases {
-		key, rem, err := parseKeySequence(testCase.input)
+		key, rem, err := parseKey(testCase.input)
 		if testCase.errRegex != "" {
 			errRegex := regexp.MustCompile(testCase.errRegex)
 			s.Regexp(errRegex, err)

--- a/cmd/internal/find/primary/meta/objectPredicate_test.go
+++ b/cmd/internal/find/primary/meta/objectPredicate_test.go
@@ -29,6 +29,7 @@ func (s *ObjectPredicateTestSuite) TestParseKey() {
 		{"\\.", "", "", "key sequences must begin with a '.'"},
 		{"\\[", "", "", "key sequences must begin with a '.'"},
 		{"\\]", "", "", "key sequences must begin with a '.'"},
+		{".\\e", "", "", "no escapable character specified after the '\\\\'"},
 		// Happy cases
 		{".k", "k", "", ""},
 		{".key", "key", "", ""},
@@ -36,26 +37,26 @@ func (s *ObjectPredicateTestSuite) TestParseKey() {
 		{".key1[]", "key1", "[]", ""},
 		{".key1]", "key1", "]", ""},
 		{".key1[", "key1", "[", ""},
-		{".k\\ey", "k\\ey", "", ""},
 		{".\\.", ".", "", ""},
 		{".\\[", "[", "", ""},
 		{".\\]", "]", "", ""},
+		{".\\\\", "\\", "", ""},
 		{".foo\\.bar\\[baz\\].", "foo.bar[baz]", ".", ""},
 		{".foo\\.bar\\[baz\\][", "foo.bar[baz]", "[", ""},
 		{".foo\\.bar\\[baz\\]]", "foo.bar[baz]", "]", ""},
-		{".k\\\\ey", "k\\\\ey", "", ""},
-		{".k\\\\.ey", "k\\.ey", "", ""},
-		{".k\\\\\\.ey", "k\\\\.ey", "", ""},
+		{".k\\\\.ey", "k\\", ".ey", ""},
 	}
 
 	for _, testCase := range testCases {
-		key, rem, err := parseKey(testCase.input)
+		input := testCase.input
+		inputMsg := "Input: " + input
+		key, rem, err := parseKey(input)
 		if testCase.errRegex != "" {
 			errRegex := regexp.MustCompile(testCase.errRegex)
-			s.Regexp(errRegex, err)
-		} else if s.NoError(err) {
-			s.Equal(testCase.key, key)
-			s.Equal(testCase.rem, rem)
+			s.Regexp(errRegex, err, inputMsg)
+		} else if s.NoError(err, inputMsg) {
+			s.Equal(testCase.key, key, inputMsg)
+			s.Equal(testCase.rem, rem, inputMsg)
 		}
 	}
 }


### PR DESCRIPTION
Fixes #509