### PR TITLE
Remove include-meta option from winfo

### DIFF
--- a/cmd/info.go
+++ b/cmd/info.go
@@ -18,17 +18,12 @@ func infoCommand() *cobra.Command {
 		RunE:    toRunE(infoMain),
 	}
 	infoCmd.Flags().StringP("output", "o", "yaml", "Set the output format (json, yaml, or text)")
-	infoCmd.Flags().BoolP("include-meta", "", false, "Include the meta attribute")
 	return infoCmd
 }
 
 func infoMain(cmd *cobra.Command, args []string) exitCode {
 	path := args[0]
 	output, err := cmd.Flags().GetString("output")
-	if err != nil {
-		panic(err.Error())
-	}
-	includeMeta, err := cmd.Flags().GetBool("include-meta")
 	if err != nil {
 		panic(err.Error())
 	}
@@ -53,7 +48,7 @@ func infoMain(cmd *cobra.Command, args []string) exitCode {
 	entryMap.Put("Name", entry.Name)
 	entryMap.Put("CName", entry.CName)
 	entryMap.Put("Actions", entry.Actions)
-	entryMap.Put("Attributes", entry.Attributes.ToMap(includeMeta))
+	entryMap.Put("Attributes", entry.Attributes.ToMap(false))
 
 	marshalledEntry, err := marshaller.Marshal(entryMap)
 	if err != nil {


### PR DESCRIPTION
People can get this via meta --attribute, so no need to have two
different ways of getting the same thing.

Resolves https://github.com/puppetlabs/wash/issues/552

Signed-off-by: Enis Inan <enis.inan@puppet.com>