### PR TITLE
Simplify string building by removing intermediate Sprintf

### DIFF
--- a/analytics/client.go
+++ b/analytics/client.go
@@ -116,11 +116,11 @@ func (c *client) flush() {
 	// before submitting the data.
 	baseParams := c.baseParams()
 	var logMsg strings.Builder
-	logMsg.WriteString(fmt.Sprintf("Submitting analytics... (%v)\nPayload:\n", baseParams))
+	fmt.Fprintf(&logMsg, "Submitting analytics... (%v)\nPayload:\n", baseParams)
 	var payload []string
 	for _, hit := range c.queuedHits {
 		payload = append(payload, hit.merge(baseParams).encode())
-		logMsg.WriteString(fmt.Sprintf("  %v\n", hit))
+		fmt.Fprintf(&logMsg, "  %v\n", hit)
 	}
 	log.Debug(logMsg.String())
 	body := strings.Join(payload, "\n")


### PR DESCRIPTION
Write directly to the string builder instead of generating an
intermediate string. Pointer to string.Builder implements io.Writer.

Signed-off-by: Michael Smith <michael.smith@puppet.com>