### PR TITLE
Add Twitter Card meta tags to website pages

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,4 +1,8 @@
 title: Wash
+description: "Wide Area SHell: a cloud-native shell for bringing remote infrastructure to your terminal."
+url: https://puppetlabs.github.io
+base_url: /wash
+title_image: /assets/images/wash-logo.png
 google_analytics: UA-144580607-2
 exclude: [vendor, Boltdir, acceptance, modules, .git, Gemfile, Gemfile.lock]
 

--- a/docs/_includes/twitter_card.html
+++ b/docs/_includes/twitter_card.html
@@ -1,0 +1,20 @@
+<!-- Twitter card -->
+{% if page.twitter -%}
+<meta name="twitter:creator" content="@{{ page.twitter }}">
+{% endif -%}
+<meta name="twitter:title"   content="{{ page.title }}">
+
+{% if page.summary -%}
+<meta name="twitter:description" content="{{ page.summary }}">
+{% else -%}
+<meta name="twitter:description" content="{{ site.description }}">
+{% endif -%}
+
+{% if page.image -%}
+<meta name="twitter:card"  content="summary_large_image">
+<meta name="twitter:image" content="{{ site.url }}{{ site.base_url }}{{ page.image }}">
+{% else -%}
+<meta name="twitter:card"  content="summary">
+<meta name="twitter:image" content="{{ site.url }}{{ site.base_url }}{{ site.title_image }}">
+{% endif -%}
+<!-- end of Twitter card -->

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -13,6 +13,8 @@
     {% endif %}
     <meta charset="UTF-8">
 
+{% include twitter_card.html %}
+
 {% seo %}
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="theme-color" content="#157878">

--- a/docs/_posts/2019-08-19-introducing-wash.md
+++ b/docs/_posts/2019-08-19-introducing-wash.md
@@ -1,5 +1,8 @@
 ---
 title: "Introducing Wash"
+summary: "Simplify exploring cloud infrastructure with Wash"
+author: Michael Smith
+twitter: lasthemy
 ---
 
 Have you ever had to:

--- a/docs/_posts/2019-11-04-is-a-filesystem.md
+++ b/docs/_posts/2019-11-04-is-a-filesystem.md
@@ -1,5 +1,8 @@
 ---
 title: "Wash is a filesystem"
+summary: "Demonstrates how Wash provides a filesystem to leverage the tools you already use"
+author: Michael Smith
+twitter: lasthemy
 ---
 
 One of the core principles of Wash is that interacting with things like a filesystem is familiar and powerful. Files are easy to manipulate; every system comes with a suite of tools to do so. They have permanence and a fixed place in a hierarchy, so they're easy to find again. When building Wash we wanted to leverage that for some basic operations.


### PR DESCRIPTION
Adds cards based on https://developer.twitter.com/en/docs/tweets/optimize-with-cards/guides/getting-started to make Wash links display better on Twitter.

Signed-off-by: Michael Smith <michael.smith@puppet.com>