### PR TITLE
Download busybox if not present for listing Docker volumes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ jobs:
   - name: Test Docker plugin
     before_script:
     - go install
-    - docker pull busybox
     - docker-compose -f examples/swarm/docker-compose.yml up -d
     script:
     - wash validate docker

--- a/activity/writer.go
+++ b/activity/writer.go
@@ -1,0 +1,17 @@
+package activity
+
+import (
+	"context"
+	"strings"
+)
+
+// Writer logs the output as a call to Record per Write.
+type Writer struct {
+	context.Context
+	Prefix string
+}
+
+func (a Writer) Write(p []byte) (int, error) {
+	Record(a.Context, "%v: %v", a.Prefix, strings.TrimSpace(string(p)))
+	return len(p), nil
+}

--- a/activity/writer_test.go
+++ b/activity/writer_test.go
@@ -1,0 +1,61 @@
+package activity
+
+import (
+	"context"
+	"io"
+	"io/ioutil"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Reads one line at a time.
+type lineReader struct {
+	string
+}
+
+func (r *lineReader) Read(p []byte) (int, error) {
+	src := r.string
+	if src == "" {
+		return 0, io.EOF
+	}
+
+	i := strings.Index(src, "\n")
+	if i == -1 {
+		r.string = ""
+	} else if i < len(p) {
+		// Add 1 to include the newline.
+		r.string = src[i+1:]
+		src = src[:i+1]
+	} else {
+		r.string = src[len(p):]
+	}
+
+	n := copy(p, src)
+	return n, nil
+}
+
+func TestWriter(t *testing.T) {
+	// Ensure the cache is cleaned up afterward.
+	defer CloseAll()
+
+	// Log to a journal
+	ctx := context.WithValue(context.Background(), JournalKey, Journal{ID: "testWriter"})
+	wr := Writer{Context: ctx, Prefix: "line"}
+
+	const message = "some text\nmore text\n\nand even more\n"
+	rdr := lineReader{message}
+	n, err := io.Copy(wr, &rdr)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(len(message)), n)
+
+	bits, err := ioutil.ReadFile(filepath.Join(Dir(), "testWriter.log"))
+	if assert.Nil(t, err) {
+		assert.Contains(t, string(bits), "line: some text")
+		assert.Contains(t, string(bits), "line: more text")
+		assert.Contains(t, string(bits), "line: ")
+		assert.Contains(t, string(bits), "line: and even more")
+	}
+}


### PR DESCRIPTION
The Docker plugin uses a busybox image to explore persistent volumes by spinning up an instance that mounts the volume and then interacting with it. If the busybox image is not present, creating the instance will fail rather than pull the image. Explicitly pull the busybox:latest image if it's missing.

Note that this isn't a problem for kubernetes as kubernetes already pulls images on-demand.

Fixes #312.

Signed-off-by: Michael Smith <michael.smith@puppet.com>