### PR TITLE
Normalize region when listing S3 buckets

### DIFF
--- a/plugin/aws/s3Bucket.go
+++ b/plugin/aws/s3Bucket.go
@@ -263,7 +263,7 @@ func (b *s3Bucket) getRegion(ctx context.Context) (string, error) {
 		// Normalize bucket location so empty region responses are interpreted as Amazon's default (us-east-1)
 		resp, err := b.client.GetBucketLocationWithContext(ctx, locRequest, s3Client.WithNormalizeBucketLocation)
 		if err != nil {
-			return nil, fmt.Errorf("could not get the region of bucket %v: %v", b.Name(), err)
+			return nil, fmt.Errorf("could not get the region of bucket %v: %w", b.Name(), err)
 		}
 		return resp, nil
 	})

--- a/plugin/aws/s3Bucket.go
+++ b/plugin/aws/s3Bucket.go
@@ -260,13 +260,12 @@ func (b *s3Bucket) getRegion(ctx context.Context) (string, error) {
 	// You can force a retry by deleting the cache entry if there was an error.
 	resp, err := plugin.CachedOp(ctx, "Region", b, 24*time.Hour, func() (interface{}, error) {
 		locRequest := &s3Client.GetBucketLocationInput{Bucket: awsSDK.String(b.Name())}
-		resp, err := b.client.GetBucketLocationWithContext(ctx, locRequest)
+		// Normalize bucket location so empty region responses are interpreted as Amazon's default (us-east-1)
+		resp, err := b.client.GetBucketLocationWithContext(ctx, locRequest, s3Client.WithNormalizeBucketLocation)
 		if err != nil {
 			return nil, fmt.Errorf("could not get the region of bucket %v: %v", b.Name(), err)
 		}
-
-		// The response will be empty if the bucket is in Amazon's default region (us-east-1)
-		return s3Client.NormalizeBucketLocation(awsSDK.StringValue(resp.LocationConstraint)), nil
+		return resp, nil
 	})
 
 	if err != nil {

--- a/plugin/aws/s3Dir.go
+++ b/plugin/aws/s3Dir.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/puppetlabs/wash/activity"
 	"github.com/puppetlabs/wash/plugin"
@@ -44,7 +45,7 @@ func (s *s3Dir) ChildSchemas() []*plugin.EntrySchema {
 func (s *s3Dir) List(ctx context.Context) ([]plugin.Entry, error) {
 	resp, err := s.client.ListBucketsWithContext(ctx, nil)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("Error listing buckets: %w", err)
 	}
 
 	activity.Record(ctx, "Listing %v S3 buckets", len(resp.Buckets))

--- a/plugin/aws/s3Dir.go
+++ b/plugin/aws/s3Dir.go
@@ -7,6 +7,7 @@ import (
 	"github.com/puppetlabs/wash/activity"
 	"github.com/puppetlabs/wash/plugin"
 
+	"github.com/aws/aws-sdk-go/aws"
 	awsSDK "github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	s3Client "github.com/aws/aws-sdk-go/service/s3"
@@ -24,7 +25,12 @@ func newS3Dir(ctx context.Context, session *session.Session) *s3Dir {
 		EntryBase: plugin.NewEntry("s3"),
 	}
 	s3Dir.session = session
-	s3Dir.client = s3Client.New(session)
+
+	// All S3 buckets can be listed from any region. Normalize the configured region so we can still
+	// list buckets if region is unspecified.
+	region := s3Client.NormalizeBucketLocation(awsSDK.StringValue(session.Config.Region))
+	s3Dir.client = s3Client.New(session, aws.NewConfig().WithRegion(region))
+
 	if _, err := plugin.List(ctx, s3Dir); err != nil {
 		s3Dir.MarkInaccessible(ctx, err)
 	}


### PR DESCRIPTION
The S3 API will list all buckets no matter what region it's called from, but the AWS SDK requires a region be set. Normalize the configured region to ensure there *is* a region set when listing buckets.

Fixes #316.

Also starts using Golang 1.13 error wrapping: https://blog.golang.org/go1.13-errors.