### PR TITLE
Allow large journal lines

### DIFF
--- a/api/list.go
+++ b/api/list.go
@@ -64,7 +64,7 @@ var listHandler handler = func(w http.ResponseWriter, r *http.Request) *errorRes
 	})
 	// Sort entries so they have a deterministic order.
 	sort.Slice(result, func(i, j int) bool { return result[i].Name < result[j].Name })
-	activity.Record(ctx, "API: List %v %+v", path, result)
+	activity.Record(ctx, "API: List %v %v items", path, len(result))
 
 	jsonEncoder := json.NewEncoder(w)
 	if err = jsonEncoder.Encode(result); err != nil {

--- a/cmd/history.go
+++ b/cmd/history.go
@@ -53,6 +53,7 @@ func printJournalEntry(index string, follow bool) error {
 	// Jun 13 15:44:04.433 stdout: 4096 1559079604 1557434981 1559079604 41ed /lib
 	//                     2597536 1552660099 1552660099 1559079604 81ed /lib/libcrypto.so.1.1
 	scanner := bufio.NewScanner(rdr)
+	scanner.Buffer(make([]byte, 4096), 100*1024*1024)
 	for scanner.Scan() {
 		var line, empty logFmtLine
 		if err := logfmt.Unmarshal(scanner.Bytes(), &line); err != nil {
@@ -81,8 +82,7 @@ func printJournalEntry(index string, follow bool) error {
 			}
 		}
 	}
-
-	return nil
+	return scanner.Err()
 }
 
 func printHistory(follow bool) error {


### PR DESCRIPTION
`bufio.Scanner` has a default buffer size of 64KiB. If a line is longer than that it stops scanning and errors. I encountered this problem with a long line from printing the output of listing a large directory, and whistory hid the error.

Ensure the error is returned if scanning fails. Also increase the buffer size to 100MiB so it's unlikely we'll encounter this error.

Fixes #580.