### PR TITLE
List all Docker containers, not just the running ones

### DIFF
--- a/plugin/docker/containersDir.go
+++ b/plugin/docker/containersDir.go
@@ -34,7 +34,7 @@ func (cs *containersDir) ChildSchemas() []*plugin.EntrySchema {
 
 // List
 func (cs *containersDir) List(ctx context.Context) ([]plugin.Entry, error) {
-	containers, err := cs.client.ContainerList(ctx, types.ContainerListOptions{})
+	containers, err := cs.client.ContainerList(ctx, types.ContainerListOptions{All: true})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This is symmetric with listing AWS/GCP VMs, and also makes it easier for
users to delete/signal containers.

Fixes https://github.com/puppetlabs/wash/issues/583

Signed-off-by: Enis Inan <enis.inan@puppet.com>