### PR TITLE
Change signal's usage to `signal <path> <signal>`

### DIFF
--- a/cmd/signal.go
+++ b/cmd/signal.go
@@ -8,7 +8,7 @@ import (
 
 func signalCommand() *cobra.Command {
 	signalCmd := &cobra.Command{
-		Use:   "signal <signal> <path>",
+		Use:   "signal <path> <signal>",
 		Short: "Sends the specified signal to the entry at the specified path",
 		Args:  cobra.MinimumNArgs(2),
 		RunE:  toRunE(signalMain),
@@ -18,8 +18,8 @@ func signalCommand() *cobra.Command {
 }
 
 func signalMain(cmd *cobra.Command, args []string) exitCode {
-	signal := args[0]
-	path := args[1]
+	path := args[0]
+	signal := args[1]
 
 	conn := cmdutil.NewClient()
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -331,7 +331,7 @@ SUPPORTED SIGNAL GROUPS
 ```
 
 ```
-wash . ❯ signal start docker/containers/wash_tutorial_redis_1
+wash . ❯ signal docker/containers/wash_tutorial_redis_1 start
 wash . ❯
 ```
 


### PR DESCRIPTION
Latter makes the command easier to extend if we ever decide to support
signal-specific options (to take full advantage of a given API's
capabilities).

Supports https://github.com/puppetlabs/wash/issues/548

Signed-off-by: Enis Inan <enis.inan@puppet.com>