### PR TITLE
Always generate executable wrappers

### DIFF
--- a/cmd/internal/shell/bash.go
+++ b/cmd/internal/shell/bash.go
@@ -12,6 +12,11 @@ type bash struct {
 }
 
 func (b bash) Command(subcommands []string, rundir string) (*exec.Cmd, error) {
+	// Generate alias executables so things like `xargs` work.
+	if err := writeAliases(subcommands, rundir); err != nil {
+		return nil, err
+	}
+
 	// Generate and invoke custom .bashenv and .bashrc files.
 	// - .bashenv will alias subcommands, then load ~/.washenv (if present).
 	// - .bashrc will load ~/.bashrc (if ~/.washrc is absent), then configure the prompt,

--- a/cmd/internal/shell/basic.go
+++ b/cmd/internal/shell/basic.go
@@ -15,14 +15,22 @@ type basic struct {
 func (b basic) Command(subcommands []string, rundir string) (*exec.Cmd, error) {
 	// These are executables instead of aliases because putting alias declarations at the beginning
 	// of stdin for the command doesn't work right (issues with TTY).
-	// Generate executable wrappers for available subcommands based on their aliases.
-	for _, alias := range subcommands {
-		if err := writeAlias(filepath.Join(rundir, alias), alias); err != nil {
-			return nil, fmt.Errorf("unable to create alias for subcommand %v: %v", alias, err)
-		}
+	if err := writeAliases(subcommands, rundir); err != nil {
+		return nil, err
 	}
 
 	return exec.Command(b.sh), nil
+}
+
+// Helper to write executable wrappers for available Wash subcommands based on their aliases.
+// This is broadly useful because things like `xargs` ignore builtins and aliases.
+func writeAliases(subcommands []string, rundir string) error {
+	for _, alias := range subcommands {
+		if err := writeAlias(filepath.Join(rundir, alias), alias); err != nil {
+			return fmt.Errorf("unable to create alias for subcommand %v: %v", alias, err)
+		}
+	}
+	return nil
 }
 
 // Create an executable file at the given path that invokes the given wash subcommand.

--- a/cmd/internal/shell/zsh.go
+++ b/cmd/internal/shell/zsh.go
@@ -12,6 +12,11 @@ type zsh struct {
 }
 
 func (z zsh) Command(subcommands []string, rundir string) (*exec.Cmd, error) {
+	// Generate alias executables so things like `xargs` work.
+	if err := writeAliases(subcommands, rundir); err != nil {
+		return nil, err
+	}
+
 	// Generate and invoke custom .zshenv and .zshrc files.
 	// - .zshenv will load ~/.zshenv (if ~/.washenv is absent), then alias subcommands,
 	//   then load ~/.washenv (if present).


### PR DESCRIPTION
This makes things like `xargs` work.

Fixes #593.

Signed-off-by: Michael Smith <michael.smith@puppet.com>