### PR TITLE
Include bucket size metrics in bucket metadata

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ replace github.com/docker/docker => github.com/docker/engine v1.4.2-0.2019082220
 
 require (
 	bazil.org/fuse v0.0.0-20180421153158-65cc252bf669
+	cloud.google.com/go v0.46.3
 	cloud.google.com/go/firestore v1.1.0
 	cloud.google.com/go/pubsub v1.0.1
 	cloud.google.com/go/storage v1.0.0
@@ -40,6 +41,7 @@ require (
 	github.com/gobwas/glob v0.2.3
 	github.com/gogo/protobuf v1.2.1 // indirect
 	github.com/golang-collections/collections v0.0.0-20130729185459-604e922904d3
+	github.com/golang/protobuf v1.3.2
 	github.com/google/uuid v1.1.1
 	github.com/googleapis/gnostic v0.2.2 // indirect
 	github.com/gorilla/context v1.1.1 // indirect
@@ -86,6 +88,7 @@ require (
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
 	golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a
 	google.golang.org/api v0.13.0
+	google.golang.org/genproto v0.0.0-20191108220845-16a3f7862a1a
 	gopkg.in/go-ini/ini.v1 v1.42.0
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.42.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.3.3 // indirect
 	github.com/docker/spdystream v0.0.0-20181023171402-6480d4af844c // indirect
+	github.com/dustin/go-humanize v1.0.0
 	github.com/ekinanp/go-cache v2.1.0+incompatible
 	github.com/ekinanp/jsonschema v0.0.0-20190624212413-cd4dbe12fbae
 	github.com/elazarl/goproxy v0.0.0-20181111060418-2ce16c963a8a // indirect

--- a/go.sum
+++ b/go.sum
@@ -64,6 +64,8 @@ github.com/docker/go-units v0.3.3 h1:Xk8S3Xj5sLGlG5g67hJmYMmUgXv5N4PhkjJHHqrwnTk
 github.com/docker/go-units v0.3.3/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docker/spdystream v0.0.0-20181023171402-6480d4af844c h1:ZfSZ3P3BedhKGUhzj7BQlPSU4OvT6tfOKe3DVHzOA7s=
 github.com/docker/spdystream v0.0.0-20181023171402-6480d4af844c/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
+github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
+github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/ekinanp/go-cache v2.1.0+incompatible h1:N6iS7ERijdaiQrZA6jBcU7eneKeRI6qJmXhgfRvu8No=
 github.com/ekinanp/go-cache v2.1.0+incompatible/go.mod h1:KnixlqQu6vDC0WobcDRDmsQi8LOhJ4O0kdqw6vFKe8E=
 github.com/ekinanp/jsonschema v0.0.0-20190624212413-cd4dbe12fbae h1:EdHwFxUzvgUpQxtkCg8nKjsXwMCKPJoHDhnVYacDdoI=
@@ -378,7 +380,6 @@ google.golang.org/api v0.9.0 h1:jbyannxz0XFD3zdjgrSUsaJbgpH4eTrkdhRChkHPfO8=
 google.golang.org/api v0.9.0/go.mod h1:o4eAsZoiT+ibD93RtjEohWalFOjRDx6CVaqeizhEnKg=
 google.golang.org/api v0.13.0 h1:Q3Ui3V3/CVinFWFiW39Iw0kMuVrRzYX0wN6OPFp0lTA=
 google.golang.org/api v0.13.0/go.mod h1:iLdEw5Ide6rF15KTC1Kkl0iskquN2gFfn9o9XIsbkAI=
-google.golang.org/api v0.14.0 h1:uMf5uLi4eQMRrMKhCplNik4U4H8Z6C1br3zOtAa/aDE=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.5.0 h1:KxkO13IPW4Lslp2bz+KHP2E3gtFlrIGNThxkZQ3g+4c=


### PR DESCRIPTION
Gets bucket size metrics from CloudWatch (AWS) and Stackdriver (GCP) when requesting bucket metadata.

For example
```
$ wash -c 'meta aws/eso/resources/s3/my-bucket'
AverageSize: 99954524987
Crtime: "2019-06-21T18:03:13Z"
HumanSize: 100 GB
MaximumSize: 99954524987
MinimumSize: 99954524987
Region: us-west-2
TagSet: null
```

Resolves #621.

Signed-off-by: Michael Smith <michael.smith@puppet.com>