### PR TITLE
Generalize console control

### DIFF
--- a/plugin/interactive_test.go
+++ b/plugin/interactive_test.go
@@ -1,12 +1,17 @@
 package plugin
 
 import (
+	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestInteractive(t *testing.T) {
+	saveInteractive := isInteractive
+	defer func() { isInteractive = saveInteractive }()
+
 	if !IsInteractive() {
 		// If tests are not run interactively we can only test the false case, so override to true.
 		isInteractive = true
@@ -20,4 +25,34 @@ func TestInteractive(t *testing.T) {
 
 	InitInteractive(true)
 	assert.False(t, IsInteractive())
+}
+
+func TestWithConsole(t *testing.T) {
+	saveInteractive := isInteractive
+	defer func() { isInteractive = saveInteractive }()
+
+	called := false
+	passing := func(context.Context) error { called = true; return nil }
+	failing := func(context.Context) error { called = true; return fmt.Errorf("failed") }
+
+	// Test non-interactive first.
+	isInteractive = false
+	assert.NoError(t, withConsole(context.Background(), passing))
+	assert.True(t, called)
+
+	called = false
+	assert.Error(t, withConsole(context.Background(), failing), "failed")
+	assert.True(t, called)
+
+	// Interactive tests.
+	isInteractive = true
+
+	called = false
+	if saveInteractive {
+		assert.NoError(t, withConsole(context.Background(), passing))
+		assert.True(t, called)
+	} else {
+		assert.Error(t, withConsole(context.Background(), passing))
+		assert.False(t, called)
+	}
 }

--- a/plugin/methodWrappers.go
+++ b/plugin/methodWrappers.go
@@ -145,18 +145,30 @@ func Metadata(ctx context.Context, e Entry) (JSONObject, error) {
 }
 
 // Exec execs the command on the given entry.
-func Exec(ctx context.Context, e Execable, cmd string, args []string, opts ExecOptions) (ExecCommand, error) {
-	return e.Exec(ctx, cmd, args, opts)
+func Exec(ctx context.Context, e Execable, cmd string, args []string, opts ExecOptions) (result ExecCommand, err error) {
+	err = withConsole(ctx, func(c context.Context) (err error) {
+		result, err = e.Exec(ctx, cmd, args, opts)
+		return
+	})
+	return
 }
 
 // Stream streams the entry's content for updates.
-func Stream(ctx context.Context, s Streamable) (io.ReadCloser, error) {
-	return s.Stream(ctx)
+func Stream(ctx context.Context, s Streamable) (rdr io.ReadCloser, err error) {
+	err = withConsole(ctx, func(c context.Context) (err error) {
+		rdr, err = s.Stream(c)
+		return
+	})
+	return
 }
 
 // Write sends the supplied buffer to the entry.
-func Write(ctx context.Context, a Writable, offset int64, b []byte) (int, error) {
-	return a.Write(ctx, offset, b)
+func Write(ctx context.Context, a Writable, offset int64, b []byte) (n int, err error) {
+	err = withConsole(ctx, func(c context.Context) (err error) {
+		n, err = a.Write(c, offset, b)
+		return
+	})
+	return
 }
 
 // Signal signals the entry with the specified signal
@@ -198,7 +210,10 @@ func Signal(ctx context.Context, s Signalable, signal string) error {
 	}
 
 	// Go ahead and send the signal
-	err = s.Signal(ctx, signal)
+	err = withConsole(ctx, func(c context.Context) (err error) {
+		err = s.Signal(c, signal)
+		return
+	})
 	if err != nil {
 		return err
 	}
@@ -218,7 +233,10 @@ func Signal(ctx context.Context, s Signalable, signal string) error {
 
 // Delete deletes the given entry.
 func Delete(ctx context.Context, d Deletable) (deleted bool, err error) {
-	deleted, err = d.Delete(ctx)
+	err = withConsole(ctx, func(c context.Context) (err error) {
+		deleted, err = d.Delete(c)
+		return
+	})
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Sometimes a plugin needs control of the console for a prompt it doesn't make directly. Get control before calling all primitives that take a context (as a proxy for potential network activity or execs).

This isn't entirely safe. If it's backgrounded and prompts for input it may not exit cleanly. Using `plugin.Prompt` guards against this issue.

Fixes #297.

Signed-off-by: Michael Smith <michael.smith@puppet.com>