### PR TITLE
Make Wash daemon part of the shell session

### DIFF
--- a/plugin/interactive.go
+++ b/plugin/interactive.go
@@ -4,10 +4,8 @@ import (
 	"fmt"
 	"os"
 	"sync"
-	"unsafe"
 
 	"github.com/mattn/go-isatty"
-	"golang.org/x/sys/unix"
 )
 
 var isInteractive bool = (isatty.IsTerminal(os.Stdin.Fd()) || isatty.IsCygwinTerminal(os.Stdin.Fd())) &&
@@ -25,16 +23,6 @@ func IsInteractive() bool {
 	return isInteractive
 }
 
-func tcGetpgrp(fd int) (pgrp int, err error) {
-	return unix.IoctlGetInt(fd, unix.TIOCGPGRP)
-}
-
-func tcSetpgrp(fd int, pgrp int) (err error) {
-	// Mimic IoctlSetPointerInt, which is not available on macOS.
-	v := int32(pgrp)
-	return unix.IoctlSetInt(fd, unix.TIOCSPGRP, int(uintptr(unsafe.Pointer(&v))))
-}
-
 // Only allow one Prompt call at a time. This prevents multiple plugins loading concurrently
 // from messing things up by calling Prompt concurrently.
 var promptMux sync.Mutex
@@ -48,35 +36,8 @@ func Prompt(msg string) (string, error) {
 	promptMux.Lock()
 	defer promptMux.Unlock()
 
-	// Even if Wash is running interactively, it will not have control of STDIN while another command
-	// is running within the shell environment. If it doesn't have control and tries to read from it,
-	// the read will fail. If we have control, read normally. If not, temporarily acquire control for
-	// the current process group while we're prompting, then return it afterward so the triggering
-	// command can continue.
-	inFd := int(os.Stdin.Fd())
-	inGrp, err := tcGetpgrp(inFd)
-	if err != nil {
-		return "", fmt.Errorf("error getting process group controlling stdin: %v", err)
-	}
-	curGrp := unix.Getpgrp()
-
 	var v string
-	if inGrp == curGrp {
-		// We control stdin
-		fmt.Fprintf(os.Stderr, "%s: ", msg)
-		_, err = fmt.Scanln(&v)
-	} else {
-		// Need to get control, prompt, then return control.
-		if err := tcSetpgrp(inFd, curGrp); err != nil {
-			return "", fmt.Errorf("error getting control of stdin: %v", err)
-		}
-		fmt.Fprintf(os.Stderr, "%s: ", msg)
-		_, err = fmt.Scanln(&v)
-		if err := tcSetpgrp(inFd, inGrp); err != nil {
-			// Panic if we can't return control. A messed up environment that they 'kill -9' is worse.
-			panic(err.Error())
-		}
-	}
-	// Return the error set by Scanln.
+	fmt.Fprintf(os.Stderr, "%s: ", msg)
+	_, err := fmt.Scanln(&v)
 	return v, err
 }


### PR DESCRIPTION
When `wash` is run, it starts a shell as a child process where all the action happens. It then stays running as a daemon to handle Wash-specific requests through FUSE and the socket API. However if it needs to prompt for input, it has trouble because it's TTY is not the same as the one handling input (the child shell).

We previously addressed that by temporarily transferring control of input to the Wash daemon, but that had some problems
- it only worked when a plugin requested input using Wash's helper
- if the process that triggered the plugin activity tried to do
something with stdin - like MacVim appears to on startup - it would fail

Reparent the Wash daemon to have a new session under the new shell so they share the same TTY. Prompts for input now work wherever they're triggered from. MacVim still behaves a little strangely if you get a prompt when opening it, but I'm not sure what to do about it.

Fixes #623.

Signed-off-by: Michael Smith <michael.smith@puppet.com>