### PR TITLE
Support block-readable entries

### DIFF
--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -314,7 +314,11 @@ func processEntry(ctx context.Context, pw progress.Writer, wp cmdutil.Pool, e pl
 
 	if plugin.ReadAction().IsSupportedOn(e) {
 		_, cancelFunc, err := withTimeout(ctx, "read", name, func(ctx context.Context) (interface{}, error) {
-			return plugin.Open(ctx, e.(plugin.Readable))
+			data, err := plugin.Read(ctx, e, 0, 1)
+			if err == io.EOF {
+				err = nil
+			}
+			return data, err
 		})
 		if err != nil {
 			errs <- err

--- a/fuse/file.go
+++ b/fuse/file.go
@@ -56,6 +56,7 @@ func (f *file) Open(ctx context.Context, req *fuse.OpenRequest, resp *fuse.OpenR
 }
 
 type fileHandle struct {
+	// This is expected to implement either plugin.Readable or plugin.BlockReadable
 	r  plugin.Entry
 	w  plugin.Writable
 	id string

--- a/plugin/analyticsWrappers.go
+++ b/plugin/analyticsWrappers.go
@@ -14,11 +14,11 @@ func ListWithAnalytics(ctx context.Context, p Parent) (*EntryMap, error) {
 	return List(ctx, p)
 }
 
-// OpenWithAnalytics is a wrapper to plugin.Open. Use it when you need to report
-// a 'Read' invocation to analytics. Otherwise, use plugin.Open.
-func OpenWithAnalytics(ctx context.Context, r Readable) (SizedReader, error) {
-	submitMethodInvocation(ctx, r, "Read")
-	return Open(ctx, r)
+// ReadWithAnalytics is a wrapper to plugin.Read. Use it when you need to report
+// a 'Read' invocation to analytics. Otherwise, use plugin.Read.
+func ReadWithAnalytics(ctx context.Context, e Entry, size int64, offset int64) ([]byte, error) {
+	submitMethodInvocation(ctx, e, "Read")
+	return Read(ctx, e, size, offset)
 }
 
 // StreamWithAnalytics is a wrapper to s#Stream. Use it when you need to report a 'Stream'

--- a/plugin/aws/ec2Instance.go
+++ b/plugin/aws/ec2Instance.go
@@ -233,7 +233,7 @@ func (inst *ec2Instance) checkLatestConsoleOutput(ctx context.Context) (*ec2Inst
 
 	awserr, ok := err.(awserr.Error)
 	if !ok {
-		// Open failed w/ some other error, which should be a
+		// Read failed w/ some other error, which should be a
 		// rare occurrence. Here we reset latestConsoleOutputOnce
 		// so that we check again for the latest console output the
 		// next time List's called, then return an error
@@ -252,7 +252,7 @@ func (inst *ec2Instance) checkLatestConsoleOutput(ctx context.Context) (*ec2Inst
 		return nil, nil
 	}
 
-	// Open failed due to some other AWS-related error. Assume this means
+	// Read failed due to some other AWS-related error. Assume this means
 	// that the instance _does_ have the latest console logs, but something
 	// went wrong with accessing them.
 	inst.hasLatestConsoleOutput = true

--- a/plugin/aws/ec2InstanceConsoleOutput.go
+++ b/plugin/aws/ec2InstanceConsoleOutput.go
@@ -1,7 +1,6 @@
 package aws
 
 import (
-	"bytes"
 	"context"
 
 	"github.com/puppetlabs/wash/plugin"
@@ -46,11 +45,11 @@ func (cl *ec2InstanceConsoleOutput) Schema() *plugin.EntrySchema {
 	return plugin.NewEntrySchema(cl, "console.out")
 }
 
-func (cl *ec2InstanceConsoleOutput) Open(ctx context.Context) (plugin.SizedReader, error) {
+func (cl *ec2InstanceConsoleOutput) Read(ctx context.Context) ([]byte, error) {
 	output, err := cl.inst.cachedConsoleOutput(ctx, cl.latest)
 	if err != nil {
 		return nil, err
 	}
 
-	return bytes.NewReader(output.content), nil
+	return output.content, nil
 }

--- a/plugin/cache.go
+++ b/plugin/cache.go
@@ -222,9 +222,11 @@ func cachedRead(ctx context.Context, e Entry) (entryContent, error) {
 			}
 			return newEntryContent(rawContent), nil
 		case blockReadableSignature:
-			// Go doesn't allow overloaded functions, so external plugin entries will
-			// implement the BlockReadable interface via the blockRead method.
-			var readFunc func(ctx context.Context, size int64, offset int64) ([]byte, error)
+			// Go doesn't allow overloaded functions, so the external plugin entry type
+			// cannot implement both BlockReadable#Read and Readable#Read. Thus, external
+			// plugins implement the BlockReadable interface via a separate blockRead
+			// method.
+			var readFunc blockReadFunc
 			switch t := e.(type) {
 			case externalPlugin:
 				// TODO: external plugin implementation here!

--- a/plugin/cache_test.go
+++ b/plugin/cache_test.go
@@ -437,17 +437,20 @@ func (m *cacheTestsMockBlockReadableEntry) Read(ctx context.Context, size int64,
 }
 
 func (suite *CacheTestSuite) TestCachedRead_BlockReadableCorePluginEntry() {
+	expectedRawContent := []byte("some raw content")
+
 	entry := &cacheTestsMockBlockReadableEntry{
 		cacheTestsMockEntry: newCacheTestsMockEntry("foo"),
 	}
 	entry.DisableDefaultCaching()
 	entry.SetTestID("/foo")
+	entry.Attributes().SetSize(uint64(len(expectedRawContent)))
 
 	ctx := context.Background()
-	expectedRawContent := []byte("some raw content")
 	entry.On("Read", ctx, int64(10), int64(0)).Return(expectedRawContent, nil).Once()
 
 	content, err := cachedRead(ctx, entry)
+	suite.Equal(entry.Attributes().Size(), content.size())
 	if suite.NoError(err) {
 		actualRawContent, err := content.read(ctx, 10, 0)
 		if suite.NoError(err) {

--- a/plugin/cache_test.go
+++ b/plugin/cache_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"regexp"
-	"strings"
 	"testing"
 	"time"
 
@@ -179,6 +178,11 @@ func (e *cacheTestsMockEntry) Open(ctx context.Context) (SizedReader, error) {
 func (e *cacheTestsMockEntry) Metadata(ctx context.Context) (JSONObject, error) {
 	args := e.Called(ctx)
 	return args.Get(0).(JSONObject), args.Error(1)
+}
+
+func (e *cacheTestsMockEntry) Read(ctx context.Context) ([]byte, error) {
+	args := e.Called(ctx)
+	return args.Get(0).([]byte), args.Error(1)
 }
 
 type cachedDefaultOpFunc func(ctx context.Context, e Entry) (interface{}, error)
@@ -369,12 +373,91 @@ func (suite *CacheTestSuite) TestCachedListSetEntryID() {
 	}
 }
 
-func (suite *CacheTestSuite) TestCachedOpen() {
-	mockReader := strings.NewReader("foo")
-	suite.testCachedDefaultOp(OpenOp, "Open", mockReader, mockReader, func(ctx context.Context, e Entry) (interface{}, error) {
-		return cachedOpen(ctx, e.(Readable))
+func (suite *CacheTestSuite) TestCachedRead_DefaultOp() {
+	// This also tests a successful read of a ReadableCorePluginEntry
+	mockRawContent := []byte("some raw content")
+	mockContent := newEntryContent(mockRawContent)
+	suite.testCachedDefaultOp(ReadOp, "Read", mockRawContent, mockContent, func(ctx context.Context, e Entry) (interface{}, error) {
+		return cachedRead(ctx, e)
 	})
 }
+
+func (suite *CacheTestSuite) TestCachedRead_ReadableCorePluginEntry_ErroredRead() {
+	entry := newCacheTestsMockEntry("foo")
+	entry.DisableDefaultCaching()
+	entry.SetTestID("/foo")
+
+	ctx := context.Background()
+	expectedErr := fmt.Errorf("an error")
+	entry.On("Read", ctx).Return([]byte{}, expectedErr)
+
+	_, err := cachedRead(ctx, entry)
+	suite.Equal(expectedErr, err)
+}
+
+func (suite *CacheTestSuite) TestCachedRead_ReadableExternalPluginEntry_SuccessfulRead() {
+	entry := &externalPluginEntry{
+		EntryBase: NewEntry("foo"),
+		methods: map[string]methodInfo{
+			"read": methodInfo{signature: defaultSignature, result: "some raw content"},
+		},
+	}
+	entry.DisableDefaultCaching()
+	entry.SetTestID("/foo")
+
+	expectedContent := newEntryContent([]byte("some raw content"))
+
+	actualContent, err := cachedRead(context.Background(), entry)
+	if suite.NoError(err) {
+		suite.Equal(expectedContent, actualContent)
+	}
+}
+
+func (suite *CacheTestSuite) TestCachedRead_ReadableExternalPluginEntry_ErroredRead() {
+	entry := &externalPluginEntry{
+		EntryBase: NewEntry("foo"),
+		methods: map[string]methodInfo{
+			"read": methodInfo{signature: defaultSignature, result: []byte("invalid content")},
+		},
+	}
+	entry.DisableDefaultCaching()
+	entry.SetTestID("/foo")
+
+	_, err := cachedRead(context.Background(), entry)
+	suite.Regexp("Read.*string", err.Error())
+}
+
+type cacheTestsMockBlockReadableEntry struct {
+	*cacheTestsMockEntry
+}
+
+func (m *cacheTestsMockBlockReadableEntry) Read(ctx context.Context, size int64, offset int64) ([]byte, error) {
+	args := m.Called(ctx, size, offset)
+	return args.Get(0).([]byte), args.Error(1)
+}
+
+func (suite *CacheTestSuite) TestCachedRead_BlockReadableCorePluginEntry() {
+	entry := &cacheTestsMockBlockReadableEntry{
+		cacheTestsMockEntry: newCacheTestsMockEntry("foo"),
+	}
+	entry.DisableDefaultCaching()
+	entry.SetTestID("/foo")
+
+	ctx := context.Background()
+	expectedRawContent := []byte("some raw content")
+	entry.On("Read", ctx, int64(10), int64(0)).Return(expectedRawContent, nil).Once()
+
+	content, err := cachedRead(ctx, entry)
+	if suite.NoError(err) {
+		actualRawContent, err := content.read(ctx, 10, 0)
+		if suite.NoError(err) {
+			suite.Equal(expectedRawContent, actualRawContent)
+			entry.AssertExpectations(suite.T())
+		}
+	}
+}
+
+// TODO: Add block readable external plugin entry test case
 
 func (suite *CacheTestSuite) TestCachedMetadata() {
 	mockJSONObject := JSONObject{"foo": "bar"}

--- a/plugin/docker/container-log.go
+++ b/plugin/docker/container-log.go
@@ -41,7 +41,7 @@ func (clf *containerLogFile) Schema() *plugin.EntrySchema {
 	return plugin.NewEntrySchema(clf, "log").IsSingleton()
 }
 
-func (clf *containerLogFile) Open(ctx context.Context) (plugin.SizedReader, error) {
+func (clf *containerLogFile) Read(ctx context.Context) ([]byte, error) {
 	opts := types.ContainerLogsOptions{ShowStdout: true, ShowStderr: true}
 	rdr, err := clf.client.ContainerLogs(ctx, clf.containerName, opts)
 	if err != nil {
@@ -62,7 +62,7 @@ func (clf *containerLogFile) Open(ctx context.Context) (plugin.SizedReader, erro
 	}
 	activity.Record(ctx, "Read %v bytes of %v log", n, clf.containerName)
 
-	return bytes.NewReader(buf.Bytes()), nil
+	return buf.Bytes(), nil
 }
 
 func (clf *containerLogFile) Stream(ctx context.Context) (io.ReadCloser, error) {

--- a/plugin/docker/volume.go
+++ b/plugin/docker/volume.go
@@ -173,7 +173,7 @@ func (v *volume) VolumeList(ctx context.Context, path string) (volpkg.DirMap, er
 	return volpkg.StatParseAll(bytes.NewReader(output), mountpoint, path, maxdepth)
 }
 
-func (v *volume) VolumeOpen(ctx context.Context, path string) (plugin.SizedReader, error) {
+func (v *volume) VolumeRead(ctx context.Context, path string) ([]byte, error) {
 	// Create a container that mounts a volume and waits. Use it to download a file.
 	cid, err := v.createContainer(ctx, []string{"sleep", "60"})
 	if err != nil {
@@ -211,7 +211,7 @@ func (v *volume) VolumeOpen(ctx context.Context, path string) (plugin.SizedReade
 	if err != nil {
 		return nil, err
 	}
-	return bytes.NewReader(bits), nil
+	return bits, nil
 }
 
 func (v *volume) VolumeStream(ctx context.Context, path string) (io.ReadCloser, error) {

--- a/plugin/entryBase.go
+++ b/plugin/entryBase.go
@@ -13,13 +13,13 @@ type defaultOpCode int8
 const (
 	// ListOp represents Parent#List
 	ListOp defaultOpCode = iota
-	// OpenOp represents Readable#Open
-	OpenOp
+	// ReadOp represents Readable/BlockReadable#Read
+	ReadOp
 	// MetadataOp represents Entry#Metadata
 	MetadataOp
 )
 
-var defaultOpCodeToNameMap = [3]string{"List", "Open", "Metadata"}
+var defaultOpCodeToNameMap = [3]string{"List", "Read", "Metadata"}
 
 /*
 EntryBase implements Entry, making it easy to create new entries.

--- a/plugin/entryBase_test.go
+++ b/plugin/entryBase_test.go
@@ -39,7 +39,7 @@ func (suite *EntryBaseTestSuite) TestNewEntry() {
 
 	suite.Equal("foo", e.Name())
 	suite.assertOpTTL(e, ListOp, "List", 15*time.Second)
-	suite.assertOpTTL(e, OpenOp, "Open", 15*time.Second)
+	suite.assertOpTTL(e, ReadOp, "Read", 15*time.Second)
 	suite.assertOpTTL(e, MetadataOp, "Metadata", 15*time.Second)
 
 	e.setID("/foo")
@@ -52,7 +52,7 @@ func (suite *EntryBaseTestSuite) TestNewEntry() {
 	suite.assertOpTTL(e, ListOp, "List", -1)
 
 	e.DisableDefaultCaching()
-	suite.assertOpTTL(e, OpenOp, "Open", -1)
+	suite.assertOpTTL(e, ReadOp, "Read", -1)
 	suite.assertOpTTL(e, MetadataOp, "Metadata", -1)
 }
 

--- a/plugin/entryContent.go
+++ b/plugin/entryContent.go
@@ -2,6 +2,7 @@ package plugin
 
 import (
 	"context"
+	"io"
 )
 
 // entryContent is the cached result of a Read invocation
@@ -26,11 +27,13 @@ func (c *entryContentImpl) read(_ context.Context, size int64, offset int64) (da
 	data = []byte{}
 	contentSize := int64(len(c.content))
 	if offset >= contentSize {
+		err = io.EOF
 		return
 	}
 	endIx := offset + size
 	if contentSize < endIx {
 		endIx = contentSize
+		err = io.EOF
 	}
 	data = c.content[offset:endIx]
 	return

--- a/plugin/entryContent.go
+++ b/plugin/entryContent.go
@@ -2,7 +2,6 @@ package plugin
 
 import (
 	"context"
-	"io"
 )
 
 // entryContent is the cached result of a Read invocation
@@ -27,13 +26,11 @@ func (c *entryContentImpl) read(_ context.Context, size int64, offset int64) (da
 	data = []byte{}
 	contentSize := int64(len(c.content))
 	if offset >= contentSize {
-		err = io.EOF
 		return
 	}
 	endIx := offset + size
 	if contentSize < endIx {
 		endIx = contentSize
-		err = io.EOF
 	}
 	data = c.content[offset:endIx]
 	return

--- a/plugin/entryContent.go
+++ b/plugin/entryContent.go
@@ -40,14 +40,16 @@ func (c *entryContentImpl) size() uint64 {
 	return uint64(len(c.content))
 }
 
+type blockReadFunc = func(context.Context, int64, int64) ([]byte, error)
+
 // blockReadableEntryContent is the implementation of entryContent that's
 // meant for BlockReadable entries. For now, it doesn't cache any content.
 type blockReadableEntryContent struct {
-	readFunc func(context.Context, int64, int64) ([]byte, error)
+	readFunc blockReadFunc
 	sz       uint64
 }
 
-func newBlockReadableEntryContent(readFunc func(context.Context, int64, int64) ([]byte, error)) *blockReadableEntryContent {
+func newBlockReadableEntryContent(readFunc blockReadFunc) *blockReadableEntryContent {
 	return &blockReadableEntryContent{
 		readFunc: readFunc,
 	}

--- a/plugin/entryContent.go
+++ b/plugin/entryContent.go
@@ -1,0 +1,69 @@
+package plugin
+
+import (
+	"context"
+	"io"
+)
+
+// entryContent is the cached result of a Read invocation
+type entryContent interface {
+	read(context.Context, int64, int64) ([]byte, error)
+	size() uint64
+}
+
+// entryContentImpl is the default implementation of entryContent,
+// meant for Readable entries
+type entryContentImpl struct {
+	content []byte
+}
+
+func newEntryContent(content []byte) *entryContentImpl {
+	return &entryContentImpl{
+		content: content,
+	}
+}
+
+func (c *entryContentImpl) read(_ context.Context, size int64, offset int64) (data []byte, err error) {
+	data = []byte{}
+	contentSize := int64(len(c.content))
+	if offset >= contentSize {
+		err = io.EOF
+		return
+	}
+	endIx := offset + size
+	if contentSize < endIx {
+		endIx = contentSize
+		err = io.EOF
+	}
+	data = c.content[offset:endIx]
+	return
+}
+
+func (c *entryContentImpl) size() uint64 {
+	return uint64(len(c.content))
+}
+
+// blockReadableEntryContent is the implementation of entryContent that's
+// meant for BlockReadable entries. For now, it doesn't cache any content.
+type blockReadableEntryContent struct {
+	readFunc func(context.Context, int64, int64) ([]byte, error)
+	sz       uint64
+}
+
+func newBlockReadableEntryContent(readFunc func(context.Context, int64, int64) ([]byte, error)) *blockReadableEntryContent {
+	return &blockReadableEntryContent{
+		readFunc: readFunc,
+	}
+}
+
+// Note that we don't need to check the offset/size because if the size attribute
+// was set, then plugin.Read already did that validation. If the size attribute
+// wasn't set, then it is the responsibility of the plugin's API to raise the error
+// for us.
+func (c *blockReadableEntryContent) read(ctx context.Context, size int64, offset int64) ([]byte, error) {
+	return c.readFunc(ctx, size, offset)
+}
+
+func (c *blockReadableEntryContent) size() uint64 {
+	return c.sz
+}

--- a/plugin/entryContent_test.go
+++ b/plugin/entryContent_test.go
@@ -3,7 +3,6 @@ package plugin
 import (
 	"context"
 	"fmt"
-	"io"
 	"testing"
 
 	"github.com/stretchr/testify/mock"
@@ -29,29 +28,23 @@ func (s *EntryContentTestSuite) TestEntryContentImpl() {
 		size     int64
 		offset   int64
 		expected []byte
-		err      error
 	}
 	testCases := []testCase{
 		// Test offset >= contentSize
-		testCase{size: 0, offset: contentSize, expected: []byte(""), err: io.EOF},
-		testCase{size: 0, offset: contentSize + 1, expected: []byte(""), err: io.EOF},
+		testCase{size: 0, offset: contentSize, expected: []byte("")},
+		testCase{size: 0, offset: contentSize + 1, expected: []byte("")},
 		// Test happy-cases
 		testCase{size: 0, offset: 0, expected: []byte("")},
 		testCase{size: 0, offset: 1, expected: []byte("")},
 		testCase{size: 4, offset: 2, expected: []byte("me r")},
 		testCase{size: contentSize, offset: 0, expected: rawContent},
 		// Test out-of-bounds sizes
-		testCase{size: contentSize + 1, offset: 0, expected: rawContent, err: io.EOF},
-		testCase{size: contentSize, offset: 1, expected: rawContent[1:], err: io.EOF},
+		testCase{size: contentSize + 1, offset: 0, expected: rawContent},
+		testCase{size: contentSize, offset: 1, expected: rawContent[1:]},
 	}
 	for _, testCase := range testCases {
 		actual, err := content.read(context.Background(), testCase.size, testCase.offset)
-		if testCase.err != nil {
-			s.Equal(testCase.err, err)
-		} else {
-			s.NoError(err)
-		}
-		if testCase.expected != nil {
+		if s.NoError(err) {
 			s.Equal(testCase.expected, actual)
 		}
 	}

--- a/plugin/entryContent_test.go
+++ b/plugin/entryContent_test.go
@@ -1,0 +1,107 @@
+package plugin
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+)
+
+type EntryContentTestSuite struct {
+	suite.Suite
+}
+
+func (s *EntryContentTestSuite) TestEntryContentImpl() {
+	// EntryContentImpl will likely never change, so go ahead and group
+	// all its tests here
+	rawContent := []byte("some raw content")
+	contentSize := int64(len(rawContent))
+	content := newEntryContent(rawContent)
+
+	// Test entryContentImpl#size
+	s.Equal(uint64(len(rawContent)), content.size())
+
+	// Now test entryContentImpl#read
+	type testCase struct {
+		size     int64
+		offset   int64
+		expected []byte
+		err      error
+	}
+	testCases := []testCase{
+		// Test offset >= contentSize
+		testCase{size: 0, offset: contentSize, expected: []byte(""), err: io.EOF},
+		testCase{size: 0, offset: contentSize + 1, expected: []byte(""), err: io.EOF},
+		// Test happy-cases
+		testCase{size: 0, offset: 0, expected: []byte("")},
+		testCase{size: 0, offset: 1, expected: []byte("")},
+		testCase{size: 4, offset: 2, expected: []byte("me r")},
+		testCase{size: contentSize, offset: 0, expected: rawContent},
+		// Test out-of-bounds sizes
+		testCase{size: contentSize + 1, offset: 0, expected: rawContent, err: io.EOF},
+		testCase{size: contentSize, offset: 1, expected: rawContent[1:], err: io.EOF},
+	}
+	for _, testCase := range testCases {
+		actual, err := content.read(context.Background(), testCase.size, testCase.offset)
+		if testCase.err != nil {
+			s.Equal(testCase.err, err)
+		} else {
+			s.NoError(err)
+		}
+		if testCase.expected != nil {
+			s.Equal(testCase.expected, actual)
+		}
+	}
+}
+
+func (s *EntryContentTestSuite) TestBlockReadableEntryContent_Size() {
+	content := newBlockReadableEntryContent(func(_ context.Context, _ int64, _ int64) ([]byte, error) {
+		return nil, nil
+	})
+	content.sz = 10
+	s.Equal(uint64(10), content.size())
+}
+
+type mockBlockReadableEntry struct {
+	mock.Mock
+}
+
+func (m *mockBlockReadableEntry) Read(ctx context.Context, size int64, offset int64) ([]byte, error) {
+	args := m.Called(ctx, size, offset)
+	return args.Get(0).([]byte), args.Error(1)
+}
+
+func (s *EntryContentTestSuite) TestBlockReadableEntryContent_Read_SuccessfulReadFuncInvocation() {
+	m := &mockBlockReadableEntry{}
+	content := newBlockReadableEntryContent(func(ctx context.Context, size int64, offset int64) ([]byte, error) {
+		return m.Read(ctx, size, offset)
+	})
+
+	ctx := context.Background()
+	m.On("Read", ctx, int64(10), int64(0)).Return([]byte("some raw content"), nil).Once()
+	rawContent, err := content.read(ctx, 10, 0)
+	if s.NoError(err) {
+		s.Equal([]byte("some raw content"), rawContent)
+	}
+}
+
+func (s *EntryContentTestSuite) TestBlockReadableEntryContent_Read_ErroredReadFuncInvocation() {
+	m := &mockBlockReadableEntry{}
+	content := newBlockReadableEntryContent(func(ctx context.Context, size int64, offset int64) ([]byte, error) {
+		return m.Read(ctx, size, offset)
+	})
+
+	ctx := context.Background()
+	expectedErr := fmt.Errorf("an error")
+	m.On("Read", ctx, int64(10), int64(0)).Return([]byte{}, expectedErr).Once()
+
+	_, err := content.read(ctx, 10, 0)
+	s.Equal(expectedErr, err)
+}
+
+func TestEntryContent(t *testing.T) {
+	suite.Run(t, new(EntryContentTestSuite))
+}

--- a/plugin/externalPluginRoot.go
+++ b/plugin/externalPluginRoot.go
@@ -71,7 +71,7 @@ it's safe to omit name from the response to 'init'`, r.script.Path()))
 	r.externalPluginEntry.script = script
 
 	// Fill in the schema graph if provided
-	if rawSchema := r.methods["schema"]; rawSchema != nil {
+	if rawSchema := r.methods["schema"].result; rawSchema != nil {
 		marshalledSchema, err := json.Marshal(rawSchema)
 		if err != nil {
 			panic(fmt.Sprintf("Error remarshaling previously unmarshaled data: %v", err))

--- a/plugin/externalPluginRoot_test.go
+++ b/plugin/externalPluginRoot_test.go
@@ -52,7 +52,9 @@ func (suite *ExternalPluginRootTestSuite) TestInit() {
 		expectedRoot := &externalPluginRoot{
 			externalPluginEntry: &externalPluginEntry{
 				EntryBase: NewEntry("foo"),
-				methods:   map[string]interface{}{"list": nil},
+				methods: map[string]methodInfo{
+					"list": methodInfo{signature: defaultSignature},
+				},
 				script:    root.script,
 				rawTypeID: "foo_type",
 			},

--- a/plugin/gcp/cloudLogFile.go
+++ b/plugin/gcp/cloudLogFile.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/puppetlabs/wash/activity"
 	cmdutil "github.com/puppetlabs/wash/cmd/util"
-	"github.com/puppetlabs/wash/plugin"
 	"google.golang.org/api/logging/v2"
 	"google.golang.org/api/option"
 )
@@ -57,7 +56,7 @@ func newCloudLogFile(
 	return clf, nil
 }
 
-func (clf *cloudLogFile) Open(ctx context.Context) (plugin.SizedReader, error) {
+func (clf *cloudLogFile) Read(ctx context.Context) ([]byte, error) {
 	// 1000 matches gcloud's upper limit for fetching logs
 	entries, err := clf.fetchEntries(ctx, 1000, "")
 	if err != nil {
@@ -72,7 +71,7 @@ func (clf *cloudLogFile) Open(ctx context.Context) (plugin.SizedReader, error) {
 	}
 	activity.Record(ctx, "HEADERS: %v, ENTRIES: %v", headers, entries)
 	table := cmdutil.NewTableWithHeaders(headers, entries)
-	return strings.NewReader(table.Format()), nil
+	return []byte(table.Format()), nil
 }
 
 // Note that we use afterTimestamp instead of pageToken because the latter doesn't work well with

--- a/plugin/gcp/computeInstConsoleOutput.go
+++ b/plugin/gcp/computeInstConsoleOutput.go
@@ -2,7 +2,6 @@ package gcp
 
 import (
 	"context"
-	"strings"
 
 	"github.com/puppetlabs/wash/activity"
 	"github.com/puppetlabs/wash/plugin"
@@ -27,7 +26,7 @@ func (cl *computeInstanceConsoleOutput) Schema() *plugin.EntrySchema {
 	return plugin.NewEntrySchema(cl, "console.out").IsSingleton()
 }
 
-func (cl *computeInstanceConsoleOutput) Open(ctx context.Context) (plugin.SizedReader, error) {
+func (cl *computeInstanceConsoleOutput) Read(ctx context.Context) ([]byte, error) {
 	zone := getZone(cl.instance)
 	activity.Record(ctx,
 		"Getting output for instance %v in project %v, zone %v", cl.instance.Name, cl.service.projectID, zone)
@@ -37,5 +36,5 @@ func (cl *computeInstanceConsoleOutput) Open(ctx context.Context) (plugin.SizedR
 		return nil, err
 	}
 
-	return strings.NewReader(outputResp.Contents), nil
+	return []byte(outputResp.Contents), nil
 }

--- a/plugin/gcp/firestoreDocument.go
+++ b/plugin/gcp/firestoreDocument.go
@@ -1,7 +1,6 @@
 package gcp
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"time"
@@ -101,8 +100,8 @@ func newFirestoreDocumentDataJSON(data map[string]interface{}) (*firestoreDocume
 	return dataEntry, nil
 }
 
-func (data *firestoreDocumentDataJSON) Open(ctx context.Context) (plugin.SizedReader, error) {
-	return bytes.NewReader(data.bytes), nil
+func (data *firestoreDocumentDataJSON) Read(ctx context.Context) ([]byte, error) {
+	return data.bytes, nil
 }
 
 func (data *firestoreDocumentDataJSON) Schema() *plugin.EntrySchema {

--- a/plugin/kubernetes/container.go
+++ b/plugin/kubernetes/container.go
@@ -59,7 +59,7 @@ func (c *container) Schema() *plugin.EntrySchema {
 		SetMetaAttributeSchema(corev1.Container{})
 }
 
-func (c *container) Open(ctx context.Context) (plugin.SizedReader, error) {
+func (c *container) Read(ctx context.Context) ([]byte, error) {
 	logOptions := corev1.PodLogOptions{
 		Container: c.Name(),
 	}
@@ -75,7 +75,7 @@ func (c *container) Open(ctx context.Context) (plugin.SizedReader, error) {
 	}
 	activity.Record(ctx, "Read %v bytes of %v log", n, c.Name())
 
-	return bytes.NewReader(buf.Bytes()), nil
+	return buf.Bytes(), nil
 }
 
 func (c *container) Stream(ctx context.Context) (io.ReadCloser, error) {

--- a/plugin/kubernetes/pvc.go
+++ b/plugin/kubernetes/pvc.go
@@ -191,12 +191,12 @@ func (v *pvc) VolumeList(ctx context.Context, path string) (volume.DirMap, error
 	return volume.StatParseAll(bytes.NewReader(output), mountpoint, path, maxdepth)
 }
 
-func (v *pvc) VolumeOpen(ctx context.Context, path string) (plugin.SizedReader, error) {
+func (v *pvc) VolumeRead(ctx context.Context, path string) ([]byte, error) {
 	output, err := v.runInTemporaryPod(ctx, []string{"cat", mountpoint + path})
 	if err != nil {
 		return nil, err
 	}
-	return bytes.NewReader(output), nil
+	return output, nil
 }
 
 func (v *pvc) VolumeStream(ctx context.Context, path string) (io.ReadCloser, error) {

--- a/plugin/metadataJSON.go
+++ b/plugin/metadataJSON.go
@@ -1,7 +1,6 @@
 package plugin
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 )
@@ -22,12 +21,12 @@ func NewMetadataJSONFile(ctx context.Context, other Entry) (*MetadataJSONFile, e
 
 	if other.getTTLOf(MetadataOp) < 0 {
 		// Content is presumably easy to get, so use it to determine size.
-		content, err := meta.Open(ctx)
+		content, err := meta.Read(ctx)
 		if err != nil {
 			return nil, err
 		}
 
-		meta.Attributes().SetSize(uint64(content.Size()))
+		meta.Attributes().SetSize(uint64(len(content)))
 	}
 
 	return meta, nil
@@ -40,8 +39,8 @@ func (m *MetadataJSONFile) Schema() *EntrySchema {
 		IsSingleton()
 }
 
-// Open returns the metadata of the `other` entry as its content.
-func (m *MetadataJSONFile) Open(ctx context.Context) (SizedReader, error) {
+// Read returns the metadata of the `other` entry as its content.
+func (m *MetadataJSONFile) Read(ctx context.Context) ([]byte, error) {
 	meta, err := Metadata(ctx, m.other)
 	if err != nil {
 		return nil, err
@@ -52,7 +51,7 @@ func (m *MetadataJSONFile) Open(ctx context.Context) (SizedReader, error) {
 		return nil, err
 	}
 
-	return bytes.NewReader(prettyMeta), nil
+	return prettyMeta, nil
 }
 
 const metadataJSONDescription = `

--- a/plugin/methodWrappers.go
+++ b/plugin/methodWrappers.go
@@ -134,7 +134,7 @@ func List(ctx context.Context, p Parent) (*EntryMap, error) {
 // len(data) to check the amount of data that was actually read.
 //
 // If the offset is >= to the available content size, then data != nil, len(data) == 0,
-// and err == io.EOF. Otherwise if len(data) < size, then err == io.EOF.
+// and err == nil. Otherwise if len(data) < size, then err == nil.
 //
 // Note that Read is thread-safe.
 func Read(ctx context.Context, e Entry, size int64, offset int64) (data []byte, err error) {
@@ -145,13 +145,11 @@ func Read(ctx context.Context, e Entry, size int64, offset int64) (data []byte, 
 	if attr := e.attributes(); attr.HasSize() {
 		contentSize := int64(attr.Size())
 		if offset >= contentSize {
-			err = io.EOF
 			return
 		}
 		minSize := size + offset
 		if contentSize < minSize {
 			size = contentSize
-			err = io.EOF
 		}
 	}
 	content, contentErr := cachedRead(ctx, e)
@@ -160,7 +158,7 @@ func Read(ctx context.Context, e Entry, size int64, offset int64) (data []byte, 
 		return
 	}
 	data, readErr := content.read(ctx, size, offset)
-	if readErr != nil {
+	if readErr != nil && readErr != io.EOF {
 		err = readErr
 	}
 	return

--- a/plugin/methodWrappers.go
+++ b/plugin/methodWrappers.go
@@ -102,9 +102,9 @@ func Attributes(e Entry) EntryAttributes {
 		// We have no way to preserve this on the entry, and it likely wouldn't help because we often
 		// recreate the entry to ensure we have an accurate representation. So when the cache expires
 		// we revert to stating the size is unknown until the next read operation.
-		if val, _ := cache.Get(defaultOpCodeToNameMap[OpenOp], e.id()); val != nil {
-			rdr := val.(SizedReader)
-			attr.SetSize(uint64(rdr.Size()))
+		if val, _ := cache.Get(defaultOpCodeToNameMap[ReadOp], e.id()); val != nil {
+			content := val.(entryContent)
+			attr.SetSize(content.size())
 		}
 	}
 	return attr
@@ -129,14 +129,41 @@ func List(ctx context.Context, p Parent) (*EntryMap, error) {
 	return cachedList(ctx, p)
 }
 
-// Open reads the entry's content. Note that Open's results could be cached. Thus, when
-// using the reader returned by this method, use idempotent read operations such as ReadAt
-// or wrap it in a SectionReader. Using Read operations on the cached reader will change it
-// and make subsequent uses of the cached reader invalid.
+// Read reads up to size bits of the entry's content starting at the given offset.
+// It will panic if the entry does not support the read action. Callers can use
+// len(data) to check the amount of data that was actually read.
 //
-// TODO: Could we change this to Read? E.g. plugin.Read.
-func Open(ctx context.Context, r Readable) (SizedReader, error) {
-	return cachedOpen(ctx, r)
+// If the offset is >= to the available content size, then data != nil, len(data) == 0,
+// and err == io.EOF. Otherwise if len(data) < size, then err == io.EOF.
+//
+// Note that Read is thread-safe.
+func Read(ctx context.Context, e Entry, size int64, offset int64) (data []byte, err error) {
+	if !ReadAction().IsSupportedOn(e) {
+		panic("plugin.Read called on a non-readable entry")
+	}
+	data = []byte{}
+	if attr := e.attributes(); attr.HasSize() {
+		contentSize := int64(attr.Size())
+		if offset >= contentSize {
+			err = io.EOF
+			return
+		}
+		minSize := size + offset
+		if contentSize < minSize {
+			size = contentSize
+			err = io.EOF
+		}
+	}
+	content, contentErr := cachedRead(ctx, e)
+	if contentErr != nil {
+		err = contentErr
+		return
+	}
+	data, readErr := content.read(ctx, size, offset)
+	if readErr != nil {
+		err = readErr
+	}
+	return
 }
 
 // Metadata returns the entry's metadata. Note that Metadata's results could be cached.

--- a/plugin/methodWrappers_test.go
+++ b/plugin/methodWrappers_test.go
@@ -3,6 +3,7 @@ package plugin
 import (
 	"context"
 	"fmt"
+	"io"
 	"regexp"
 	"testing"
 	"time"
@@ -82,6 +83,11 @@ func (m *methodWrappersTestsMockEntry) Signal(ctx context.Context, signal string
 	return args.Error(0)
 }
 
+func (m *methodWrappersTestsMockEntry) Read(ctx context.Context) ([]byte, error) {
+	args := m.Called(ctx)
+	return args.Get(0).([]byte), args.Error(1)
+}
+
 func newMethodWrappersTestsMockEntry(name string) *methodWrappersTestsMockEntry {
 	e := &methodWrappersTestsMockEntry{
 		EntryBase: NewEntry(name),
@@ -106,6 +112,116 @@ func (suite *MethodWrappersTestSuite) TestPrefetched() {
 	suite.False(IsPrefetched(e))
 	e.Prefetched()
 	suite.True(IsPrefetched(e))
+}
+
+func (suite *MethodWrappersTestSuite) TestRead_PanicsOnNonReadableEntry() {
+	// Use an external plugin entry because they're easier to setup
+	panicFunc := func() {
+		entry := &externalPluginEntry{
+			EntryBase: NewEntry("foo"),
+		}
+		_, _ = Read(context.Background(), entry, 10, 0)
+	}
+	suite.Panics(panicFunc, "plugin.Read called on a non-readable entry")
+}
+
+func (suite *MethodWrappersTestSuite) TestRead_ReturnsCachedReadError() {
+	// This test-case only applies to Readable entries
+	e := newMethodWrappersTestsMockEntry("mockEntry")
+	e.DisableDefaultCaching()
+	e.SetTestID("/foo")
+
+	ctx := context.Background()
+	expectedErr := fmt.Errorf("an error")
+	e.On("Read", ctx).Return([]byte{}, expectedErr)
+
+	_, err := Read(ctx, e, 2, 1)
+	suite.Equal(expectedErr, err)
+}
+
+type methodWrappersTestsMockBlockReadableEntry struct {
+	*methodWrappersTestsMockEntry
+}
+
+func (m *methodWrappersTestsMockBlockReadableEntry) Read(ctx context.Context, size int64, offset int64) ([]byte, error) {
+	args := m.Called(ctx, size, offset)
+	return args.Get(0).([]byte), args.Error(1)
+}
+
+func (suite *MethodWrappersTestSuite) TestRead_ReturnsContentReadError() {
+	// This test-case only applies to BlockReadable entries
+	e := &methodWrappersTestsMockBlockReadableEntry{
+		newMethodWrappersTestsMockEntry("mockEntry"),
+	}
+	e.DisableDefaultCaching()
+	e.SetTestID("/foo")
+
+	ctx := context.Background()
+	expectedErr := fmt.Errorf("an error")
+	e.On("Read", ctx, int64(10), int64(0)).Return([]byte{}, expectedErr)
+
+	_, err := Read(ctx, e, 10, 0)
+	suite.Equal(expectedErr, err)
+}
+
+func (suite *MethodWrappersTestSuite) TestRead_ReadsTheEntryContent() {
+	e := newMethodWrappersTestsMockEntry("mockEntry")
+	e.DisableDefaultCaching()
+	e.SetTestID("/foo")
+
+	ctx := context.Background()
+	e.On("Read", ctx).Return([]byte("some raw content"), nil).Once()
+
+	rawContent, err := Read(ctx, e, 2, 1)
+	if suite.NoError(err) {
+		suite.Equal([]byte("om"), rawContent)
+	}
+}
+
+func (suite *MethodWrappersTestSuite) TestRead_EntryHasSizeAttribute() {
+	rawContent := []byte("some raw content")
+	contentSize := int64(len(rawContent))
+
+	e := &methodWrappersTestsMockBlockReadableEntry{
+		newMethodWrappersTestsMockEntry("mockEntry"),
+	}
+	e.DisableDefaultCaching()
+	e.SetTestID("/foo")
+	e.Attributes().SetSize(uint64(contentSize))
+
+	ctx := context.Background()
+
+	// Test that out-of-bounds offset does the right thing.
+	data, err := Read(ctx, e, 0, contentSize)
+	suite.Equal(io.EOF, err)
+	suite.Equal([]byte{}, data)
+	data, err = Read(ctx, e, 0, contentSize+1)
+	suite.Equal(io.EOF, err)
+	suite.Equal([]byte{}, data)
+
+	// Now test that the right "size" parameter is passed in to
+	// entryContent#read
+	type testCase struct {
+		size         int64
+		offset       int64
+		expectedSize int64
+	}
+	testCases := []testCase{
+		// Test with an in-bounds size
+		testCase{contentSize - 1, 0, contentSize - 1},
+		// Test with an out-of-bounds size
+		testCase{contentSize + 1, 0, contentSize},
+	}
+	for _, testCase := range testCases {
+		e.On("Read", ctx, testCase.expectedSize, testCase.offset).Return([]byte("success"), nil).Once()
+		actual, err := Read(context.Background(), e, testCase.size, testCase.offset)
+		if testCase.expectedSize != testCase.size {
+			suite.Equal(io.EOF, err)
+		} else {
+			suite.NoError(err)
+		}
+		suite.Equal([]byte("success"), actual)
+	}
 }
 
 func (suite *MethodWrappersTestSuite) TestSignal_ReturnsSignalError() {

--- a/plugin/methodWrappers_test.go
+++ b/plugin/methodWrappers_test.go
@@ -178,6 +178,23 @@ func (suite *MethodWrappersTestSuite) TestRead_ReadsTheEntryContent() {
 	}
 }
 
+func (suite *MethodWrappersTestSuite) TestRead_IgnoresIOEOFErrors() {
+	// This test-case only applies to BlockReadable entries
+	e := &methodWrappersTestsMockBlockReadableEntry{
+		newMethodWrappersTestsMockEntry("mockEntry"),
+	}
+	e.DisableDefaultCaching()
+	e.SetTestID("/foo")
+
+	ctx := context.Background()
+	e.On("Read", ctx, int64(10), int64(0)).Return([]byte("foo"), io.EOF)
+
+	data, err := Read(ctx, e, 10, 0)
+	if suite.NoError(err) {
+		suite.Equal([]byte("foo"), data)
+	}
+}
+
 func (suite *MethodWrappersTestSuite) TestRead_EntryHasSizeAttribute() {
 	rawContent := []byte("some raw content")
 	contentSize := int64(len(rawContent))
@@ -193,11 +210,13 @@ func (suite *MethodWrappersTestSuite) TestRead_EntryHasSizeAttribute() {
 
 	// Test that out-of-bounds offset does the right thing.
 	data, err := Read(ctx, e, 0, contentSize)
-	suite.Equal(io.EOF, err)
-	suite.Equal([]byte{}, data)
+	if suite.NoError(err) {
+		suite.Equal([]byte{}, data)
+	}
 	data, err = Read(ctx, e, 0, contentSize+1)
-	suite.Equal(io.EOF, err)
-	suite.Equal([]byte{}, data)
+	if suite.NoError(err) {
+		suite.Equal([]byte{}, data)
+	}
 
 	// Now test that the right "size" parameter is passed in to
 	// entryContent#read
@@ -215,12 +234,9 @@ func (suite *MethodWrappersTestSuite) TestRead_EntryHasSizeAttribute() {
 	for _, testCase := range testCases {
 		e.On("Read", ctx, testCase.expectedSize, testCase.offset).Return([]byte("success"), nil).Once()
 		actual, err := Read(context.Background(), e, testCase.size, testCase.offset)
-		if testCase.expectedSize != testCase.size {
-			suite.Equal(io.EOF, err)
-		} else {
-			suite.NoError(err)
+		if suite.NoError(err) {
+			suite.Equal([]byte("success"), actual)
 		}
-		suite.Equal([]byte("success"), actual)
 	}
 }
 

--- a/plugin/types.go
+++ b/plugin/types.go
@@ -189,10 +189,16 @@ type SizedReader interface {
 	Size() int64
 }
 
-// Readable is an entry that has a fixed amount of content we can read.
+// BlockReadable is an entry with content that can be read in blocks
+type BlockReadable interface {
+	Entry
+	Read(ctx context.Context, size int64, offset int64) ([]byte, error)
+}
+
+// Readable is an entry with content that can be read
 type Readable interface {
 	Entry
-	Open(context.Context) (SizedReader, error)
+	Read(context.Context) ([]byte, error)
 }
 
 // Writable is an entry that can write data directly to the entry. It mirrors

--- a/volume/core.go
+++ b/volume/core.go
@@ -28,7 +28,7 @@ type Interface interface {
 	// points to a nil Dir, it is assumed to be unexplored.
 	VolumeList(ctx context.Context, path string) (DirMap, error)
 	// Accepts a path and returns the content associated with that path.
-	VolumeOpen(ctx context.Context, path string) (plugin.SizedReader, error)
+	VolumeRead(ctx context.Context, path string) ([]byte, error)
 	// Accepts a path and streams updates to the content associated with that path.
 	VolumeStream(ctx context.Context, path string) (io.ReadCloser, error)
 	// Deletes the volume node at the specified path. Mirrors plugin.Deletable#Delete

--- a/volume/dir_test.go
+++ b/volume/dir_test.go
@@ -23,7 +23,7 @@ func (m *mockDirEntry) VolumeList(ctx context.Context, path string) (DirMap, err
 	return arger.Get(0).(DirMap), arger.Error(1)
 }
 
-func (m *mockDirEntry) VolumeOpen(context.Context, string) (plugin.SizedReader, error) {
+func (m *mockDirEntry) VolumeRead(context.Context, string) ([]byte, error) {
 	return nil, nil
 }
 

--- a/volume/file.go
+++ b/volume/file.go
@@ -24,7 +24,7 @@ func newFile(name string, attr plugin.EntryAttributes, impl Interface, path stri
 	vf.impl = impl
 	vf.path = path
 	vf.SetAttributes(attr)
-	vf.SetTTLOf(plugin.OpenOp, 60*time.Second)
+	vf.SetTTLOf(plugin.ReadOp, 60*time.Second)
 
 	return vf
 }
@@ -33,9 +33,9 @@ func (v *file) Schema() *plugin.EntrySchema {
 	return plugin.NewEntrySchema(v, "file").SetDescription(fileDescription)
 }
 
-// Open returns the content of the file as a SizedReader.
-func (v *file) Open(ctx context.Context) (plugin.SizedReader, error) {
-	return v.impl.VolumeOpen(ctx, v.path)
+// Read reads the content of the file
+func (v *file) Read(ctx context.Context) ([]byte, error) {
+	return v.impl.VolumeRead(ctx, v.path)
 }
 
 func (v *file) Stream(ctx context.Context) (io.ReadCloser, error) {

--- a/volume/fs.go
+++ b/volume/fs.go
@@ -114,8 +114,8 @@ func (d *FS) VolumeList(ctx context.Context, path string) (DirMap, error) {
 	return StatParseAll(buf, RootPath, path, d.maxdepth)
 }
 
-// VolumeOpen satisfies the Interface required by List to read file contents.
-func (d *FS) VolumeOpen(ctx context.Context, path string) (plugin.SizedReader, error) {
+// VolumeRead satisfies the Interface required by List to read file contents.
+func (d *FS) VolumeRead(ctx context.Context, path string) ([]byte, error) {
 	activity.Record(ctx, "Reading %v on %v", path, plugin.ID(d.executor))
 
 	// Don't use Tty when outputting file content because it may convert LF to CRLF.
@@ -124,7 +124,7 @@ func (d *FS) VolumeOpen(ctx context.Context, path string) (plugin.SizedReader, e
 		activity.Record(ctx, "Exec error running 'cat %v' in VolumeOpen: %v", path, err)
 		return nil, err
 	}
-	return bytes.NewReader(buf.Bytes()), nil
+	return buf.Bytes(), nil
 }
 
 // VolumeStream satisfies the Interface required by List to stream file contents.

--- a/volume/fs_test.go
+++ b/volume/fs_test.go
@@ -217,14 +217,10 @@ func (suite *fsTestSuite) TestFSRead() {
 
 	execResult := suite.createResult("hello")
 	exec.On("Exec", mock.Anything, "cat", []string{"/var/log/path1/a file"}, plugin.ExecOptions{Elevate: true}).Return(execResult, nil)
-	rdr, err := entry.(plugin.Readable).Open(context.Background())
-	suite.NoError(err)
-	suite.Equal(int64(5), rdr.Size())
-	buf := make([]byte, 5)
-	n, err := rdr.ReadAt(buf, 0)
-	suite.NoError(err)
-	suite.Equal(5, n)
-	suite.Equal("hello", string(buf))
+	content, err := entry.(plugin.Readable).Read(context.Background())
+	if suite.NoError(err) {
+		suite.Equal([]byte("hello"), content)
+	}
 }
 
 func (suite *fsTestSuite) TestVolumeDelete() {


### PR DESCRIPTION
External plugins will be handled in a follow-up PR. We should also file a separate issue for the volume package; I didn't implement BlockReadable for the volume package because it isn't as easy to do as e.g. S3 objects or GCP storage objects.

Supports https://github.com/puppetlabs/wash/issues/619