### PR TITLE
Fix prompt when in a folder with spaces

### DIFF
--- a/cmd/internal/shell/bash.go
+++ b/cmd/internal/shell/bash.go
@@ -51,9 +51,9 @@ func (b bash) Command(subcommands []string, rundir string) (*exec.Cmd, error) {
 function prompter() {
   local prompt_path
   if [ -x "$(command -v realpath)" ]; then
-    prompt_path=$(realpath --relative-base=$W $(pwd))
+    prompt_path=$(realpath --relative-base=$W "$(pwd)")
   else
-    prompt_path=$(basename $(pwd))
+    prompt_path=$(basename "$(pwd)")
   fi
   export PS1="\e[0;36mwash ${prompt_path}\e[0;32m ❯\e[m "
 }

--- a/cmd/internal/shell/zsh.go
+++ b/cmd/internal/shell/zsh.go
@@ -61,9 +61,9 @@ fi
 function prompter() {
   local prompt_path
   if [ -x "$(command -v realpath)" ]; then
-    prompt_path=$(realpath --relative-base=$W $(pwd))
+    prompt_path=$(realpath --relative-base=$W "$(pwd)")
   else
-    prompt_path=$(basename $(pwd))
+    prompt_path=$(basename "$(pwd)")
   fi
   PROMPT="%F{cyan}wash ${prompt_path}%F{green} ❯%f "
 }


### PR DESCRIPTION
Quote working directory before passing to realpath/basename so it's interpreted as a single path rather than several.

Fixes #636.

Signed-off-by: Michael Smith <michael.smith@puppet.com>