### PR TITLE
Use os-package signals rather than syscall

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
-	"syscall"
 	"time"
 
 	"github.com/Benchkram/errz"
@@ -62,7 +61,7 @@ func serverMain(cmd *cobra.Command, args []string) exitCode {
 	// On Ctrl-C, trigger the clean-up. This consists of shutting down the API
 	// server and unmounting the FS.
 	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	signal.Notify(sigCh, os.Interrupt, os.Kill)
 
 	plugins, serverOpts, err := serverOptsFor(cmd)
 	if err != nil {


### PR DESCRIPTION
Removes a direct dependency that can be platform-dependent in favor of the `os` abstraction for the same signal types.

Signed-off-by: Michael Smith <michael.smith@puppet.com>