### PR TITLE
Support block-readable external plugin entries

### DIFF
--- a/plugin/cache.go
+++ b/plugin/cache.go
@@ -222,14 +222,12 @@ func cachedRead(ctx context.Context, e Entry) (entryContent, error) {
 			}
 			return newEntryContent(rawContent), nil
 		case blockReadableSignature:
-			// Go doesn't allow overloaded functions, so the external plugin entry type
-			// cannot implement both BlockReadable#Read and Readable#Read. Thus, external
-			// plugins implement the BlockReadable interface via a separate blockRead
-			// method.
 			var readFunc blockReadFunc
 			switch t := e.(type) {
 			case externalPlugin:
-				// TODO: external plugin implementation here!
+				readFunc = func(ctx context.Context, size int64, offset int64) ([]byte, error) {
+					return t.blockRead(ctx, size, offset)
+				}
 			case BlockReadable:
 				readFunc = func(ctx context.Context, size int64, offset int64) ([]byte, error) {
 					return t.Read(ctx, size, offset)


### PR DESCRIPTION
Supports https://github.com/puppetlabs/wash/issues/619

Signed-off-by: Enis Inan <enis.inan@puppet.com>