### PR TITLE
Cleanup from Read changes

### DIFF
--- a/api/fs/dir.go
+++ b/api/fs/dir.go
@@ -44,3 +44,5 @@ func (d *dir) Schema() *plugin.EntrySchema {
 	// plugin.
 	return nil
 }
+
+var _ = plugin.Parent(&dir{})

--- a/api/fs/file.go
+++ b/api/fs/file.go
@@ -1,7 +1,6 @@
 package apifs
 
 import (
-	"bytes"
 	"context"
 	"io/ioutil"
 	"os"
@@ -19,14 +18,16 @@ func newFile(ctx context.Context, finfo os.FileInfo, path string) *file {
 	}
 }
 
-func (f *file) Open(ctx context.Context) (plugin.SizedReader, error) {
+func (f *file) Read(ctx context.Context) ([]byte, error) {
 	content, err := ioutil.ReadFile(f.path)
 	if err != nil {
 		return nil, err
 	}
-	return bytes.NewReader(content), nil
+	return content, nil
 }
 
 func (f *file) Schema() *plugin.EntrySchema {
 	return nil
 }
+
+var _ = plugin.Readable(&file{})

--- a/plugin/types.go
+++ b/plugin/types.go
@@ -183,12 +183,6 @@ type Streamable interface {
 	Stream(context.Context) (io.ReadCloser, error)
 }
 
-// SizedReader returns a ReaderAt that can report its Size.
-type SizedReader interface {
-	io.ReaderAt
-	Size() int64
-}
-
 // BlockReadable is an entry with content that can be read in blocks
 type BlockReadable interface {
 	Entry


### PR DESCRIPTION
`SizedReader` is no longer needed, and api.fs was missed in the work. Add static assertions on the intended types for the api.fs resources to catch this in the future.

Signed-off-by: Michael Smith <michael.smith@puppet.com>