### PR TITLE
Fix CI

### DIFF
--- a/plugin/cache_test.go
+++ b/plugin/cache_test.go
@@ -170,11 +170,6 @@ func (e *cacheTestsMockEntry) Schema() *EntrySchema {
 	return nil
 }
 
-func (e *cacheTestsMockEntry) Open(ctx context.Context) (SizedReader, error) {
-	args := e.Called(ctx)
-	return args.Get(0).(SizedReader), args.Error(1)
-}
-
 func (e *cacheTestsMockEntry) Metadata(ctx context.Context) (JSONObject, error) {
 	args := e.Called(ctx)
 	return args.Get(0).(JSONObject), args.Error(1)

--- a/plugin/methodWrappers_test.go
+++ b/plugin/methodWrappers_test.go
@@ -73,11 +73,6 @@ func (m *methodWrappersTestsMockEntry) Delete(ctx context.Context) (bool, error)
 	return args.Get(0).(bool), args.Error(1)
 }
 
-func (m *methodWrappersTestsMockEntry) Open(ctx context.Context) (SizedReader, error) {
-	args := m.Called(ctx)
-	return args.Get(0).(SizedReader), args.Error(1)
-}
-
 func (m *methodWrappersTestsMockEntry) Signal(ctx context.Context, signal string) error {
 	args := m.Called(ctx, signal)
 	return args.Error(0)


### PR DESCRIPTION
Previous PR was merged before CI finished, and failed to cleanup some unused test definitions that relied on `SizedReader`.

Signed-off-by: Michael Smith <michael.smith@puppet.com>