### PR TITLE
Set OpenDirectIO flag for entries w/ unknown content size

### DIFF
--- a/fuse/core.go
+++ b/fuse/core.go
@@ -92,13 +92,8 @@ func (f *fuseNode) applyAttr(a *fuse.Attr, attr *plugin.EntryAttributes, default
 		a.Mode = defaultMode
 	}
 
-	const blockSize = 4096
 	if attr.HasSize() {
 		a.Size = attr.Size()
-	} else {
-		// Default to the block size to encourage tools to read the file to determine its actual size.
-		// We don't know the size, and cat at least ignores a file with size 0.
-		a.Size = blockSize
 	}
 
 	a.Mtime = startTime
@@ -117,7 +112,7 @@ func (f *fuseNode) applyAttr(a *fuse.Attr, attr *plugin.EntryAttributes, default
 	if attr.HasCrtime() {
 		a.Crtime = attr.Crtime()
 	}
-	a.BlockSize = blockSize
+	a.BlockSize = 4096
 	a.Uid = uid
 	a.Gid = gid
 }

--- a/plugin/methodWrappers.go
+++ b/plugin/methodWrappers.go
@@ -93,23 +93,9 @@ func ID(e Entry) string {
 	return e.id()
 }
 
-// Attributes returns the entry's attributes. If size is unknown, it will check whether the entry
-// has locally cached content and if so set that for the size.
+// Attributes returns the entry's attributes.
 func Attributes(e Entry) EntryAttributes {
-	// Sometimes an entry doesn't know its size unless it's already downloaded some content. Having
-	// to download content makes list slow, and is a burden for external plugin developers. Check if
-	// we already know the size. If not, FUSE will use a reasonable default so tools don't ignore it.
-	attr := e.attributes()
-	if !attr.HasSize() && cache != nil {
-		// We have no way to preserve this on the entry, and it likely wouldn't help because we often
-		// recreate the entry to ensure we have an accurate representation. So when the cache expires
-		// we revert to stating the size is unknown until the next read operation.
-		if val, _ := cache.Get(defaultOpCodeToNameMap[ReadOp], e.id()); val != nil {
-			content := val.(entryContent)
-			attr.SetSize(content.size())
-		}
-	}
-	return attr
+	return e.attributes()
 }
 
 // IsPrefetched returns whether an entry has data that was added during creation that it would


### PR DESCRIPTION
This way, FUSE will still read those entries' content even when their
(reported) size is 0.

Fixes https://github.com/puppetlabs/wash/issues/609

Signed-off-by: Enis Inan <enis.inan@puppet.com>