### PR TITLE
Implement updated Writable spec

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ When making changes to Wash's APIs, remember to update the inline swagger docume
 
 ### Local filesystem testing
 
-A developer-only plugin is included in Wash that references the local filesystem. It can be enabled by setting the `WASH_LOCALFS` environment variable to local file path to mount before starting Wash. This can be useful for testing changes to core functionality like the `fuse` or `api` modules.
+A developer-only plugin is included in Wash that references the local filesystem. It can be enabled by setting the `WASH_LOCALFS` environment variable to the local file path to mount before starting Wash. This can be useful for testing changes to core functionality like the `fuse` or `api` modules.
 
 ## Submitting Changes
 Fork the repo, make changes, file a Pull Request.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,10 @@ It should always be safe to run `go get -u=patch` to pickup patches.
 
 When making changes to Wash's APIs, remember to update the inline swagger documentation. Instructions for regenerating the API docs are [here](./website/README.md#regenerate-swagger-docs).
 
+### Local filesystem testing
+
+A developer-only plugin is included in Wash that references the local filesystem. It can be enabled by setting the `WASH_LOCALFS` environment variable to local file path to mount before starting Wash. This can be useful for testing changes to core functionality like the `fuse` or `api` modules.
+
 ## Submitting Changes
 Fork the repo, make changes, file a Pull Request.
 

--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ Project maintainers are not actively working on all of these things, but any of 
 ### Primitives
 
 * [ ] file/directory upload _(prereq for executing commands that aren't just one-liners)_
-* [ ] edit a resource _(e.g. edit a file representing a k8s ConfigMap, and upon write save it via the k8s api)_
-* [ ] delete a resource _(e.g. `rm`-ing a file in an S3 bucket deletes it)_
-* [ ] signal handling to represent basic verbs _(e.g. sending a TERM to an EC2 instance will terminate it)_
+* [x] edit a resource _(e.g. edit a file representing a k8s ConfigMap, and upon write save it via the k8s api)_
+* [x] delete a resource _(e.g. `rm`-ing a file in an S3 bucket deletes it)_
+* [x] signal handling to represent basic verbs _(e.g. sending a TERM to an EC2 instance will terminate it)_
 * [ ] copy / move / rename _(how should this work?)_
 * [ ] make `stream` able to "go back in time" _(e.g. support `tail -100 -f` style of "look-back")_
 
@@ -52,7 +52,7 @@ Project maintainers are not actively working on all of these things, but any of 
 ### CLI tools
 
 * [ ] colorized output for `ls`, similar to `exa -l`
-* [ ] make `ls` emit something useful when used against non-`wash` resources
+* [x] make `ls` emit something useful when used against non-`wash` resources
 * [ ] `exec` should work in parallel across multiple target resources
 * [ ] build an interactive shell that works over `exec` _(need to update plugins API to support this, most likely)_
 * [ ] a version of `top` that works using `wash` primitives to get information to display from multiple targets

--- a/api/fs/dir.go
+++ b/api/fs/dir.go
@@ -38,13 +38,14 @@ func (d *dir) List(ctx context.Context) ([]plugin.Entry, error) {
 }
 
 func (d *dir) ChildSchemas() []*plugin.EntrySchema {
-	return nil
+	return []*plugin.EntrySchema{
+		(&dir{}).Schema(),
+		(&file{}).Schema(),
+	}
 }
 
 func (d *dir) Schema() *plugin.EntrySchema {
-	// Schema only makes sense for core plugins. apifs isn't a core
-	// plugin.
-	return nil
+	return plugin.NewEntrySchema(d, "dir")
 }
 
 var _ = plugin.Parent(&dir{})

--- a/api/fs/file.go
+++ b/api/fs/file.go
@@ -32,4 +32,9 @@ func (f *file) Schema() *plugin.EntrySchema {
 	return plugin.NewEntrySchema(f, "file")
 }
 
+func (f *file) Write(ctx context.Context, p []byte) error {
+	return ioutil.WriteFile(f.path, p, 0640)
+}
+
 var _ = plugin.Readable(&file{})
+var _ = plugin.Writable(&file{})

--- a/api/fs/file.go
+++ b/api/fs/file.go
@@ -29,7 +29,7 @@ func (f *file) Read(ctx context.Context) ([]byte, error) {
 }
 
 func (f *file) Schema() *plugin.EntrySchema {
-	return nil
+	return plugin.NewEntrySchema(f, "file")
 }
 
 var _ = plugin.Readable(&file{})

--- a/api/fs/root.go
+++ b/api/fs/root.go
@@ -1,0 +1,52 @@
+package apifs
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/puppetlabs/wash/plugin"
+)
+
+// Root of the local filesystem plugin
+type Root struct {
+	dir
+}
+
+// Init for root
+func (r *Root) Init(cfg map[string]interface{}) error {
+	var basepath string
+	if pathI, ok := cfg["basepath"]; ok {
+		basepath, ok = pathI.(string)
+		if !ok {
+			return fmt.Errorf("local.basepath config must be a string, not %s", pathI)
+		}
+	} else {
+		basepath = "/tmp"
+	}
+
+	finfo, err := os.Stat(basepath)
+	if err != nil {
+		return err
+	}
+
+	r.dir.fsnode = newFSNode(finfo, basepath)
+
+	r.EntryBase = plugin.NewEntry("local")
+	r.DisableDefaultCaching()
+	return nil
+}
+
+// Schema returns the root's schema
+func (r *Root) Schema() *plugin.EntrySchema {
+	return plugin.
+		NewEntrySchema(r, "local").
+		SetDescription(rootDescription).
+		IsSingleton()
+}
+
+var _ = plugin.Root(&Root{})
+
+const rootDescription = `
+This plugin exposes part of the local filesystem. The path is mounted based on the path specified
+in the WASH_LOCALFS environment variable.
+`

--- a/cmd/internal/server/core.go
+++ b/cmd/internal/server/core.go
@@ -23,6 +23,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// InternalPlugins lists the plugins enabled by default in Wash.
 var InternalPlugins = map[string]plugin.Root{
 	"aws":        &aws.Root{},
 	"docker":     &docker.Root{},

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/Benchkram/errz"
+	apifs "github.com/puppetlabs/wash/api/fs"
 	"github.com/puppetlabs/wash/cmd/internal/config"
 	"github.com/puppetlabs/wash/cmd/internal/server"
 	cmdutil "github.com/puppetlabs/wash/cmd/util"
@@ -167,6 +168,12 @@ func serverOptsFor(cmd *cobra.Command) (map[string]plugin.Root, server.Opts, err
 	pluginConfig := make(map[string]map[string]interface{})
 	for name := range plugins {
 		pluginConfig[name] = viper.GetStringMap(name)
+	}
+
+	// Developer flag to enable a local filesystem for testing core functionality.
+	if localfsPath := os.Getenv("WASH_LOCALFS"); localfsPath != "" {
+		plugins["local"] = &apifs.Root{}
+		pluginConfig["local"] = map[string]interface{}{"basepath": localfsPath}
 	}
 
 	// Return the options

--- a/docs/docs/external-plugins.md
+++ b/docs/docs/external-plugins.md
@@ -162,6 +162,10 @@ where `Some content` is the entry's content.
 
 When `write` is invoked, the script must read from `stdin` to get the content to write to the entry.
 
+Wash distinguishes between two different patterns for things you can read and write. It considers a "file-like" entry to be one with a defined size (so the `size` attribute is set when listing the entry). Reading and writing a "file-like" entry edits the contents.
+
+Something that can be read and written but doesn't define size has different characteristics. Reading and writing are not symmetrical: if you write to it then read from it, you may not see what you just wrote. So these non-file-like entries error if you try to open them with a ReadWrite handle.
+
 ### Examples
 
 ```

--- a/docs/docs/external-plugins.md
+++ b/docs/docs/external-plugins.md
@@ -162,9 +162,9 @@ where `Some content` is the entry's content.
 
 When `write` is invoked, the script must read from `stdin` to get the content to write to the entry.
 
-Wash distinguishes between two different patterns for things you can read and write. It considers a "file-like" entry to be one with a defined size (so the `size` attribute is set when listing the entry). Reading and writing a "file-like" entry edits the contents.
+Wash distinguishes between two different patterns for things you can read and write. It considers a "file-like" entry to be one with a defined size (so the `size` attribute is set when listing the entry). Reading and writing a "file-like" entry edits the contents. The data passed to `stdin` is meant to be the entire content of the file.
 
-Something that can be read and written but doesn't define size has different characteristics. Reading and writing are not symmetrical: if you write to it then read from it, you may not see what you just wrote. So these non-file-like entries error if you try to open them with a ReadWrite handle.
+Something that can be read and written but doesn't define size has different characteristics. Reading and writing are not symmetrical: if you write to it then read from it, you may not see what you just wrote. So these non-file-like entries error if you try to open them with a ReadWrite handle. If your plugin implements non-file-like write-semantics, remember to document how they work in the plugin schema's description.
 
 ### Examples
 

--- a/docs/docs/external-plugins.md
+++ b/docs/docs/external-plugins.md
@@ -7,6 +7,7 @@ title: External Plugins
     - [init](#init)
     - [list](#list)
     - [read](#read)
+    - [write](#write)
     - [metadata](#metadata)
     - [stream](#stream)
     - [exec](#exec)
@@ -155,6 +156,19 @@ Som
 ```
 
 where `Some content` is the entry's content.
+
+## write
+`<plugin_script> write <path> <state>`
+
+When `write` is invoked, the script must read from `stdin` to get the content to write to the entry.
+
+### Examples
+
+```
+bash-3.2$ echo 'new content' | /path/to/myplugin.rb write /myplugin/foo ''
+```
+
+results in changing the entry's content to `new content`.
 
 ## metadata
 `<plugin_script> metadata <path> <state>`

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -264,9 +264,12 @@ echo "Hello, world!"
 ### write
 The `write` action lets you write data to an entry. Thus, any command that writes a file also works with these entries.
 
-Note that Wash distinguishes between file-like and non-file-like entries. An entry is file-like if it's readable and writable and defines its size; you can edit it like a file. If it doesn't define a size then it's non-file-like, and trying to open it with a ReadWrite handle will error; reads from it may not return data you previously wrote to it.
+Note that Wash distinguishes between file-like and non-file-like entries. An entry is file-like if it's readable and writable and defines its size; you can edit it like a file.
+
+If it doesn't define a size then it's non-file-like, and trying to open it with a ReadWrite handle will error; reads from it may not return data you previously wrote to it. You should check its documentation with the `docs` command for that entry's write semantics. We also recommend not using editors with these entries to avoid weird behavior.
 
 #### Examples
+Modifying a file stored in Google Cloud Storage
 ```
 wash . ❯ echo 'exit 1' >> gcp/Wash/storage/some-wash-stuff/an\ example\ folder/static.sh
 wash . ❯ cat gcp/Wash/storage/some-wash-stuff/an\ example\ folder/static.sh
@@ -274,6 +277,16 @@ wash . ❯ cat gcp/Wash/storage/some-wash-stuff/an\ example\ folder/static.sh
 
 echo "Hello, world!"
 exit 1
+```
+
+Writing a message to a hypothetical message queue where each write publishes a message and each read consumes a message
+```
+wash > echo 'message 1' >> myqueue
+wash > echo 'message 2' >> myqueue
+wash > cat myqueue
+message 1
+wash > cat myqueue
+message 2
 ```
 
 ### stream

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -264,6 +264,8 @@ echo "Hello, world!"
 ### write
 The `write` action lets you write data to an entry. Thus, any command that writes a file also works with these entries.
 
+Note that Wash distinguishes between file-like and non-file-like entries. An entry is file-like if it's readable and writable and defines its size; you can edit it like a file. If it doesn't define a size then it's non-file-like, and trying to open it with a ReadWrite handle will error; reads from it may not return data you previously wrote to it.
+
 #### Examples
 ```
 wash . ❯ echo 'exit 1' >> gcp/Wash/storage/some-wash-stuff/an\ example\ folder/static.sh

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -29,6 +29,7 @@ title: Docs
 * [Actions](#actions)
   * [list](#list)
   * [read](#read)
+  * [write](#write)
   * [stream](#stream)
   * [exec](#exec)
   * [delete](#delete)
@@ -245,7 +246,7 @@ gcp/Wash/storage/some-wash-stuff
 ```
 
 ### read
-The `read` action lets you view an entry’s content. Thus, any command that reads a file also works with these entries.
+The `read` action lets you read data from an entry. Thus, any command that reads a file also works with these entries.
 
 #### Examples
 ```
@@ -258,6 +259,19 @@ echo "Hello, world!"
 ```
 wash . ❯ grep "Hello" gcp/Wash/storage/some-wash-stuff/an\ example\ folder/static.sh
 echo "Hello, world!"
+```
+
+### write
+The `write` action lets you write data to an entry. Thus, any command that writes a file also works with these entries.
+
+#### Examples
+```
+wash . ❯ echo 'exit 1' >> gcp/Wash/storage/some-wash-stuff/an\ example\ folder/static.sh
+wash . ❯ cat gcp/Wash/storage/some-wash-stuff/an\ example\ folder/static.sh
+#!/bin/sh
+
+echo "Hello, world!"
+exit 1
 ```
 
 ### stream

--- a/fuse/file.go
+++ b/fuse/file.go
@@ -3,9 +3,12 @@ package fuse
 import (
 	"context"
 	"io"
+	"os"
+	"sync"
 
 	"bazil.org/fuse"
 	"bazil.org/fuse/fs"
+	"bazil.org/fuse/fuseutil"
 	"github.com/puppetlabs/wash/activity"
 	"github.com/puppetlabs/wash/plugin"
 )
@@ -13,93 +16,274 @@ import (
 // ==== FUSE file Interface ====
 
 type file struct {
-	*fuseNode
-}
+	fuseNode
 
-var _ fs.Node = (*file)(nil)
-var _ = fs.NodeOpener(&file{})
+	mux sync.Mutex
+	// Handles with in-progress writes
+	writers map[fuse.HandleID]struct{}
+	// Only valid if len(writers) > 0
+	data []byte
+	// Size for content during writing
+	size uint64
+}
 
 func newFile(p *dir, e plugin.Entry) *file {
-	return &file{newFuseNode("f", p, e)}
+	return &file{fuseNode: newFuseNode("f", p, e), writers: make(map[fuse.HandleID]struct{})}
 }
+
+var _ = fs.Node(&file{})
+var _ = fs.Handle(&file{})
+
+func (f *file) Attr(ctx context.Context, a *fuse.Attr) error {
+	f.mux.Lock()
+	defer f.mux.Unlock()
+
+	if len(f.writers) == 0 {
+		// Fetch updated attributes.
+		entry, err := f.refind(ctx)
+		if err != nil {
+			activity.Warnf(ctx, "FUSE: Attr errored %v, %v", f, err)
+			return err
+		}
+		f.entry = entry
+	}
+
+	f.fillAttr(a)
+	activity.Record(ctx, "FUSE: Attr %v: %+v", f, *a)
+	return nil
+}
+
+func (f *file) fillAttr(a *fuse.Attr) {
+	attr := plugin.Attributes(f.entry)
+	applyAttr(a, attr, getFileMode(f.entry))
+
+	if len(f.writers) != 0 {
+		// Use whatever size we know locally.
+		a.Size = f.size
+	}
+}
+
+func getFileMode(entry plugin.Entry) os.FileMode {
+	var mode os.FileMode
+	if plugin.WriteAction().IsSupportedOn(entry) {
+		mode |= 0220
+	}
+	if plugin.ReadAction().IsSupportedOn(entry) ||
+		plugin.StreamAction().IsSupportedOn(entry) {
+		mode |= 0440
+	}
+	return mode
+}
+
+var _ = fs.NodeOpener(&file{})
 
 // Open a file for reading or writing.
 func (f *file) Open(ctx context.Context, req *fuse.OpenRequest, resp *fuse.OpenResponse) (fs.Handle, error) {
-	activity.Record(ctx, "FUSE: Open %v", f)
+	f.mux.Lock()
+	defer f.mux.Unlock()
+	activity.Record(ctx, "FUSE: Open %v: %+v", f, *req)
 
 	// Check for an updated entry in case it has static state.
-	updatedEntry, err := f.refind(ctx)
+	entry, err := f.refind(ctx)
 	if err != nil {
 		activity.Warnf(ctx, "FUSE: Open errored %v, %v", f, err)
 		return nil, err
 	}
+	f.entry = entry
 
-	var fh fileHandle
-	fh.id = f.String()
+	readable := plugin.ReadAction().IsSupportedOn(f.entry)
+	writable := plugin.WriteAction().IsSupportedOn(f.entry)
+	switch {
+	case req.Flags.IsReadOnly() && !readable:
+		activity.Record(ctx, "FUSE: Open read-only unsupported on %v", f)
+		return nil, fuse.ENOTSUP
+	case req.Flags.IsWriteOnly() && !writable:
+		activity.Record(ctx, "FUSE: Open write-only unsupported on %v", f)
+		return nil, fuse.ENOTSUP
+	case req.Flags.IsReadWrite() && (!readable || !writable):
+		activity.Record(ctx, "FUSE: Open read-write unsupported on %v", f)
+		return nil, fuse.ENOTSUP
+	}
 
-	// Initiate content request and return a channel providing the results.
-	if plugin.ReadAction().IsSupportedOn(updatedEntry) {
-		activity.Record(ctx, "FUSE: Opened %v", f)
-		if attr := plugin.Attributes(updatedEntry); !attr.HasSize() {
-			// The entry's content size is unknown so open the file in direct
-			// IO mode. This enables FUSE to still read the entry's content so
-			// that built-in tools like cat and grep still work.
+	if req.Flags.IsReadOnly() || req.Flags.IsReadWrite() {
+		attr := plugin.Attributes(entry)
+		if !attr.HasSize() {
+			// The entry's content size is unknown so open the file in direct IO mode. This enables FUSE
+			// to still read the entry's content so that built-in tools like cat and grep still work.
 			resp.Flags |= fuse.OpenDirectIO
 		}
-		fh.r = updatedEntry
 	}
-
-	if plugin.WriteAction().IsSupportedOn(updatedEntry) {
-		fh.w = updatedEntry.(plugin.Writable)
-	}
-
-	if fh.r != nil || fh.w != nil {
-		return &fh, nil
-	}
-
-	activity.Record(ctx, "FUSE: Open unsupported on %v", f)
-	return nil, fuse.ENOTSUP
+	return f, nil
 }
 
-type fileHandle struct {
-	// This is expected to implement either plugin.Readable or plugin.BlockReadable
-	r  plugin.Entry
-	w  plugin.Writable
-	id string
-}
+var _ = fs.HandleReleaser(&file{})
 
-var _ fs.Handle = (*fileHandle)(nil)
-var _ = fs.HandleReleaser(fileHandle{})
-var _ = fs.HandleReader(fileHandle{})
-var _ = fs.HandleWriter(fileHandle{})
-
-func (fh fileHandle) Release(ctx context.Context, req *fuse.ReleaseRequest) error {
-	activity.Record(ctx, "FUSE: Release %v", fh.id)
-	if closer, ok := fh.r.(io.Closer); ok {
-		return closer.Close()
+func (f *file) Release(ctx context.Context, req *fuse.ReleaseRequest) error {
+	if req.ReleaseFlags&fuse.ReleaseFlush != 0 {
+		err := f.Flush(ctx, &fuse.FlushRequest{
+			Header:    req.Header,
+			Handle:    req.Handle,
+			LockOwner: uint64(req.LockOwner),
+		})
+		if err != nil {
+			return err
+		}
 	}
 
-	if closer, ok := fh.w.(io.Closer); ok {
-		return closer.Close()
+	activity.Record(ctx, "FUSE: Release %v: %+v", f, *req)
+	return nil
+}
+
+var _ = fs.HandleReader(&file{})
+
+func (f *file) Read(ctx context.Context, req *fuse.ReadRequest, resp *fuse.ReadResponse) error {
+	f.mux.Lock()
+	defer f.mux.Unlock()
+
+	if len(f.writers) == 0 {
+		data, err := plugin.ReadWithAnalytics(ctx, f.entry, int64(req.Size), req.Offset)
+		if err != nil && err != io.EOF {
+			// If we don't ignore EOF, then cat will display an input/output error message
+			// for entries with unknown content size.
+			return err
+		}
+		resp.Data = data
+	} else {
+		fuseutil.HandleRead(req, resp, f.data)
+	}
+
+	activity.Record(ctx, "FUSE: Read %v/%v bytes starting at %v from %v", len(resp.Data), req.Size, req.Offset, f)
+	return nil
+}
+
+var _ = fs.HandleWriter(&file{})
+
+func (f *file) Write(ctx context.Context, req *fuse.WriteRequest, resp *fuse.WriteResponse) error {
+	f.mux.Lock()
+	defer f.mux.Unlock()
+
+	// Ensure handle is in list of writers.
+	f.writers[req.Handle] = struct{}{}
+
+	// If starting write beyond the current length, read to fill it in.
+	if start := int64(len(f.data)); req.Offset > start {
+		data, err := f.load(ctx, start, req.Offset)
+		if err != nil {
+			return err
+		}
+		f.data = append(f.data, data...)
+	}
+
+	// Expand the buffer if necessary and update known size.
+	newLen := req.Offset + int64(len(req.Data))
+	if newLen := int(newLen); newLen > len(f.data) {
+		f.data = append(f.data, make([]byte, newLen-len(f.data))...)
+	}
+	// Write-only entries are assumed not to have a size.
+	if plugin.ReadAction().IsSupportedOn(f.entry) && f.size < uint64(newLen) {
+		f.size = uint64(newLen)
+	}
+
+	resp.Size = copy(f.data[req.Offset:], req.Data)
+	activity.Record(ctx, "FUSE: Write %v/%v bytes starting at %v from %v", resp.Size, len(req.Data), req.Offset, f)
+	return nil
+}
+
+func (f *file) load(ctx context.Context, start, end int64) ([]byte, error) {
+	if !plugin.ReadAction().IsSupportedOn(f.entry) {
+		activity.Record(ctx, "FUSE: Non-contiguous writes (at %v) unsupported on %v", start, f)
+		return nil, fuse.ENOTSUP
+	}
+
+	return plugin.Read(ctx, f.entry, end-start, start)
+}
+
+var _ = fs.HandleFlusher(&file{})
+
+// Note that this implementation of Flush only calls plugin.Write if there were previous calls to
+// Write or Setattr. It doesn't check whether the data that's there matches what we're writing.
+func (f *file) Flush(ctx context.Context, req *fuse.FlushRequest) error {
+	f.mux.Lock()
+	defer f.mux.Unlock()
+	activity.Record(ctx, "FUSE: Flush %v: %+v", f, *req)
+	var releasedWriter bool
+
+	// If this handle had an open writer, write current data.
+	if _, ok := f.writers[req.Handle]; ok {
+		dataLen := int64(len(f.data))
+		// Write-only entries don't track size.
+		if plugin.ReadAction().IsSupportedOn(f.entry) && uint64(dataLen) > f.size {
+			panic("Size was not kept up-to-date with changes to data.")
+		}
+
+		if uint64(dataLen) < f.size {
+			// Missing some data, load the remainder before writing.
+			data, err := f.load(ctx, dataLen, int64(f.size))
+			if err != nil {
+				return err
+			}
+			f.data = append(f.data, data...)
+		}
+
+		if err := plugin.WriteWithAnalytics(ctx, f.entry.(plugin.Writable), f.data); err != nil {
+			return err
+		}
+		delete(f.writers, req.Handle)
+		releasedWriter = true
+	}
+
+	if len(f.writers) == 0 && releasedWriter {
+		// Ensure data is released. Leave size so we can use it for future attribute requests.
+		f.data = nil
+
+		// Invalidate cache on the entry and its parent. Need to get updated content and size.
+		plugin.ClearCacheFor(plugin.ID(f.entry), true)
 	}
 	return nil
 }
 
-func (fh fileHandle) Read(ctx context.Context, req *fuse.ReadRequest, resp *fuse.ReadResponse) error {
-	data, err := plugin.ReadWithAnalytics(ctx, fh.r, int64(req.Size), req.Offset)
-	if err == io.EOF {
-		// If we don't ignore this, then cat will display an input/output error message
-		// for entries with unknown content size.
-		err = nil
+var _ = fs.NodeSetattrer(&file{})
+
+func (f *file) Setattr(ctx context.Context, req *fuse.SetattrRequest, resp *fuse.SetattrResponse) error {
+	f.mux.Lock()
+	defer f.mux.Unlock()
+	activity.Record(ctx, "FUSE: Setattr[%v] %v: %+v", req.Handle, f, *req)
+
+	if req.Valid.Size() {
+		if req.Valid.Handle() {
+			// Ensure handle is in list of writers.
+			f.writers[req.Handle] = struct{}{}
+		} else {
+			// No guarantee we'll ever write the change. If this is ever necessary, we could update it
+			// to immediately do a plugin.Write.
+			return fuse.ENOTSUP
+		}
+
+		// Update known size. If the caller tries to increase the size of a Write-only entry, Flush
+		// will error because we won't be able to read to fill it in. We choose to error instead of
+		// filling with null data because there's no obvious use-case for supporting it.
+		if f.size != req.Size {
+			f.size = req.Size
+		}
+
+		// Shrink data if too large. Filling if too small is left for Write/Flush to deal with.
+		if uint64(len(f.data)) > f.size {
+			f.data = f.data[:f.size]
+		}
 	}
-	activity.Record(ctx, "FUSE: Read %v/%v bytes starting at %v from %v: %v", len(data), req.Size, req.Offset, fh.id, err)
-	resp.Data = data
-	return err
+
+	f.fillAttr(&resp.Attr)
+	return nil
 }
 
-func (fh fileHandle) Write(ctx context.Context, req *fuse.WriteRequest, resp *fuse.WriteResponse) error {
-	n, err := plugin.WriteWithAnalytics(ctx, fh.w, req.Offset, req.Data)
-	resp.Size = n
-	activity.Record(ctx, "FUSE: Write %v/%v bytes starting at %v from %v: %v", n, len(req.Data), req.Offset, fh.id, err)
-	return err
+// Needs to be defined or vim gets an fuse.EIO error on Fsync.
+var _ = fs.NodeFsyncer(&file{})
+
+func (f *file) Fsync(ctx context.Context, req *fuse.FsyncRequest) error {
+	// As noted in the docs for fs.NodeFsyncer, this should be implemented on a Handle. Write Fsync
+	// should be unnecessary because Flush handles complete serialization out. On a handle opened
+	// for reading, we could potentially invalidate the Wash cache and re-request data from the
+	// plugin, but in most cases that doesn't seem to be necessary.
+	activity.Record(ctx, "FUSE: Fsync %v: %+v", f, *req)
+	return fuse.ENOSYS
 }

--- a/fuse/file_test.go
+++ b/fuse/file_test.go
@@ -1,0 +1,389 @@
+package fuse
+
+import (
+	"context"
+	"testing"
+
+	"bazil.org/fuse"
+	"bazil.org/fuse/fs"
+	"github.com/puppetlabs/wash/datastore"
+	"github.com/puppetlabs/wash/plugin"
+	plugintest "github.com/puppetlabs/wash/plugin/test"
+	"github.com/stretchr/testify/suite"
+)
+
+type fileTestSuite struct {
+	suite.Suite
+	ctx context.Context
+}
+
+func (suite *fileTestSuite) SetupTest() {
+	plugin.SetTestCache(datastore.NewMemCache())
+}
+
+func (suite *fileTestSuite) TearDownTest() {
+	plugin.UnsetTestCache()
+}
+
+func (suite *fileTestSuite) TestOpen() {
+	var req fuse.OpenRequest
+	var resp fuse.OpenResponse
+
+	m := plugintest.NewMockBase()
+	mr := plugintest.NewMockRead()
+	mr.Attributes().SetSize(1)
+	mw := plugintest.NewMockWrite()
+	mw.Attributes().SetSize(1)
+	mrw := plugintest.NewMockReadWrite()
+	mrw.Attributes().SetSize(1)
+
+	// expectErrs corresponds to expectations on fields in flags.
+	flags := []fuse.OpenFlags{fuse.OpenReadOnly, fuse.OpenWriteOnly, fuse.OpenReadWrite}
+	for m, expectErrs := range map[plugin.Entry][]bool{
+		m:   []bool{true, true, true},
+		mr:  []bool{false, true, true},
+		mw:  []bool{true, false, true},
+		mrw: []bool{false, false, false},
+	} {
+		f := newFile(nil, m)
+
+		for i, flag := range flags {
+			req.Flags = flag
+			_, err := f.Open(suite.ctx, &req, &resp)
+			if expectErr := expectErrs[i]; expectErr {
+				suite.Error(err)
+			} else {
+				suite.NoError(err)
+			}
+		}
+	}
+}
+
+func (suite *fileTestSuite) TestOpen_WithSize() {
+	m := plugintest.NewMockRead()
+	m.Attributes().SetSize(1)
+
+	f := newFile(nil, m)
+	var req fuse.OpenRequest
+	var resp fuse.OpenResponse
+	handle, err := f.Open(suite.ctx, &req, &resp)
+	suite.NoError(err)
+	suite.Zero(resp.Flags)
+	suite.Equal(f, handle)
+
+	var attr fuse.Attr
+	err = f.Attr(suite.ctx, &attr)
+	suite.NoError(err)
+	suite.Equal(uint64(1), attr.Size)
+}
+
+func (suite *fileTestSuite) TestOpen_ReadNoSize() {
+	m := plugintest.NewMockRead()
+
+	f := newFile(nil, m)
+	req := fuse.OpenRequest{Flags: fuse.OpenReadOnly}
+	var resp fuse.OpenResponse
+	handle, err := f.Open(suite.ctx, &req, &resp)
+	suite.NoError(err)
+	suite.Equal(fuse.OpenDirectIO, resp.Flags)
+	suite.Equal(f, handle)
+
+	var attr fuse.Attr
+	err = f.Attr(suite.ctx, &attr)
+	suite.NoError(err)
+	suite.Equal(uint64(0), attr.Size)
+}
+
+func (suite *fileTestSuite) TestOpen_WriteNoSize() {
+	m := plugintest.NewMockWrite()
+
+	f := newFile(nil, m)
+	req := fuse.OpenRequest{Flags: fuse.OpenWriteOnly}
+	var resp fuse.OpenResponse
+	handle, err := f.Open(suite.ctx, &req, &resp)
+	suite.NoError(err)
+	suite.Zero(resp.Flags)
+	suite.Equal(f, handle)
+
+	var attr fuse.Attr
+	err = f.Attr(suite.ctx, &attr)
+	suite.NoError(err)
+	suite.Zero(attr.Size)
+}
+
+func (suite *fileTestSuite) TestOpenAndRelease() {
+	m := plugintest.NewMockReadWrite()
+
+	f := newFile(nil, m)
+	req := fuse.OpenRequest{Flags: fuse.OpenReadWrite}
+	var resp fuse.OpenResponse
+	handle, err := f.Open(suite.ctx, &req, &resp)
+	suite.NoError(err)
+	suite.Empty(f.writers)
+	if suite.Implements((*fs.HandleReleaser)(nil), handle) {
+		relReq := fuse.ReleaseRequest{Flags: fuse.OpenReadWrite}
+		err = handle.(fs.HandleReleaser).Release(suite.ctx, &relReq)
+		suite.NoError(err)
+		suite.Empty(f.writers)
+	}
+}
+
+func (suite *fileTestSuite) TestOpenAndRelease_WriteOnly() {
+	m := plugintest.NewMockWrite()
+
+	f := newFile(nil, m)
+	req := fuse.OpenRequest{Flags: fuse.OpenWriteOnly}
+	var resp fuse.OpenResponse
+	handle, err := f.Open(suite.ctx, &req, &resp)
+	suite.NoError(err)
+	suite.Empty(f.writers)
+	if suite.Implements((*fs.HandleReleaser)(nil), handle) {
+		relReq := fuse.ReleaseRequest{Flags: fuse.OpenReadWrite}
+		err = handle.(fs.HandleReleaser).Release(suite.ctx, &relReq)
+		suite.NoError(err)
+		suite.Empty(f.writers)
+	}
+}
+
+func (suite *fileTestSuite) TestOpenAndFlush() {
+	m := plugintest.NewMockReadWrite()
+
+	f := newFile(nil, m)
+	req := fuse.OpenRequest{Flags: fuse.OpenReadWrite}
+	var resp fuse.OpenResponse
+	handle, err := f.Open(suite.ctx, &req, &resp)
+	suite.NoError(err)
+	suite.Empty(f.writers)
+	if suite.Implements((*fs.HandleFlusher)(nil), handle) {
+		err = handle.(fs.HandleFlusher).Flush(suite.ctx, &fuse.FlushRequest{})
+		suite.NoError(err)
+		suite.Empty(f.writers)
+		suite.Nil(f.data)
+	}
+}
+
+func (suite *fileTestSuite) TestOpenAndFlushRelease() {
+	m := plugintest.NewMockReadWrite()
+
+	f := newFile(nil, m)
+	req := fuse.OpenRequest{Flags: fuse.OpenReadWrite}
+	var resp fuse.OpenResponse
+	handle, err := f.Open(suite.ctx, &req, &resp)
+	suite.NoError(err)
+	suite.Empty(f.writers)
+	if suite.Implements((*fs.HandleReleaser)(nil), handle) {
+		relReq := fuse.ReleaseRequest{Flags: fuse.OpenReadWrite, ReleaseFlags: fuse.ReleaseFlush}
+		err = handle.(fs.HandleReleaser).Release(suite.ctx, &relReq)
+		suite.NoError(err)
+		suite.Empty(f.writers)
+		suite.Nil(f.data)
+	}
+}
+
+func (suite *fileTestSuite) TestAttrWithReaders() {
+	m := plugintest.NewMockRead()
+	m.Attributes().SetSize(1)
+
+	f := newFile(nil, m)
+	req := fuse.OpenRequest{Flags: fuse.OpenReadOnly}
+	var resp fuse.OpenResponse
+	_, err := f.Open(suite.ctx, &req, &resp)
+	suite.NoError(err)
+	suite.Empty(f.writers)
+
+	var attr fuse.Attr
+	err = f.Attr(suite.ctx, &attr)
+	suite.NoError(err)
+	suite.Equal(uint64(1), attr.Size)
+}
+
+func (suite *fileTestSuite) TestAttrWithWriters() {
+	m := plugintest.NewMockWrite()
+	m.Attributes().SetSize(5)
+
+	f := newFile(nil, m)
+	req := fuse.OpenRequest{Flags: fuse.OpenWriteOnly}
+	var resp fuse.OpenResponse
+	_, err := f.Open(suite.ctx, &req, &resp)
+	suite.NoError(err)
+	suite.Empty(f.writers)
+
+	var attr fuse.Attr
+	err = f.Attr(suite.ctx, &attr)
+	suite.NoError(err)
+	suite.Equal(uint64(5), attr.Size)
+}
+
+func (suite *fileTestSuite) assertFileHandle(handle fs.Handle) bool {
+	return suite.Implements((*fs.HandleReader)(nil), handle) &&
+		suite.Implements((*fs.HandleWriter)(nil), handle) &&
+		suite.Implements((*fs.HandleFlusher)(nil), handle) &&
+		suite.Implements((*fs.HandleReleaser)(nil), handle)
+}
+
+func (suite *fileTestSuite) TestRead() {
+	m := plugintest.NewMockRead()
+	m.On("Read", suite.ctx).Return([]byte("hello"), nil).Once()
+
+	f := newFile(nil, m)
+	var resp fuse.OpenResponse
+	handle, err := f.Open(suite.ctx, &fuse.OpenRequest{Flags: fuse.OpenReadOnly}, &resp)
+	if !suite.NoError(err) || !suite.assertFileHandle(handle) {
+		suite.FailNow("Unusable handle")
+	}
+
+	readReq := fuse.ReadRequest{Offset: 2, Size: 2, Handle: 1}
+	var readResp fuse.ReadResponse
+	err = handle.(fs.HandleReader).Read(suite.ctx, &readReq, &readResp)
+	suite.NoError(err)
+	suite.Equal([]byte("ll"), readResp.Data)
+
+	err = handle.(fs.HandleFlusher).Flush(suite.ctx, &fuse.FlushRequest{Handle: 1})
+	suite.NoError(err)
+
+	relReq := fuse.ReleaseRequest{ReleaseFlags: fuse.ReleaseFlush, Handle: 1}
+	err = handle.(fs.HandleReleaser).Release(suite.ctx, &relReq)
+	suite.NoError(err)
+
+	m.AssertExpectations(suite.T())
+}
+
+func (suite *fileTestSuite) TestWrite() {
+	m := plugintest.NewMockWrite()
+	m.On("Write", suite.ctx, []byte("hello")).Return(nil).Once()
+
+	f := newFile(nil, m)
+	var resp fuse.OpenResponse
+	handle, err := f.Open(suite.ctx, &fuse.OpenRequest{Flags: fuse.OpenWriteOnly}, &resp)
+	if !suite.NoError(err) || !suite.assertFileHandle(handle) {
+		suite.FailNow("Unusable handle")
+	}
+
+	writeReq := fuse.WriteRequest{Offset: 0, Data: []byte("hello"), Handle: 1}
+	var writeResp fuse.WriteResponse
+	err = handle.(fs.HandleWriter).Write(suite.ctx, &writeReq, &writeResp)
+	suite.NoError(err)
+	suite.Equal(5, writeResp.Size)
+
+	err = handle.(fs.HandleFlusher).Flush(suite.ctx, &fuse.FlushRequest{Handle: 1})
+	suite.NoError(err)
+
+	relReq := fuse.ReleaseRequest{ReleaseFlags: fuse.ReleaseFlush, Handle: 1}
+	err = handle.(fs.HandleReleaser).Release(suite.ctx, &relReq)
+	suite.NoError(err)
+
+	m.AssertExpectations(suite.T())
+}
+
+func (suite *fileTestSuite) TestTruncateAndWrite() {
+	m := plugintest.NewMockReadWrite()
+	m.On("Write", suite.ctx, []byte("hello")).Return(nil).Once()
+
+	f := newFile(nil, m)
+	var resp fuse.OpenResponse
+	handle, err := f.Open(suite.ctx, &fuse.OpenRequest{Flags: fuse.OpenWriteOnly}, &resp)
+	if !suite.NoError(err) || !suite.assertFileHandle(handle) {
+		suite.FailNow("Unusable handle")
+	}
+
+	setReq := fuse.SetattrRequest{Valid: fuse.SetattrHandle | fuse.SetattrSize, Handle: 1, Size: 0}
+	var setResp fuse.SetattrResponse
+	err = f.Setattr(suite.ctx, &setReq, &setResp)
+	suite.NoError(err)
+
+	writeReq := fuse.WriteRequest{Offset: 0, Data: []byte("hello"), Handle: 1}
+	var writeResp fuse.WriteResponse
+	err = handle.(fs.HandleWriter).Write(suite.ctx, &writeReq, &writeResp)
+	suite.NoError(err)
+	suite.Equal(5, writeResp.Size)
+
+	err = handle.(fs.HandleFlusher).Flush(suite.ctx, &fuse.FlushRequest{Handle: 1})
+	suite.NoError(err)
+
+	err = handle.(fs.HandleReleaser).Release(suite.ctx, &fuse.ReleaseRequest{Handle: 1})
+	suite.NoError(err)
+
+	m.AssertExpectations(suite.T())
+}
+
+func (suite *fileTestSuite) TestReadWrite_Smaller() {
+	m := plugintest.NewMockBlockReadWrite()
+	m.Attributes().SetSize(5)
+	m.On("Read", suite.ctx, int64(2), int64(0)).Return([]byte("he"), nil).Once()
+	m.On("Write", suite.ctx, []byte("hell")).Return(nil).Once()
+
+	f := newFile(nil, m)
+	var resp fuse.OpenResponse
+	handle, err := f.Open(suite.ctx, &fuse.OpenRequest{Flags: fuse.OpenReadWrite}, &resp)
+	if !suite.NoError(err) || !suite.assertFileHandle(handle) {
+		suite.FailNow("Unusable handle")
+	}
+
+	// Shrink the file
+	setReq := fuse.SetattrRequest{Valid: fuse.SetattrHandle | fuse.SetattrSize, Handle: 1, Size: 4}
+	var setResp fuse.SetattrResponse
+	err = f.Setattr(suite.ctx, &setReq, &setResp)
+	suite.NoError(err)
+
+	writeReq := fuse.WriteRequest{Offset: 2, Data: []byte("ll"), Handle: 1}
+	var writeResp fuse.WriteResponse
+	err = handle.(fs.HandleWriter).Write(suite.ctx, &writeReq, &writeResp)
+	suite.NoError(err)
+	suite.Equal(2, writeResp.Size)
+
+	// Test this for correct size mid-write. After flush, the reported size will be
+	// whatever future calls to List return.
+	var attr fuse.Attr
+	err = f.Attr(suite.ctx, &attr)
+	suite.NoError(err)
+	suite.Equal(uint64(4), attr.Size)
+
+	err = handle.(fs.HandleFlusher).Flush(suite.ctx, &fuse.FlushRequest{Handle: 1})
+	suite.NoError(err)
+
+	err = handle.(fs.HandleReleaser).Release(suite.ctx, &fuse.ReleaseRequest{Handle: 1})
+	suite.NoError(err)
+
+	m.AssertExpectations(suite.T())
+}
+
+func (suite *fileTestSuite) TestReadWrite_Larger() {
+	m := plugintest.NewMockBlockReadWrite()
+	m.Attributes().SetSize(5)
+	m.On("Read", suite.ctx, int64(2), int64(0)).Return([]byte("he"), nil).Once()
+	m.On("Write", suite.ctx, []byte("hello there")).Return(nil).Once()
+
+	f := newFile(nil, m)
+	var resp fuse.OpenResponse
+	handle, err := f.Open(suite.ctx, &fuse.OpenRequest{Flags: fuse.OpenReadWrite}, &resp)
+	if !suite.NoError(err) || !suite.assertFileHandle(handle) {
+		suite.FailNow("Unusable handle")
+	}
+
+	writeReq := fuse.WriteRequest{Offset: 2, Data: []byte("llo there"), Handle: 1}
+	var writeResp fuse.WriteResponse
+	err = handle.(fs.HandleWriter).Write(suite.ctx, &writeReq, &writeResp)
+	suite.NoError(err)
+	suite.Equal(9, writeResp.Size)
+
+	// Test this for correct size mid-write. After flush, the reported size will be
+	// whatever future calls to List return.
+	var attr fuse.Attr
+	err = f.Attr(suite.ctx, &attr)
+	suite.NoError(err)
+	suite.Equal(uint64(11), attr.Size)
+
+	err = handle.(fs.HandleFlusher).Flush(suite.ctx, &fuse.FlushRequest{Handle: 1})
+	suite.NoError(err)
+
+	err = handle.(fs.HandleReleaser).Release(suite.ctx, &fuse.ReleaseRequest{Handle: 1})
+	suite.NoError(err)
+
+	m.AssertExpectations(suite.T())
+}
+
+func TestFile(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	suite.Run(t, &fileTestSuite{ctx: ctx})
+	cancel()
+}

--- a/fuse/file_test.go
+++ b/fuse/file_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/puppetlabs/wash/datastore"
 	"github.com/puppetlabs/wash/plugin"
 	plugintest "github.com/puppetlabs/wash/plugin/test"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -25,7 +26,7 @@ func (suite *fileTestSuite) TearDownTest() {
 	plugin.UnsetTestCache()
 }
 
-func (suite *fileTestSuite) TestOpen() {
+func (suite *fileTestSuite) TestOpen_File() {
 	var req fuse.OpenRequest
 	var resp fuse.OpenResponse
 
@@ -59,46 +60,41 @@ func (suite *fileTestSuite) TestOpen() {
 	}
 }
 
-func (suite *fileTestSuite) TestOpen_SizeFromRead() {
+func (suite *fileTestSuite) TestOpen_NonFile() {
+	var req fuse.OpenRequest
+	var resp fuse.OpenResponse
+
+	mr := plugintest.NewMockRead()
+	mr.On("Read", suite.ctx).Return([]byte{'_'}, nil).Once()
+	mw := plugintest.NewMockWrite()
+	mrw := plugintest.NewMockReadWrite()
+	mrw.On("Read", suite.ctx).Return([]byte{'_'}, nil).Once()
+
+	// expectErrs corresponds to expectations on fields in flags.
+	flags := []fuse.OpenFlags{fuse.OpenReadOnly, fuse.OpenWriteOnly, fuse.OpenReadWrite}
+	for m, expectErrs := range map[plugin.Entry][]bool{
+		mr:  []bool{false, true, true},
+		mw:  []bool{true, false, true},
+		mrw: []bool{false, false, true},
+	} {
+		f := newFile(nil, m)
+
+		for i, flag := range flags {
+			req.Flags = flag
+			_, err := f.Open(suite.ctx, &req, &resp)
+			if expectErr := expectErrs[i]; expectErr {
+				suite.Error(err)
+			} else {
+				suite.NoError(err)
+			}
+		}
+	}
+
+	mock.AssertExpectationsForObjects(suite.T(), mr, mw, mrw)
+}
+
+func (suite *fileTestSuite) TestOpen_NonFileDirect() {
 	m := plugintest.NewMockReadWrite()
-	m.On("Read", suite.ctx).Return([]byte("hello"), nil).Once()
-
-	f := newFile(nil, m)
-	var req fuse.OpenRequest
-	var resp fuse.OpenResponse
-	handle, err := f.Open(suite.ctx, &req, &resp)
-	suite.NoError(err)
-	suite.Equal(fuse.OpenDirectIO, resp.Flags)
-	suite.Equal(f, handle)
-
-	var attr fuse.Attr
-	err = f.Attr(suite.ctx, &attr)
-	suite.NoError(err)
-	suite.Equal(uint64(5), attr.Size)
-
-	m.AssertExpectations(suite.T())
-}
-
-func (suite *fileTestSuite) TestOpen_WithSize() {
-	m := plugintest.NewMockRead()
-	m.Attributes().SetSize(1)
-
-	f := newFile(nil, m)
-	var req fuse.OpenRequest
-	var resp fuse.OpenResponse
-	handle, err := f.Open(suite.ctx, &req, &resp)
-	suite.NoError(err)
-	suite.Zero(resp.Flags)
-	suite.Equal(f, handle)
-
-	var attr fuse.Attr
-	err = f.Attr(suite.ctx, &attr)
-	suite.NoError(err)
-	suite.Equal(uint64(1), attr.Size)
-}
-
-func (suite *fileTestSuite) TestOpen_ReadNoSize() {
-	m := plugintest.NewMockRead()
 	m.On("Read", suite.ctx).Return([]byte("hello"), nil).Once()
 
 	f := newFile(nil, m)
@@ -109,6 +105,12 @@ func (suite *fileTestSuite) TestOpen_ReadNoSize() {
 	suite.Equal(fuse.OpenDirectIO, resp.Flags)
 	suite.Equal(f, handle)
 
+	req.Flags = fuse.OpenWriteOnly
+	handle, err = f.Open(suite.ctx, &req, &resp)
+	suite.NoError(err)
+	suite.Equal(fuse.OpenDirectIO, resp.Flags)
+	suite.Equal(f, handle)
+
 	var attr fuse.Attr
 	err = f.Attr(suite.ctx, &attr)
 	suite.NoError(err)
@@ -117,13 +119,26 @@ func (suite *fileTestSuite) TestOpen_ReadNoSize() {
 	m.AssertExpectations(suite.T())
 }
 
-func (suite *fileTestSuite) TestOpen_WriteNoSize() {
-	m := plugintest.NewMockWrite()
+func (suite *fileTestSuite) TestOpen_FileBuffered() {
+	m := plugintest.NewMockReadWrite()
+	m.Attributes().SetSize(1)
 
 	f := newFile(nil, m)
-	req := fuse.OpenRequest{Flags: fuse.OpenWriteOnly}
+	req := fuse.OpenRequest{Flags: fuse.OpenReadOnly}
 	var resp fuse.OpenResponse
 	handle, err := f.Open(suite.ctx, &req, &resp)
+	suite.NoError(err)
+	suite.Zero(resp.Flags)
+	suite.Equal(f, handle)
+
+	req.Flags = fuse.OpenWriteOnly
+	handle, err = f.Open(suite.ctx, &req, &resp)
+	suite.NoError(err)
+	suite.Zero(resp.Flags)
+	suite.Equal(f, handle)
+
+	req.Flags = fuse.OpenReadWrite
+	handle, err = f.Open(suite.ctx, &req, &resp)
 	suite.NoError(err)
 	suite.Zero(resp.Flags)
 	suite.Equal(f, handle)
@@ -131,12 +146,12 @@ func (suite *fileTestSuite) TestOpen_WriteNoSize() {
 	var attr fuse.Attr
 	err = f.Attr(suite.ctx, &attr)
 	suite.NoError(err)
-	suite.Zero(attr.Size)
+	suite.Equal(uint64(1), attr.Size)
 }
 
 func (suite *fileTestSuite) TestOpenAndRelease() {
 	m := plugintest.NewMockReadWrite()
-	m.On("Read", suite.ctx).Return([]byte("hello"), nil).Once()
+	m.Attributes().SetSize(5)
 
 	f := newFile(nil, m)
 	req := fuse.OpenRequest{Flags: fuse.OpenReadWrite}
@@ -242,6 +257,17 @@ func (suite *fileTestSuite) TestAttrWithWriters() {
 	suite.Equal(uint64(5), attr.Size)
 }
 
+func (suite *fileTestSuite) TestSetAttr_NoHandle() {
+	m := plugintest.NewMockReadWrite()
+	m.Attributes().SetSize(0)
+
+	f := newFile(nil, m)
+	req := fuse.SetattrRequest{Valid: fuse.SetattrSize, Size: 1}
+	var resp fuse.SetattrResponse
+	err := f.Setattr(suite.ctx, &req, &resp)
+	suite.Error(err)
+}
+
 func (suite *fileTestSuite) assertFileHandle(handle fs.Handle) bool {
 	return suite.Implements((*fs.HandleReader)(nil), handle) &&
 		suite.Implements((*fs.HandleWriter)(nil), handle) &&
@@ -249,7 +275,7 @@ func (suite *fileTestSuite) assertFileHandle(handle fs.Handle) bool {
 		suite.Implements((*fs.HandleReleaser)(nil), handle)
 }
 
-func (suite *fileTestSuite) TestRead() {
+func (suite *fileTestSuite) TestRead_NonFile() {
 	m := plugintest.NewMockRead()
 	m.On("Read", suite.ctx).Return([]byte("hello"), nil).Once()
 
@@ -276,9 +302,66 @@ func (suite *fileTestSuite) TestRead() {
 	m.AssertExpectations(suite.T())
 }
 
-func (suite *fileTestSuite) TestWrite() {
+func (suite *fileTestSuite) TestRead_File() {
+	m := plugintest.NewMockRead()
+	m.Attributes().SetSize(5)
+	m.On("Read", suite.ctx).Return([]byte("hello"), nil).Once()
+
+	f := newFile(nil, m)
+	var resp fuse.OpenResponse
+	handle, err := f.Open(suite.ctx, &fuse.OpenRequest{Flags: fuse.OpenReadOnly}, &resp)
+	if !suite.NoError(err) || !suite.assertFileHandle(handle) {
+		suite.FailNow("Unusable handle")
+	}
+
+	readReq := fuse.ReadRequest{Offset: 2, Size: 2, Handle: 1}
+	var readResp fuse.ReadResponse
+	err = handle.(fs.HandleReader).Read(suite.ctx, &readReq, &readResp)
+	suite.NoError(err)
+	suite.Equal([]byte("ll"), readResp.Data)
+
+	err = handle.(fs.HandleFlusher).Flush(suite.ctx, &fuse.FlushRequest{Handle: 1})
+	suite.NoError(err)
+
+	relReq := fuse.ReleaseRequest{ReleaseFlags: fuse.ReleaseFlush, Handle: 1}
+	err = handle.(fs.HandleReleaser).Release(suite.ctx, &relReq)
+	suite.NoError(err)
+
+	m.AssertExpectations(suite.T())
+}
+
+func (suite *fileTestSuite) TestWrite_NonFile() {
 	m := plugintest.NewMockWrite()
-	// Called for Flush and ReleaseFlush.
+	// Called on first Flush only.
+	m.On("Write", suite.ctx, []byte("hello")).Return(nil).Once()
+
+	f := newFile(nil, m)
+	var resp fuse.OpenResponse
+	handle, err := f.Open(suite.ctx, &fuse.OpenRequest{Flags: fuse.OpenWriteOnly}, &resp)
+	if !suite.NoError(err) || !suite.assertFileHandle(handle) {
+		suite.FailNow("Unusable handle")
+	}
+
+	writeReq := fuse.WriteRequest{Offset: 0, Data: []byte("hello"), Handle: 1}
+	var writeResp fuse.WriteResponse
+	err = handle.(fs.HandleWriter).Write(suite.ctx, &writeReq, &writeResp)
+	suite.NoError(err)
+	suite.Equal(5, writeResp.Size)
+
+	err = handle.(fs.HandleFlusher).Flush(suite.ctx, &fuse.FlushRequest{Handle: 1})
+	suite.NoError(err)
+
+	relReq := fuse.ReleaseRequest{ReleaseFlags: fuse.ReleaseFlush, Handle: 1}
+	err = handle.(fs.HandleReleaser).Release(suite.ctx, &relReq)
+	suite.NoError(err)
+
+	m.AssertExpectations(suite.T())
+}
+
+func (suite *fileTestSuite) TestWrite_File() {
+	m := plugintest.NewMockWrite()
+	m.Attributes().SetSize(5)
+	// Called on both Flush and Release+Flush only.
 	m.On("Write", suite.ctx, []byte("hello")).Return(nil).Twice()
 
 	f := newFile(nil, m)
@@ -304,7 +387,7 @@ func (suite *fileTestSuite) TestWrite() {
 	m.AssertExpectations(suite.T())
 }
 
-func (suite *fileTestSuite) TestTruncateAndWrite() {
+func (suite *fileTestSuite) TestTruncateAndWrite_File() {
 	m := plugintest.NewMockReadWrite()
 	m.Attributes().SetSize(4)
 	m.On("Write", suite.ctx, []byte("hello")).Return(nil).Once()
@@ -336,7 +419,7 @@ func (suite *fileTestSuite) TestTruncateAndWrite() {
 	m.AssertExpectations(suite.T())
 }
 
-func (suite *fileTestSuite) TestGrowAndWrite() {
+func (suite *fileTestSuite) TestGrowAndWrite_File() {
 	m := plugintest.NewMockReadWrite()
 	m.Attributes().SetSize(4)
 	m.On("Write", suite.ctx, append([]byte("hello"), make([]byte, 5)...)).Return(nil).Once()
@@ -368,8 +451,31 @@ func (suite *fileTestSuite) TestGrowAndWrite() {
 	m.AssertExpectations(suite.T())
 }
 
-func (suite *fileTestSuite) TestPartialWrite() {
+func (suite *fileTestSuite) TestPartialWrite_NonFile() {
 	m := plugintest.NewMockWrite()
+	m.On("Write", suite.ctx, []byte{0, 0, '1', '1'}).Return(nil).Once()
+
+	f := newFile(nil, m)
+	var resp fuse.OpenResponse
+	handle, err := f.Open(suite.ctx, &fuse.OpenRequest{Flags: fuse.OpenWriteOnly}, &resp)
+	if !suite.NoError(err) || !suite.assertFileHandle(handle) {
+		suite.FailNow("Unusable handle")
+	}
+
+	writeReq := fuse.WriteRequest{Offset: 2, Data: []byte("11"), Handle: 1}
+	var writeResp fuse.WriteResponse
+	err = handle.(fs.HandleWriter).Write(suite.ctx, &writeReq, &writeResp)
+	suite.NoError(err)
+
+	err = handle.(fs.HandleFlusher).Flush(suite.ctx, &fuse.FlushRequest{Handle: 1})
+	suite.NoError(err)
+
+	m.AssertExpectations(suite.T())
+}
+
+func (suite *fileTestSuite) TestPartialWrite_File() {
+	m := plugintest.NewMockWrite()
+	m.Attributes().SetSize(3)
 
 	f := newFile(nil, m)
 	var resp fuse.OpenResponse
@@ -384,7 +490,7 @@ func (suite *fileTestSuite) TestPartialWrite() {
 	suite.Error(err)
 }
 
-func (suite *fileTestSuite) TestReadWrite_Smaller() {
+func (suite *fileTestSuite) TestReadWrite_FileSmaller() {
 	m := plugintest.NewMockBlockReadWrite()
 	m.Attributes().SetSize(5)
 	m.On("Read", suite.ctx, int64(2), int64(0)).Return([]byte("he"), nil).Once()
@@ -422,8 +528,9 @@ func (suite *fileTestSuite) TestReadWrite_Smaller() {
 	m.AssertExpectations(suite.T())
 }
 
-func (suite *fileTestSuite) TestReadWrite_PartialWriteOnly() {
+func (suite *fileTestSuite) TestReadWrite_FilePartialWriteOnly() {
 	m := plugintest.NewMockReadWrite()
+	m.Attributes().SetSize(5)
 	m.On("Read", suite.ctx).Return([]byte("hello"), nil).Once()
 	m.On("Write", suite.ctx, []byte("he11o")).Return(nil).Once()
 
@@ -456,7 +563,7 @@ func (suite *fileTestSuite) TestReadWrite_PartialWriteOnly() {
 	m.AssertExpectations(suite.T())
 }
 
-func (suite *fileTestSuite) TestReadWrite_Larger() {
+func (suite *fileTestSuite) TestReadWrite_FileLarger() {
 	m := plugintest.NewMockBlockReadWrite()
 	m.Attributes().SetSize(5)
 	m.On("Read", suite.ctx, int64(2), int64(0)).Return([]byte("he"), nil).Once()
@@ -487,6 +594,54 @@ func (suite *fileTestSuite) TestReadWrite_Larger() {
 
 	err = handle.(fs.HandleReleaser).Release(suite.ctx, &fuse.ReleaseRequest{Handle: 1})
 	suite.NoError(err)
+
+	m.AssertExpectations(suite.T())
+}
+
+func (suite *fileTestSuite) TestWriteRead_NonFile() {
+	m := plugintest.NewMockReadWrite()
+	m.On("Write", suite.ctx, []byte("hello there")).Return(nil).Once()
+	m.On("Read", suite.ctx).Return([]byte("not what I expected"), nil).Once()
+
+	f := newFile(nil, m)
+	var resp fuse.OpenResponse
+	handle, err := f.Open(suite.ctx, &fuse.OpenRequest{Flags: fuse.OpenWriteOnly}, &resp)
+	if !suite.NoError(err) || !suite.assertFileHandle(handle) {
+		suite.FailNow("Unusable handle")
+	}
+
+	writeReq := fuse.WriteRequest{Offset: 0, Data: []byte("hello there"), Handle: 1}
+	var writeResp fuse.WriteResponse
+	err = handle.(fs.HandleWriter).Write(suite.ctx, &writeReq, &writeResp)
+	suite.NoError(err)
+	suite.Equal(11, writeResp.Size)
+
+	// Test that we get empty size mid-write
+	var attr fuse.Attr
+	err = f.Attr(suite.ctx, &attr)
+	suite.NoError(err)
+	suite.Equal(uint64(0), attr.Size)
+
+	err = handle.(fs.HandleFlusher).Flush(suite.ctx, &fuse.FlushRequest{Handle: 1})
+	suite.NoError(err)
+
+	err = handle.(fs.HandleReleaser).Release(suite.ctx, &fuse.ReleaseRequest{Handle: 1})
+	suite.NoError(err)
+
+	handle, err = f.Open(suite.ctx, &fuse.OpenRequest{Flags: fuse.OpenReadOnly}, &resp)
+	if !suite.NoError(err) || !suite.assertFileHandle(handle) {
+		suite.FailNow("Unusable handle")
+	}
+
+	err = f.Attr(suite.ctx, &attr)
+	suite.NoError(err)
+	suite.Equal(uint64(19), attr.Size)
+
+	readReq := fuse.ReadRequest{Offset: 0, Size: 19, Handle: 1}
+	var readResp fuse.ReadResponse
+	err = handle.(fs.HandleReader).Read(suite.ctx, &readReq, &readResp)
+	suite.NoError(err)
+	suite.Equal([]byte("not what I expected"), readResp.Data)
 
 	m.AssertExpectations(suite.T())
 }

--- a/go.mod
+++ b/go.mod
@@ -86,7 +86,7 @@ require (
 	go.opencensus.io v0.22.1 // indirect
 	golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
-	golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a
+	golang.org/x/sys v0.0.0-20191210023423-ac6580df4449
 	google.golang.org/api v0.13.0
 	google.golang.org/genproto v0.0.0-20191108220845-16a3f7862a1a
 	gopkg.in/go-ini/ini.v1 v1.42.0

--- a/go.sum
+++ b/go.sum
@@ -345,6 +345,8 @@ golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a h1:aYOabOQFp6Vj6W1F80affTUvO9UxmJRx8K0gsfABByQ=
 golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191210023423-ac6580df4449 h1:gSbV7h1NRL2G1xTg/owz62CST1oJBmxy4QpMMregXVQ=
+golang.org/x/sys v0.0.0-20191210023423-ac6580df4449/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=

--- a/plugin/analyticsWrappers.go
+++ b/plugin/analyticsWrappers.go
@@ -30,9 +30,9 @@ func StreamWithAnalytics(ctx context.Context, s Streamable) (io.ReadCloser, erro
 
 // WriteWithAnalytics is a wrapper to w#Write. Use it when you need to report an 'Write'
 // invocation to analytics. Otherwise, use w#Write.
-func WriteWithAnalytics(ctx context.Context, w Writable, off int64, b []byte) (int, error) {
+func WriteWithAnalytics(ctx context.Context, w Writable, b []byte) error {
 	submitMethodInvocation(ctx, w, "Write")
-	return Write(ctx, w, off, b)
+	return Write(ctx, w, b)
 }
 
 // ExecWithAnalytics is a wrapper to e#Exec. Use it when you need to report an 'Exec'

--- a/plugin/aws/ec2InstanceConsoleOutput.go
+++ b/plugin/aws/ec2InstanceConsoleOutput.go
@@ -35,8 +35,7 @@ func newEC2InstanceConsoleOutput(ctx context.Context, inst *ec2Instance, latest 
 		SetCrtime(output.mtime).
 		SetMtime(output.mtime).
 		SetCtime(output.mtime).
-		SetAtime(output.mtime).
-		SetSize(uint64(len(output.content)))
+		SetAtime(output.mtime)
 
 	return cl, nil
 }

--- a/plugin/entryBase.go
+++ b/plugin/entryBase.go
@@ -122,6 +122,11 @@ func (e *EntryBase) Name() string {
 	return e.name()
 }
 
+// String returns a unique identifier for the entry suitable for logging and error messages.
+func (e *EntryBase) String() string {
+	return e.id()
+}
+
 // Attributes returns a pointer to the entry's attributes. Use it
 // to individually set the entry's attributes
 func (e *EntryBase) Attributes() *EntryAttributes {

--- a/plugin/externalPluginEntry.go
+++ b/plugin/externalPluginEntry.go
@@ -310,14 +310,14 @@ func (e *externalPluginEntry) schema() (*EntrySchema, error) {
 			)
 			return nil, err
 		}
-		graph, err = unmarshalSchemaGraph(e, inv.stdout.Bytes())
+		graph, err = unmarshalSchemaGraph(e, inv.Stdout().Bytes())
 		if err != nil {
 			err := fmt.Errorf(
 				"%v (%v): could not decode schema from stdout: %v\nreceived:\n%v\nexpected something like:\n%v",
 				ID(e),
 				rawTypeID(e),
 				err,
-				strings.TrimSpace(inv.stdout.String()),
+				strings.TrimSpace(inv.Stdout().String()),
 				schemaFormat,
 			)
 			return nil, err
@@ -349,7 +349,7 @@ func (e *externalPluginEntry) List(ctx context.Context) ([]Entry, error) {
 		if err != nil {
 			return nil, err
 		}
-		if err := json.Unmarshal(inv.stdout.Bytes(), &decodedEntries); err != nil {
+		if err := json.Unmarshal(inv.Stdout().Bytes(), &decodedEntries); err != nil {
 			return nil, newStdoutDecodeErr(ctx, "the entries", err, inv, listFormat)
 		}
 	}
@@ -380,7 +380,7 @@ func (e *externalPluginEntry) Read(ctx context.Context) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	return inv.stdout.Bytes(), nil
+	return inv.Stdout().Bytes(), nil
 }
 
 func (e *externalPluginEntry) blockRead(ctx context.Context, size int64, offset int64) ([]byte, error) {
@@ -388,31 +388,13 @@ func (e *externalPluginEntry) blockRead(ctx context.Context, size int64, offset 
 	if err != nil {
 		return nil, err
 	}
-	return inv.stdout.Bytes(), nil
+	return inv.Stdout().Bytes(), nil
 }
 
 func (e *externalPluginEntry) Write(ctx context.Context, p []byte) error {
-	// Start the command.
 	inv := e.script.NewInvocation(ctx, "write", e)
-	inv.command.SetStdout(&inv.stdout)
-	inv.command.SetStderr(&inv.stderr)
-	inv.command.SetStdin(bytes.NewReader(p))
-
-	activity.Record(ctx, "Invoking %v", inv.command)
-	err := inv.command.Run()
-	exitCode := inv.command.ExitCode()
-	if exitCode < 0 {
-		return newInvokeError(err.Error(), inv)
-	}
-
-	activity.Record(ctx, "stdout: %v", inv.stdout.String())
-	if inv.stderr.Len() != 0 {
-		activity.Record(ctx, "stderr: %v", inv.stderr.String())
-	}
-	if exitCode != 0 {
-		return newInvokeError(fmt.Sprintf("script returned a non-zero exit code of %v", exitCode), inv)
-	}
-	return nil
+	inv.SetStdin(bytes.NewReader(p))
+	return inv.RunAndWait(ctx)
 }
 
 func (e *externalPluginEntry) Metadata(ctx context.Context) (JSONObject, error) {
@@ -426,7 +408,7 @@ func (e *externalPluginEntry) Metadata(ctx context.Context) (JSONObject, error) 
 		return nil, err
 	}
 	var metadata JSONObject
-	if err := json.Unmarshal(inv.stdout.Bytes(), &metadata); err != nil {
+	if err := json.Unmarshal(inv.Stdout().Bytes(), &metadata); err != nil {
 		return nil, newStdoutDecodeErr(
 			ctx,
 			"the metadata",
@@ -448,7 +430,7 @@ func (e *externalPluginEntry) Delete(ctx context.Context) (deleted bool, err err
 	if err != nil {
 		return
 	}
-	if err = json.Unmarshal(inv.stdout.Bytes(), &deleted); err != nil {
+	if err = json.Unmarshal(inv.Stdout().Bytes(), &deleted); err != nil {
 		err = newStdoutDecodeErr(
 			ctx,
 			"delete's result",
@@ -463,17 +445,16 @@ func (e *externalPluginEntry) Delete(ctx context.Context) (deleted bool, err err
 
 func (e *externalPluginEntry) Stream(ctx context.Context) (io.ReadCloser, error) {
 	inv := e.script.NewInvocation(ctx, "stream", e)
-	cmd := inv.command
-	stdoutR, err := cmd.StdoutPipe()
+	stdoutR, err := inv.StdoutPipe()
 	if err != nil {
 		return nil, err
 	}
-	stderrR, err := cmd.StderrPipe()
+	stderrR, err := inv.StderrPipe()
 	if err != nil {
 		return nil, err
 	}
-	activity.Record(ctx, "Starting %v", cmd)
-	if err := cmd.Start(); err != nil {
+	activity.Record(ctx, "Starting %v", inv)
+	if err := inv.Start(); err != nil {
 		return nil, newInvokeError(err.Error(), inv)
 	}
 	// "wait" will be used in Stream's error handlers. It will be wrapped
@@ -481,8 +462,8 @@ func (e *externalPluginEntry) Stream(ctx context.Context) (io.ReadCloser, error)
 	// all of stdout/stderr. These are the preconditions specified in
 	// exec.Cmd#Wait's docs.
 	wait := func() {
-		if err := cmd.Wait(); err != nil {
-			activity.Record(ctx, "Failed waiting for %v to finish: %v", cmd, err)
+		if err := inv.Wait(); err != nil {
+			activity.Record(ctx, "Failed waiting for %v to finish: %v", inv, err)
 		}
 	}
 
@@ -509,12 +490,12 @@ func (e *externalPluginEntry) Stream(ctx context.Context) (io.ReadCloser, error)
 	select {
 	case err := <-headerRdrCh:
 		if err != nil {
-			cmd.Terminate()
+			inv.Terminate()
 			defer wait()
 			// Try to get more context from stderr
-			n, readErr := inv.stderr.ReadFrom(stderrR)
+			n, readErr := inv.Stderr().ReadFrom(stderrR)
 			if readErr == nil && n > 0 {
-				err = fmt.Errorf(inv.stderr.String())
+				err = fmt.Errorf(inv.Stderr().String())
 			}
 			return nil, newInvokeError(fmt.Sprintf("failed to read the header: %v", err), inv)
 		}
@@ -523,15 +504,15 @@ func (e *externalPluginEntry) Stream(ctx context.Context) (io.ReadCloser, error)
 		go func() {
 			_, _ = io.Copy(ioutil.Discard, stderrR)
 		}()
-		return &stdoutStreamer{cmd, stdoutR}, nil
+		return &stdoutStreamer{inv, stdoutR}, nil
 	case <-timer:
-		cmd.Terminate()
+		inv.Terminate()
 		defer wait()
 		// We timed out while waiting for the streaming header to appear.
 		// Return an appropriate error message using whatever was printed
 		// on stderr.
 		errMsgFmt := fmt.Sprintf("did not see the %v header after %v seconds:", header, timeout)
-		n, err := inv.stderr.ReadFrom(stderrR)
+		n, err := inv.Stderr().ReadFrom(stderrR)
 		if err != nil {
 			return nil, newInvokeError(fmt.Sprintf(
 				errMsgFmt+" %v",
@@ -565,19 +546,18 @@ func (e *externalPluginEntry) Exec(ctx context.Context, cmd string, args []strin
 
 	// Start the command.
 	inv := e.script.NewInvocation(ctx, "exec", e, append([]string{string(optsJSON), cmd}, args...)...)
-	cmdObj := inv.command
 	execCmd := NewExecCommand(ctx)
-	cmdObj.SetStdout(execCmd.Stdout())
-	cmdObj.SetStderr(execCmd.Stderr())
+	inv.SetStdout(execCmd.Stdout())
+	inv.SetStderr(execCmd.Stderr())
 	if opts.Stdin != nil {
-		cmdObj.SetStdin(opts.Stdin)
+		inv.SetStdin(opts.Stdin)
 	} else {
 		// Go's exec.Cmd reads from the null device if no stdin is provided. We instead provide
 		// an empty string for input so plugins can test whether there is content to read.
-		cmdObj.SetStdin(strings.NewReader(""))
+		inv.SetStdin(strings.NewReader(""))
 	}
-	activity.Record(ctx, "Starting %v", cmdObj)
-	if err := cmdObj.Start(); err != nil {
+	activity.Record(ctx, "Starting %v", inv)
+	if err := inv.Start(); err != nil {
 		return nil, err
 	}
 	// internal.Command handles context-cancellation cleanup
@@ -585,9 +565,9 @@ func (e *externalPluginEntry) Exec(ctx context.Context, cmd string, args []strin
 
 	// Asynchronously wait for the command to finish
 	go func() {
-		err := cmdObj.Wait()
+		err := inv.Wait()
 		execCmd.CloseStreamsWithError(nil)
-		exitCode := cmdObj.ExitCode()
+		exitCode := inv.ExitCode()
 		if exitCode < 0 {
 			execCmd.SetExitCodeErr(err)
 		} else {
@@ -616,7 +596,7 @@ func newStdoutDecodeErr(ctx context.Context, decodedThing string, reason error, 
 		ctx,
 		"could not decode %v from stdout\nreceived:\n%v\nexpected something like:\n%v",
 		decodedThing,
-		strings.TrimSpace(inv.stdout.String()),
+		strings.TrimSpace(inv.Stdout().String()),
 		example,
 	)
 	return newInvokeError(fmt.Sprintf("could not decode %v from stdout: %v", decodedThing, reason), inv)

--- a/plugin/externalPluginRoot.go
+++ b/plugin/externalPluginRoot.go
@@ -39,7 +39,7 @@ func (r *externalPluginRoot) Init(cfg map[string]interface{}) error {
 		}
 	}
 	var decodedRoot decodedExternalPluginEntry
-	if err := json.Unmarshal(inv.stdout.Bytes(), &decodedRoot); err != nil {
+	if err := json.Unmarshal(inv.Stdout().Bytes(), &decodedRoot); err != nil {
 		return newStdoutDecodeErr(
 			context.Background(),
 			"the plugin root",

--- a/plugin/externalPluginScript.go
+++ b/plugin/externalPluginScript.go
@@ -18,19 +18,59 @@ type externalPluginScript interface {
 	NewInvocation(ctx context.Context, method string, entry *externalPluginEntry, args ...string) invocation
 }
 
-type invocation struct {
-	command        internal.Command
+// An internal.Command object that stores output in separate stdout and stderr buffers.
+type invocation interface {
+	internal.Command
+	// RunAndWait should run the command, ensuring stdout and stderr are buffered, and return
+	// any errors or non-zero exit codes that result from running the command.
+	RunAndWait(context.Context) error
+	Stdout() *bytes.Buffer
+	Stderr() *bytes.Buffer
+}
+
+type invocationImpl struct {
+	internal.Command
 	stdout, stderr bytes.Buffer
+}
+
+func (inv *invocationImpl) RunAndWait(ctx context.Context) error {
+	inv.SetStdout(&inv.stdout)
+	inv.SetStderr(&inv.stderr)
+
+	activity.Record(ctx, "Invoking %v", inv)
+	err := inv.Run()
+	exitCode := inv.ExitCode()
+	if exitCode < 0 {
+		return newInvokeError(err.Error(), inv)
+	}
+
+	activity.Record(ctx, "stdout: %v", inv.stdout.String())
+	if inv.stderr.Len() != 0 {
+		activity.Record(ctx, "stderr: %v", inv.stderr.String())
+	}
+	if exitCode != 0 {
+		return newInvokeError(fmt.Sprintf("script returned a non-zero exit code of %v", exitCode), inv)
+	}
+	return nil
+}
+
+func (inv *invocationImpl) Stdout() *bytes.Buffer {
+	return &inv.stdout
+}
+
+func (inv *invocationImpl) Stderr() *bytes.Buffer {
+	return &inv.stderr
 }
 
 func newInvokeError(msg string, inv invocation) error {
 	var builder strings.Builder
 	builder.WriteString(msg)
-	fmt.Fprintf(&builder, "\nCOMMAND: %s", inv.command)
-	if inv.stdout.Len() > 0 {
-		fmt.Fprintf(&builder, "\nSTDOUT:\n%s", strings.Trim(inv.stdout.String(), "\n"))
+	fmt.Fprintf(&builder, "\nCOMMAND: %s", inv)
+	stdout := inv.Stdout()
+	if stdout.Len() > 0 {
+		fmt.Fprintf(&builder, "\nSTDOUT:\n%s", strings.Trim(stdout.String(), "\n"))
 	}
-	if output := strings.Trim(inv.stderr.String(), "\n"); len(output) > 0 {
+	if output := strings.Trim(inv.Stderr().String(), "\n"); len(output) > 0 {
 		fmt.Fprintf(&builder, "\nSTDERR:\n%s", output)
 	}
 	return errors.New(builder.String())
@@ -53,23 +93,8 @@ func (s externalPluginScriptImpl) InvokeAndWait(
 	args ...string,
 ) (invocation, error) {
 	inv := s.NewInvocation(ctx, method, entry, args...)
-	inv.command.SetStdout(&inv.stdout)
-	inv.command.SetStderr(&inv.stderr)
-	activity.Record(ctx, "Invoking %v", inv.command)
-	err := inv.command.Run()
-	exitCode := inv.command.ExitCode()
-	if exitCode < 0 {
-		return inv, newInvokeError(err.Error(), inv)
-	}
-
-	activity.Record(ctx, "stdout: %v", inv.stdout.String())
-	if inv.stderr.Len() != 0 {
-		activity.Record(ctx, "stderr: %v", inv.stderr.String())
-	}
-	if exitCode != 0 {
-		return inv, newInvokeError(fmt.Sprintf("script returned a non-zero exit code of %v", exitCode), inv)
-	}
-	return inv, nil
+	err := inv.RunAndWait(ctx)
+	return inv, err
 }
 
 func (s externalPluginScriptImpl) NewInvocation(
@@ -79,13 +104,13 @@ func (s externalPluginScriptImpl) NewInvocation(
 	args ...string,
 ) invocation {
 	if method == "init" {
-		return invocation{command: internal.NewCommand(ctx, s.Path(), append([]string{"init"}, args...)...)}
+		return &invocationImpl{Command: internal.NewCommand(ctx, s.Path(), append([]string{"init"}, args...)...)}
 	}
 	if entry == nil {
 		msg := fmt.Sprintf("s.NewInvocation called with method '%v' and entry == nil", method)
 		panic(msg)
 	}
-	return invocation{command: internal.NewCommand(
+	return &invocationImpl{Command: internal.NewCommand(
 		ctx,
 		s.Path(),
 		append([]string{method, entry.id(), entry.state}, args...)...,

--- a/plugin/externalPluginScript.go
+++ b/plugin/externalPluginScript.go
@@ -19,7 +19,7 @@ type externalPluginScript interface {
 }
 
 type invocation struct {
-	command        *internal.Command
+	command        internal.Command
 	stdout, stderr bytes.Buffer
 }
 
@@ -57,7 +57,7 @@ func (s externalPluginScriptImpl) InvokeAndWait(
 	inv.command.SetStderr(&inv.stderr)
 	activity.Record(ctx, "Invoking %v", inv.command)
 	err := inv.command.Run()
-	exitCode := inv.command.ProcessState().ExitCode()
+	exitCode := inv.command.ExitCode()
 	if exitCode < 0 {
 		return inv, newInvokeError(err.Error(), inv)
 	}

--- a/plugin/gcp/pubsubTopic.go
+++ b/plugin/gcp/pubsubTopic.go
@@ -141,14 +141,11 @@ func (t *pubsubTopic) Stream(ctx context.Context) (io.ReadCloser, error) {
 	return t.newPubsubTopicWatcher(ctx)
 }
 
-func (t *pubsubTopic) Write(ctx context.Context, _ int64, b []byte) (int, error) {
+func (t *pubsubTopic) Write(ctx context.Context, b []byte) error {
 	result := t.topic.Publish(ctx, &pubsub.Message{Data: b})
 	sid, err := result.Get(ctx)
 	activity.Record(ctx, "Message %v published with server ID %v: %v", string(b), sid, err)
-	if err != nil {
-		return 0, err
-	}
-	return len(b), nil
+	return err
 }
 
 func (t *pubsubTopic) Schema() *plugin.EntrySchema {

--- a/plugin/gcp/storageObject.go
+++ b/plugin/gcp/storageObject.go
@@ -45,6 +45,17 @@ func (s *storageObject) Read(ctx context.Context, size int64, offset int64) ([]b
 	return ioutil.ReadAll(rdr)
 }
 
+func (s *storageObject) Write(ctx context.Context, p []byte) error {
+	wr := s.ObjectHandle.NewWriter(ctx)
+	if _, err := wr.Write(p); err != nil {
+		wr.Close()
+		return err
+	}
+
+	// When Close fails we can assume the object update failed.
+	return wr.Close()
+}
+
 func (s *storageObject) Delete(ctx context.Context) (bool, error) {
 	err := s.ObjectHandle.Delete(ctx)
 	return true, err

--- a/plugin/metadataJSON.go
+++ b/plugin/metadataJSON.go
@@ -14,22 +14,10 @@ type MetadataJSONFile struct {
 // NewMetadataJSONFile creates a new MetadataJSONFile. If caching Metadata on the `other` entry is
 // disabled, it will use that to compute the file size upfront.
 func NewMetadataJSONFile(ctx context.Context, other Entry) (*MetadataJSONFile, error) {
-	meta := &MetadataJSONFile{
+	return &MetadataJSONFile{
 		EntryBase: NewEntry("metadata.json"),
 		other:     other,
-	}
-
-	if other.getTTLOf(MetadataOp) < 0 {
-		// Content is presumably easy to get, so use it to determine size.
-		content, err := meta.Read(ctx)
-		if err != nil {
-			return nil, err
-		}
-
-		meta.Attributes().SetSize(uint64(len(content)))
-	}
-
-	return meta, nil
+	}, nil
 }
 
 // Schema defines the schema of a metadata.json file.

--- a/plugin/methodWrappers.go
+++ b/plugin/methodWrappers.go
@@ -166,10 +166,14 @@ func Read(ctx context.Context, e Entry, size int64, offset int64) (data []byte, 
 	return
 }
 
-// Size returns the size of readable content (if we can determine it).
+// Size returns the size of readable data for an entry. It may call Read to do so.
 func Size(ctx context.Context, e Entry) (uint64, error) {
+	if attr := e.attributes(); attr.HasSize() {
+		return attr.Size(), nil
+	}
+
 	if !ReadAction().IsSupportedOn(e) {
-		panic("plugin.Read called on a non-readable entry")
+		return 0, nil
 	}
 
 	data, err := cachedRead(ctx, e)

--- a/plugin/methodWrappers.go
+++ b/plugin/methodWrappers.go
@@ -182,8 +182,8 @@ func Stream(ctx context.Context, s Streamable) (io.ReadCloser, error) {
 }
 
 // Write sends the supplied buffer to the entry.
-func Write(ctx context.Context, a Writable, offset int64, b []byte) (int, error) {
-	return a.Write(ctx, offset, b)
+func Write(ctx context.Context, a Writable, b []byte) error {
+	return a.Write(ctx, b)
 }
 
 // Signal signals the entry with the specified signal

--- a/plugin/methodWrappers.go
+++ b/plugin/methodWrappers.go
@@ -166,6 +166,19 @@ func Read(ctx context.Context, e Entry, size int64, offset int64) (data []byte, 
 	return
 }
 
+// Size returns the size of readable content (if we can determine it).
+func Size(ctx context.Context, e Entry) (uint64, error) {
+	if !ReadAction().IsSupportedOn(e) {
+		panic("plugin.Read called on a non-readable entry")
+	}
+
+	data, err := cachedRead(ctx, e)
+	if err != nil {
+		return 0, err
+	}
+	return data.size(), nil
+}
+
 // Metadata returns the entry's metadata. Note that Metadata's results could be cached.
 func Metadata(ctx context.Context, e Entry) (JSONObject, error) {
 	return cachedMetadata(ctx, e)

--- a/plugin/test/entryMocks.go
+++ b/plugin/test/entryMocks.go
@@ -34,8 +34,8 @@ type MockRead struct {
 
 // NewMockRead creates a new "mock" entry for reads.
 func NewMockRead() *MockRead {
-	m := &MockRead{MockBase{EntryBase: plugin.NewEntry("mock")}}
-	m.SetTestID("/mock")
+	m := &MockRead{MockBase{EntryBase: plugin.NewEntry("mockr")}}
+	m.SetTestID("/mockr")
 	return m
 }
 
@@ -53,8 +53,8 @@ type MockWrite struct {
 
 // NewMockWrite creates a new "mock" entry for writes.
 func NewMockWrite() *MockWrite {
-	m := &MockWrite{MockBase{EntryBase: plugin.NewEntry("mock")}}
-	m.SetTestID("/mock")
+	m := &MockWrite{MockBase{EntryBase: plugin.NewEntry("mockw")}}
+	m.SetTestID("/mockw")
 	return m
 }
 
@@ -72,8 +72,8 @@ type MockReadWrite struct {
 
 // NewMockReadWrite creates a new "mock" entry for reads and writes.
 func NewMockReadWrite() *MockReadWrite {
-	m := &MockReadWrite{MockBase{EntryBase: plugin.NewEntry("mock")}}
-	m.SetTestID("/mock")
+	m := &MockReadWrite{MockBase{EntryBase: plugin.NewEntry("mockrw")}}
+	m.SetTestID("/mockrw")
 	return m
 }
 
@@ -97,8 +97,8 @@ type MockBlockReadWrite struct {
 
 // NewMockBlockReadWrite creates a new "mock" entry for (block) reads and writes.
 func NewMockBlockReadWrite() *MockBlockReadWrite {
-	m := &MockBlockReadWrite{MockBase{EntryBase: plugin.NewEntry("mock")}}
-	m.SetTestID("/mock")
+	m := &MockBlockReadWrite{MockBase{EntryBase: plugin.NewEntry("mockbrw")}}
+	m.SetTestID("/mockbrw")
 	return m
 }
 

--- a/plugin/test/entryMocks.go
+++ b/plugin/test/entryMocks.go
@@ -1,0 +1,116 @@
+package plugintest
+
+import (
+	"context"
+
+	"github.com/puppetlabs/wash/plugin"
+	"github.com/stretchr/testify/mock"
+)
+
+// MockBase is a basic mock with no read/write operations.
+type MockBase struct {
+	plugin.EntryBase
+	mock.Mock
+}
+
+// NewMockBase creates a new "mock" entry without read/write.
+func NewMockBase() *MockBase {
+	m := &MockBase{EntryBase: plugin.NewEntry("mock")}
+	m.SetTestID("/mock")
+	return m
+}
+
+// Schema returns a simple schema.
+func (m *MockBase) Schema() *plugin.EntrySchema {
+	return plugin.NewEntrySchema(m, "mock")
+}
+
+var _ = plugin.Entry(&MockBase{})
+
+// MockRead only mocks Read operations.
+type MockRead struct {
+	MockBase
+}
+
+// NewMockRead creates a new "mock" entry for reads.
+func NewMockRead() *MockRead {
+	m := &MockRead{MockBase{EntryBase: plugin.NewEntry("mock")}}
+	m.SetTestID("/mock")
+	return m
+}
+
+func (m *MockRead) Read(ctx context.Context) ([]byte, error) {
+	args := m.Called(ctx)
+	return args.Get(0).([]byte), args.Error(1)
+}
+
+var _ = plugin.Readable(&MockRead{})
+
+// MockWrite only mocks Write operations.
+type MockWrite struct {
+	MockBase
+}
+
+// NewMockWrite creates a new "mock" entry for writes.
+func NewMockWrite() *MockWrite {
+	m := &MockWrite{MockBase{EntryBase: plugin.NewEntry("mock")}}
+	m.SetTestID("/mock")
+	return m
+}
+
+func (m *MockWrite) Write(ctx context.Context, p []byte) error {
+	args := m.Called(ctx, p)
+	return args.Error(0)
+}
+
+var _ = plugin.Writable(&MockWrite{})
+
+// MockReadWrite mocks read and write operations.
+type MockReadWrite struct {
+	MockBase
+}
+
+// NewMockReadWrite creates a new "mock" entry for reads and writes.
+func NewMockReadWrite() *MockReadWrite {
+	m := &MockReadWrite{MockBase{EntryBase: plugin.NewEntry("mock")}}
+	m.SetTestID("/mock")
+	return m
+}
+
+func (m *MockReadWrite) Read(ctx context.Context) ([]byte, error) {
+	args := m.Called(ctx)
+	return args.Get(0).([]byte), args.Error(1)
+}
+
+func (m *MockReadWrite) Write(ctx context.Context, p []byte) error {
+	args := m.Called(ctx, p)
+	return args.Error(0)
+}
+
+var _ = plugin.Readable(&MockReadWrite{})
+var _ = plugin.Writable(&MockReadWrite{})
+
+// MockBlockReadWrite mocks block read and write operations.
+type MockBlockReadWrite struct {
+	MockBase
+}
+
+// NewMockBlockReadWrite creates a new "mock" entry for (block) reads and writes.
+func NewMockBlockReadWrite() *MockBlockReadWrite {
+	m := &MockBlockReadWrite{MockBase{EntryBase: plugin.NewEntry("mock")}}
+	m.SetTestID("/mock")
+	return m
+}
+
+func (m *MockBlockReadWrite) Read(ctx context.Context, size, off int64) ([]byte, error) {
+	args := m.Called(ctx, size, off)
+	return args.Get(0).([]byte), args.Error(1)
+}
+
+func (m *MockBlockReadWrite) Write(ctx context.Context, p []byte) error {
+	args := m.Called(ctx, p)
+	return args.Error(0)
+}
+
+var _ = plugin.BlockReadable(&MockBlockReadWrite{})
+var _ = plugin.Writable(&MockBlockReadWrite{})

--- a/plugin/types.go
+++ b/plugin/types.go
@@ -23,7 +23,9 @@ a "file-like" entry to be one with a defined size (so the `size` attribute is se
 entry). Reading and writing a "file-like" entry edits the contents. Something that can be read and
 written but doesn't define size has different characteristics. Reading and writing are not
 symmetrical: if you write to it then read from it, you may not see what you just wrote. So these
-non-file-like entries error if you try to open them with a ReadWrite handle.
+non-file-like entries error if you try to open them with a ReadWrite handle. If your plugin
+implements non-file-like write-semantics, remember to document how they work in the plugin schema's
+description.
 
 All of the above, as well as other types - Execable, Stream - provide additional functionality
 via the HTTP API.
@@ -213,8 +215,6 @@ type Readable interface {
 // Writable can be implemented with or without Readable/BlockReadable. If an
 // entry is only Writable, then only full writes (starting from offset 0) are
 // allowed, anything else initiated by the filesystem will result in an error.
-//
-// It's up to the implementer to decide how much data integrity to guarantee.
 type Writable interface {
 	Entry
 	Write(context.Context, []byte) error

--- a/plugin/types.go
+++ b/plugin/types.go
@@ -15,7 +15,15 @@ or referenced via the API - and tools for controlling how its data is cached.
 Implementing the Parent interface displays that resource as a directory on the filesystem.
 Anything that does not implement Parent will be displayed as a file.
 
-The Readable interface gives a file its contents when read via the filesystem.
+The Readable interface allows reading data from an entry via the filesystem. The Writable
+interface allows sending data to the entry.
+
+Wash distinguishes between two different patterns for things you can read and write. It considers
+a "file-like" entry to be one with a defined size (so the `size` attribute is set when listing the
+entry). Reading and writing a "file-like" entry edits the contents. Something that can be read and
+written but doesn't define size has different characteristics. Reading and writing are not
+symmetrical: if you write to it then read from it, you may not see what you just wrote. So these
+non-file-like entries error if you try to open them with a ReadWrite handle.
 
 All of the above, as well as other types - Execable, Stream - provide additional functionality
 via the HTTP API.

--- a/plugin/types.go
+++ b/plugin/types.go
@@ -184,6 +184,8 @@ type Streamable interface {
 }
 
 // BlockReadable is an entry with data that can be read in blocks.
+// A BlockReadable entry must set its Size attribute. If you don't set it, the
+// file size will be reported as 0 and reads will return an empty file.
 type BlockReadable interface {
 	Entry
 	Read(ctx context.Context, size int64, offset int64) ([]byte, error)
@@ -199,6 +201,10 @@ type Readable interface {
 // implementation-specific; it could be overwriting a file, submitting a
 // configuration change to an API, or writing data to a queue. It doesn't
 // support a concept of a partial write.
+//
+// Writable can be implemented with or without Readable/BlockReadable. If an
+// entry is only Writable, then only full writes (starting from offset 0) are
+// allowed, anything else initiated by the filesystem will result in an error.
 //
 // It's up to the implementer to decide how much data integrity to guarantee.
 type Writable interface {

--- a/plugin/types.go
+++ b/plugin/types.go
@@ -183,24 +183,27 @@ type Streamable interface {
 	Stream(context.Context) (io.ReadCloser, error)
 }
 
-// BlockReadable is an entry with content that can be read in blocks
+// BlockReadable is an entry with data that can be read in blocks.
 type BlockReadable interface {
 	Entry
 	Read(ctx context.Context, size int64, offset int64) ([]byte, error)
 }
 
-// Readable is an entry with content that can be read
+// Readable is an entry with data that can be read.
 type Readable interface {
 	Entry
 	Read(context.Context) ([]byte, error)
 }
 
-// Writable is an entry that can write data directly to the entry. It mirrors
-// the WriterAt interface with an added context for handling the lifecycle of
-// remote write operations.
+// Writable is an entry that we can write new data to. What that means can be
+// implementation-specific; it could be overwriting a file, submitting a
+// configuration change to an API, or writing data to a queue. It doesn't
+// support a concept of a partial write.
+//
+// It's up to the implementer to decide how much data integrity to guarantee.
 type Writable interface {
 	Entry
-	Write(context.Context, int64, []byte) (int, error)
+	Write(context.Context, []byte) error
 }
 
 // Deletable is an entry that can be deleted. Entries that implement Delete


### PR DESCRIPTION
Implement the new Writable interface (defined to mirror the Readable interface). Implement Write on simple file interfaces: local, AWS S3, and Google Cloud Storage.

Resolves #620. Also fixes #656.