### PR TITLE
Ensure ClearCache removes attributes in parent list as well

### DIFF
--- a/api/cache.go
+++ b/api/cache.go
@@ -29,7 +29,7 @@ var cacheHandler = handler{fn: func(w http.ResponseWriter, r *http.Request) *err
 		return errResp
 	}
 
-	deleted := plugin.ClearCacheFor(path)
+	deleted := plugin.ClearCacheFor(path, true)
 	activity.Record(r.Context(), "API: Cache DELETE %v %+v", path, deleted)
 
 	jsonEncoder := json.NewEncoder(w)

--- a/plugin/cache_test.go
+++ b/plugin/cache_test.go
@@ -140,9 +140,20 @@ func (suite *CacheTestSuite) TestClearCache() {
 	path := "/a"
 	rx := allOpKeysIncludingChildrenRegex(path)
 
-	suite.cache.On("Delete", rx).Return([]string{"/a"})
-	deleted := ClearCacheFor(path)
-	suite.Equal([]string{"/a"}, deleted)
+	suite.cache.On("Delete", rx).Return([]string{path})
+	deleted := ClearCacheFor(path, false)
+	suite.Equal([]string{path}, deleted)
+}
+
+func (suite *CacheTestSuite) TestClearCache_WithParent() {
+	path := "/a/b"
+	rxEntry := allOpKeysIncludingChildrenRegex(path)
+	rxParent := opKeyRegex(defaultOpCodeToNameMap[ListOp], "/a")
+
+	suite.cache.On("Delete", rxEntry).Return([]string{"List:/a/b", "Read:/a/b"})
+	suite.cache.On("Delete", rxParent).Return([]string{"List:/a"})
+	deleted := ClearCacheFor(path, true)
+	suite.Equal([]string{"List:/a/b", "Read:/a/b", "List:/a"}, deleted)
 }
 
 type cacheTestsMockEntry struct {

--- a/plugin/methodWrappers_test.go
+++ b/plugin/methodWrappers_test.go
@@ -266,7 +266,6 @@ func (suite *MethodWrappersTestSuite) TestSignal_SendsSignalAndUpdatesCache() {
 	e.On("Signal", ctx, "start").Return(nil)
 
 	suite.cache.On("Delete", allOpKeysIncludingChildrenRegex(e.id())).Return([]string{})
-	suite.cache.On("Get", "List", "/foo").Return(newEntryMap(), nil)
 	suite.cache.On("Delete", opKeyRegex("List", "/foo")).Return([]string{})
 
 	// Also test case-insensitivity here
@@ -331,7 +330,6 @@ func (suite *MethodWrappersTestSuite) TestDelete_EntryDeletionInProgress_Updates
 	e.On("Delete", mock.Anything).Return(false, nil)
 
 	suite.cache.On("Delete", allOpKeysIncludingChildrenRegex(e.id())).Return([]string{})
-	suite.cache.On("Get", "List", "/foo").Return(newEntryMap(), nil)
 	suite.cache.On("Delete", opKeyRegex("List", "/foo")).Return([]string{})
 
 	deleted, err := Delete(context.Background(), e)
@@ -353,7 +351,7 @@ func (suite *MethodWrappersTestSuite) TestDelete_EntryDeletionInProgress_NoCache
 	deleted, err := Delete(context.Background(), e)
 	if suite.NoError(err) {
 		suite.False(deleted)
-		suite.cache.AssertNotCalled(suite.T(), "Delete", opKeyRegex("List", "/foo"))
+		suite.cache.AssertCalled(suite.T(), "Delete", opKeyRegex("List", "/foo"))
 	}
 }
 

--- a/volume/fs_test.go
+++ b/volume/fs_test.go
@@ -198,7 +198,7 @@ func (suite *fsTestSuite) TestFSListExpiredCache() {
 	suite.Equal(1, entries.Len())
 	suite.Contains(entries.Map(), "path")
 
-	_ = plugin.ClearCacheFor("/instance/fs")
+	_ = plugin.ClearCacheFor("/instance/fs", false)
 	entries, err = plugin.List(suite.ctx, entry)
 	if suite.NoError(err) {
 		suite.Equal(1, entries.Len())


### PR DESCRIPTION
Makes ClearCache more thorough about clearing data about the entry. Attributes and metadata frequently come from the parent's List command, so clear that cache as well.

Fixes #667.

Signed-off-by: Michael Smith <michael.smith@puppet.com>