### PR TITLE
Generate version-agnostic release TARs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,14 +43,16 @@ jobs:
     script:
     - GOOS=darwin GOARCH=amd64 go build -ldflags="$LINKFLAGS"
     - tar czf ${PROJECT_NAME}-${TRAVIS_TAG}-x86_64-apple-darwin.tgz wash
+    - cp ${PROJECT_NAME}-${TRAVIS_TAG}-x86_64-apple-darwin.tgz ${PROJECT_NAME}-x86_64-apple-darwin.tgz
     - GOOS=linux GOARCH=amd64 go build -ldflags="$LINKFLAGS"
     - tar czf ${PROJECT_NAME}-${TRAVIS_TAG}-x86_64-unknown-linux.tgz wash
+    - cp ${PROJECT_NAME}-${TRAVIS_TAG}-x86_64-unknown-linux.tgz ${PROJECT_NAME}-x86_64-unknown-linux.tgz
     deploy:
       provider: releases
       api_key:
         secure: PVefYvPRdpOtWvvZEG9wxv2HxjBUQ1/t1XsXQFOuF30/YzjY4EHaYBH/RXtFzuiCqpyk5GA1dWVUSE356Aka2Y3JlqImv1d0n+prrG2fEJBEtaDlR7Q6DeIiONPsCMxWyJ22r+bBz3C1Qq+QwSLzFuTN1XKIQTFdzIaqnIO7rthPNZNSfMmreed6SXfFmnsIcA+7TG+k4iDYz8COSDrYdjaiHnejvHlUiXh9Rfa3LzTdC4rxtOKofbUa9Qei08mSaSuRGD0U0vymOfFKf/QjNuwFmGSbdIH+1KmCOD9MV/47l6xZMDHDL4mLabsDB9ipf9LFAWmN9pQ/a5UoPyh4IXgaP7NeS3ISNlbKSCx7S70In8/whQv7jB8a5dNuo8HtKx0wzdQ9pKDBDt/N3h1YYJhGR2UF4JJd1CkBytRgIKzjZ5D7Ky+j23Vr6/+lvCRL0CN3RvvBP91/rfyO61eW4FGo+J/Es2u5+HPjVST4S4ntZnTDA6I2K1js8AbG1ofalivpcth4i+2zoKANXEjlXgUUI63gypBvyKGgHHouQTzKuyeIPBzlhYCIrQVhN5QG2+Lc9w7A2KqeRm0vxQ9elEKO1i5bSzSxYUXLMVSPkted0+gSPRRp4i67wOUO+1V9cLubbXm8PG1E1DhpiOQnxQb2DnaaVlL1mr3XQVDl6BY=
       file_glob: true
-      file: ${PROJECT_NAME}-${TRAVIS_TAG}-*.tgz
+      file: ${PROJECT_NAME}-*.tgz
       skip_cleanup: true
       on:
         repo: puppetlabs/wash


### PR DESCRIPTION
This will make it easier for people to install the project from source
when getting started. The website will be updated after the next Wash
release.

We continue to maintain the versioned TARs since that seems to be a
common convention in projects.

Supports #658

Signed-off-by: Enis Inan <enis.inan@puppet.com>