### PR TITLE
Link to find tutorials in find's help text

### DIFF
--- a/cmd/internal/find/primary/meta.go
+++ b/cmd/internal/find/primary/meta.go
@@ -67,6 +67,9 @@ var Meta = Parser.add(&Primary{
 })
 
 const metaDetailedDescription = `
+NOTE: https://puppetlabs.github.io/wash/tutorials/02_find/meta-primary
+contains a hands-on tutorial of the meta primary.
+
 The meta primary constructs a predicate on the entry's metadata. By
 default, this is the meta attribute. If you'd like to construct the
 predicate on the entry's full metadata, then set the "fullmeta" option.

--- a/cmd/internal/find/usage.go
+++ b/cmd/internal/find/usage.go
@@ -2,9 +2,9 @@ package find
 
 import (
 	"github.com/puppetlabs/wash/cmd/internal/config"
-	"github.com/puppetlabs/wash/cmd/internal/find/types"
 	"github.com/puppetlabs/wash/cmd/internal/find/parser"
 	"github.com/puppetlabs/wash/cmd/internal/find/primary"
+	"github.com/puppetlabs/wash/cmd/internal/find/types"
 )
 
 // Usage returns `wash find`'s usage string
@@ -14,11 +14,14 @@ func Usage() string {
 		use = "find"
 	}
 	u := ""
+	u += "NOTE: https://puppetlabs.github.io/wash/tutorials/02_find/ contains a hands-on\n"
+	u += "tutorial of 'find'.\n"
+	u += "\n"
 	u += "Recursively descends the directory tree of the specified paths, evaluating an\n"
 	u += "'expression' composed of 'primaries' and 'operands' for each entry in the tree.\n"
 	u += "\n"
 	u += "Usage:\n"
-	u += "  "+use+" [paths] [options] [expression]\n"
+	u += "  " + use + " [paths] [options] [expression]\n"
 	u += "\n"
 
 	t := types.OptionsTable()

--- a/docs/_includes/test_environment_reminder.md
+++ b/docs/_includes/test_environment_reminder.md
@@ -1,0 +1,1 @@
+**Note:** Make sure you've set up the [test environment]({{ '/tutorials/00_test_environment' | relative_url }}) so you can follow along in the tutorial.

--- a/docs/_tutorials/01_attributes_metadata/index.md
+++ b/docs/_tutorials/01_attributes_metadata/index.md
@@ -3,7 +3,8 @@ title: A deeper dive into attributes and metadata
 main: true
 sections: []
 ---
-This tutorial covers attributes and metadata in more detail.
+
+{% include test_environment_reminder.md %}
 
 # Metadata
 All entries are completely described by their metadata. An entry’s metadata is a key-value map containing everything you’ll ever need to know about the entry. You can use the `meta` command to view an entry’s metadata.

--- a/docs/_tutorials/02_find/depth-primaries-expression.md
+++ b/docs/_tutorials/02_find/depth-primaries-expression.md
@@ -3,6 +3,8 @@ title: Understanding depth, primaries and expression syntax
 ---
 **Note:** If you’ve used BSD/GNU’s `find` command, then much of the stuff in this tutorial will be familiar to you.
 
+{% include test_environment_reminder.md %}
+
 The `find` command recursively descends a given path, printing out all of its subchildren.
 
 ```

--- a/docs/_tutorials/02_find/meta-primary.md
+++ b/docs/_tutorials/02_find/meta-primary.md
@@ -1,6 +1,8 @@
 ---
 title: Metadata filtering with the meta primary
 ---
+{% include test_environment_reminder.md %}
+
 This tutorial gives a detailed overview of the `meta` primary. The `meta` primary lets you filter entries on their metadata properties, which is useful when you want to filter entries on a non-Wash attribute property. Examples of such properties include vendor-specific things like an AWS EC2 instance’s VPC ID or a GCP compute instance’s service accounts. They also include properties that don't yet exist as Wash attributes, such as a VM or container’s state, labels, and tags.
 
 The `meta` primary is its own mini-DSL (domain specific language). Each `meta` primary expression consists of:

--- a/docs/_tutorials/04_debugging/whistory.md
+++ b/docs/_tutorials/04_debugging/whistory.md
@@ -1,6 +1,8 @@
 ---
 title: whistory
 ---
+{% include test_environment_reminder.md %}
+
 Use the `whistory` command to view a history of all executed commands that have interacted with the Wash server.
 
 ```

--- a/docs/_tutorials/index.md
+++ b/docs/_tutorials/index.md
@@ -1,11 +1,9 @@
 ---
 title: Tutorials
 ---
-**Note:** Make sure you've [installed Wash]({{ '/getting_started' | relative_url }}) before going any further.
+**Note:** Make sure you've [installed Wash]({{ '/getting_started' | relative_url }}) before going any further. If you're unfamiliar with Wash, then check out the [home page]({{ '/' | relative_url }}) and watch at least one of the screencasts.
 
-This series of hands-on tutorials introduces you to Wash's more advanced features. Each tutorial assumes that you have the [test environment set-up](00_test_environment), and that you have an understanding of Wash’s key abstractions. If you're unfamiliar with Wash, then check out the [home page]({{ '/' | relative_url }}) and watch at least one of the screencasts.
-
-You can complete the tutorials in any order. If you're not sure where to start, here are a few good options: 
+This series of hands-on tutorials introduces you to Wash's more advanced features. You can complete them in any order. If you're not sure where to start, here are a few good options: 
 
 * [A deeper dive into attributes and metadata](01_attributes_metadata) is useful if you'd like to understand the difference between an entry's attributes and its metadata.
 
@@ -15,6 +13,6 @@ You can complete the tutorials in any order. If you're not sure where to start, 
 
 * [Debugging](04_debugging/whistory) is useful if you plan on doing some complicated stuff with Wash that would require you to do a lot of debugging if anything fails.
 
-Some tutorials include optional exercises at the end of each section. The exercises are meant to test and improve your understanding of the material. Note that the exercises are not meant to trick you. They are intended to be straightforward and fun. If you find yourself feeling frustrated with a specific exercise or question, please let us know in the #wash channel on [Puppet's community Slack](https://puppetcommunity.slack.com/?redir=%2Fapp_redirect%3Fchannel%3Dwash). We’ll try to find a way to simplify the exercise, or even remove it if it does not add any value.
+Some tutorials include optional exercises at the end of each section. These exercises are meant to test and improve your understanding of the material; they are _not_ meant to trick you. If you find yourself feeling frustrated with a specific exercise or question, please let us know in the #wash channel on [Puppet's community Slack](https://puppetcommunity.slack.com/?redir=%2Fapp_redirect%3Fchannel%3Dwash). We’ll try to find a way to simplify the exercise, or even remove it if it does not add any value.
 
 All exercises include their answers so you can double-check your work. Some exercises may have more than one acceptable answer. If you have any questions on an exercise’s solution, or on the correctness of your answer, then please let us know on the Slack channel.


### PR DESCRIPTION
This commit also adds a "set up test environment" reminder to the
specific tutorials that depend on it.

Signed-off-by: Enis Inan <enis.inan@puppet.com>