### PR TITLE
Change "description" => "docs" in storage prefix/object descriptions

### DIFF
--- a/plugin/aws/s3Object.go
+++ b/plugin/aws/s3Object.go
@@ -118,6 +118,6 @@ func (o *s3Object) Delete(ctx context.Context) (bool, error) {
 }
 
 const s3ObjectDescription = `
-This is an S3 object. See the bucket's description for more details on
+This is an S3 object. See the bucket's docs for more details on
 why we have this kind of entry.
 `

--- a/plugin/aws/s3ObjectPrefix.go
+++ b/plugin/aws/s3ObjectPrefix.go
@@ -53,5 +53,5 @@ func (d *s3ObjectPrefix) Delete(ctx context.Context) (bool, error) {
 
 const s3ObjectPrefixDescription = `
 This represents a common prefix shared by multiple S3 objects. See the
-bucket's description for more details on why we have this kind of entry.
+bucket's docs for more details on why we have this kind of entry.
 `

--- a/plugin/gcp/storageObject.go
+++ b/plugin/gcp/storageObject.go
@@ -62,6 +62,6 @@ func (s *storageObject) Delete(ctx context.Context) (bool, error) {
 }
 
 const storageObjectDescription = `
-This is a Storage object. See the bucket's description for more details
+This is a Storage object. See the bucket's docs for more details
 on why we have this kind of entry.
 `

--- a/plugin/gcp/storageObjectPrefix.go
+++ b/plugin/gcp/storageObjectPrefix.go
@@ -55,5 +55,5 @@ func (s *storageObjectPrefix) ChildSchemas() []*plugin.EntrySchema {
 
 const storageObjectPrefixDescription = `
 This represents a common prefix shared by multiple Storage objects. See
-the bucket's description for more details on why we have this kind of entry.
+the bucket's docs for more details on why we have this kind of entry.
 `


### PR DESCRIPTION
This makes it more obvious for people to do `docs <bucket>`

Signed-off-by: Enis Inan <enis.inan@puppet.com>