### PR TITLE
Fix denoting a code block in godoc markup

### DIFF
--- a/transport/ssh.go
+++ b/transport/ssh.go
@@ -198,10 +198,8 @@ type Identity struct {
 // from config as enumerated in https://github.com/kevinburke/ssh_config/blob/0.5/validators.go.
 //
 // The known hosts file will be ignored if StrictHostKeyChecking=no, such as in
-// ```
-// Host *.compute.amazonaws.com
-//   StrictHostKeyChecking no
-// ```
+//   Host *.compute.amazonaws.com
+//     StrictHostKeyChecking no
 func ExecSSH(ctx context.Context, id Identity, cmd []string, opts plugin.ExecOptions) (plugin.ExecCommand, error) {
 	// find port, username, etc from .ssh/config
 	conf, err := getConnInfo(ctx, id)


### PR DESCRIPTION
Triple backtick isn't used in godoc, code blocks need to be indented relative to the surrounding text.

Signed-off-by: Michael Smith <michael.smith@puppet.com>