### PR TITLE
Use simple print for server shutdown messages

### DIFF
--- a/transport/ssh_test.go
+++ b/transport/ssh_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"strconv"
@@ -119,7 +120,7 @@ func (suite *SSHTestSuite) SetupSuite() {
 	suite.s.AddHostKey(signer)
 	suite.s.PasswordHandler = suite.PasswordHandler
 	suite.s.PublicKeyHandler = suite.PublicKeyHandler
-	go func() { suite.T().Log(suite.s.ListenAndServe()) }()
+	go func() { fmt.Println(suite.s.ListenAndServe()) }()
 }
 
 func (suite *SSHTestSuite) SetupTest() {


### PR DESCRIPTION
Trying to log server shutdown using the test suite was exposing a race - detected using `go test -race` - between server shutdown and test suite cleanup. Use a simple print statement instead.

Signed-off-by: Michael Smith <michael.smith@puppet.com>