### PR TITLE
Test with -race in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
 jobs:
   include:
   - name: Test Go stable
+    script: go test -race ./...
   - name: Acceptance tests
     before_script:
     - |

--- a/plugin/execCommandImpl_test.go
+++ b/plugin/execCommandImpl_test.go
@@ -12,8 +12,8 @@ import (
 
 type ExecCommandImplTestSuite struct {
 	suite.Suite
-	ctx         context.Context
-	cancelFunc  context.CancelFunc
+	ctx        context.Context
+	cancelFunc context.CancelFunc
 }
 
 func (suite *ExecCommandImplTestSuite) SetupTest() {
@@ -89,7 +89,8 @@ func (suite *ExecCommandImplTestSuite) TestNewExecCommand_CancelledContext_Close
 func (suite *ExecCommandImplTestSuite) TestSetStopFunc_CancelledContext_StopsCommand() {
 	execCmd := suite.NewExecCommand()
 	stoppedCh := make(chan bool, 1)
-	time.AfterFunc(1 * time.Second, func() {
+	// Allow lots of time for slow testing with `-race`.
+	time.AfterFunc(10*time.Second, func() {
 		close(stoppedCh)
 	})
 	execCmd.SetStopFunc(func() {
@@ -179,4 +180,3 @@ func (suite *ExecCommandImplTestSuite) TestExitCode_ReturnsExitCodeErrIfSet() {
 func TestExecCommandImpl(t *testing.T) {
 	suite.Run(t, new(ExecCommandImplTestSuite))
 }
-


### PR DESCRIPTION
Attempt to detect race conditions in CI. Make a test timeout longer to account for slower speed with the `-race` flag.

Signed-off-by: Michael Smith <michael.smith@puppet.com>