### PR TITLE
Fix typo in command

### DIFF
--- a/docs/_posts/2020-02-07-boltwash.md
+++ b/docs/_posts/2020-02-07-boltwash.md
@@ -58,7 +58,7 @@ Feb  7 18:39:51 pe-agent01 systemd[1]: Started User Manager for UID 1000.
 
 We can also explore Windows targets using WinRM
 ```
-wash bolt/my-windows-nodes/node5/fs > cat Users
+wash bolt/my-windows-nodes/node5/fs > ls Users
 Administrator/
 Public/
 ```


### PR DESCRIPTION
Alleged command was `cat Users` but output reflected `ls Users`. Output was correct as `Users` is a directory.

Signed-off-by: Michael Smith <michael.smith@puppet.com>