### PR TITLE
Specify canonical user for gcp instance exec

### DIFF
--- a/plugin/gcp/computeInst.go
+++ b/plugin/gcp/computeInst.go
@@ -134,7 +134,7 @@ func (c *computeInstance) Exec(ctx context.Context, cmd string, args []string,
 
 	identity := transport.Identity{
 		Host:         hostname,
-		FallbackUser: user,
+		User:         user,
 		IdentityFile: conf.privateKey,
 		KnownHosts:   conf.knownHosts,
 		HostKeyAlias: hostKeyAlias(c.instance),


### PR DESCRIPTION
Previously we supplied the user registered with GCP metadata as a `FallbackUser`, which allowed a user's SSH config to change the user. However this behavior is inconsistent with `gcloud ssh` and resulted in default user entries (`Host *`) in SSH config breaking this functionality.

Switch to using the user from GCP metadata as the canonical user for login. If we later need to support changing that user, it should be a new feature of the `wexec` command/API.

Fixes #725.

Signed-off-by: Michael Smith <michael.smith@puppet.com>