### PR TITLE
Make 'cd' go to Wash's root

### DIFF
--- a/cmd/docs.go
+++ b/cmd/docs.go
@@ -175,11 +175,10 @@ func stringifySupportedActions(path string, entry apitypes.Entry) string {
 				fmt.Sprintf("- ls %s", path),
 				fmt.Sprintf("    Type 'docs <child>' to view an ls'ed child's documentation"),
 				fmt.Sprintf("- cd %s", path),
-				fmt.Sprintf("    The 'W' environment variable contains the Wash root. Use 'cd $W' to"),
-				fmt.Sprintf("    return to it."),
+				fmt.Sprintf("    Use 'cd' to return to Wash's starting directory"),
 				fmt.Sprintf("- stree %s", path),
 				fmt.Sprintf("    Gives you a high-level overview of the kinds of things that you will"),
-				fmt.Sprintf("    encounter when you 'cd' and 'ls' through this entry."),
+				fmt.Sprintf("    encounter when you 'cd' and 'ls' through this entry"),
 				fmt.Sprintf("- (anything else that works with directories [e.g. 'tree'])"),
 			}
 		case plugin.ReadAction().Name:

--- a/cmd/internal/shell/bash.go
+++ b/cmd/internal/shell/bash.go
@@ -47,18 +47,11 @@ func (b bash) Command(subcommands []string, rundir string) (*exec.Cmd, error) {
 `
 	// Re-add aliases in case .bashrc overrode them.
 	content += common
-	content += `
-function prompter() {
-  local prompt_path
-  if [ -x "$(command -v realpath)" ]; then
-    prompt_path=$(realpath --relative-base=$W "$(pwd)")
-  else
-    prompt_path=$(basename "$(pwd)")
-  fi
-  export PS1="\e[0;36mwash ${prompt_path}\e[0;32m ❯\e[m "
-}
-export PROMPT_COMMAND=prompter
 
+	// Configure prompt and override `cd`
+	content += preparePrompt(`\e[0;36m`, `\e[0;32m`, `\e[m`, "export PS1") + `
+export PROMPT_COMMAND=prompter
+` + overrideCd() + `
 [[ -s ~/.washrc ]] && source ~/.washrc
 `
 	if err := ioutil.WriteFile(rcpath, []byte(content), 0644); err != nil {

--- a/cmd/internal/shell/zsh.go
+++ b/cmd/internal/shell/zsh.go
@@ -57,20 +57,12 @@ fi
 `
 	// Re-add aliases in case .zprofile or .zshrc overrode them.
 	content += common
-	content += `
-function prompter() {
-  local prompt_path
-  if [ -x "$(command -v realpath)" ]; then
-    prompt_path=$(realpath --relative-base=$W "$(pwd)")
-  else
-    prompt_path=$(basename "$(pwd)")
-  fi
-  PROMPT="%F{cyan}wash ${prompt_path}%F{green} ❯%f "
-}
 
+	// Configure prompt and override `cd`
+	content += preparePrompt("%F{cyan}", "%F{green}", "%f", "PROMPT") + `
 autoload -Uz add-zsh-hook
 add-zsh-hook precmd prompter
-
+` + overrideCd() + `
 if [[ -s ~/.washrc ]]; then source ~/.washrc; fi
 `
 	if err := ioutil.WriteFile(filepath.Join(rundir, ".zshrc"), []byte(content), 0644); err != nil {


### PR DESCRIPTION
One challenge new users run into is how to get back to Wash's root. Make `cd` without arguments take them there.

Fixes #716.

Signed-off-by: Michael Smith <michael.smith@puppet.com>