### PR TITLE
Avoid shutdown race when handlers are slow, ensure GCP pubsub cancels

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -144,8 +144,6 @@ func StartAPI(
 	// Start the server
 	serverStoppedCh := make(chan struct{})
 	go func() {
-		defer close(serverStoppedCh)
-
 		err := httpServer.Serve(server)
 		if err != nil && err != http.ErrServerClosed {
 			log.Warnf("API: %v", err)
@@ -163,8 +161,7 @@ func StartAPI(
 		if err != nil {
 			log.Warnf("API: Shutdown failed: %v", err)
 		}
-
-		<-serverStoppedCh
+		close(serverStoppedCh)
 	}()
 
 	return stopCh, serverStoppedCh, nil


### PR DESCRIPTION
Use a single select so if the context is canceled while we're waiting for a new GCP pubsub message, the read errors rather than remaining blocked.

When `Shutdown` is called on a net/http `Server`, it causes the `Serve` function to return but may still have further cleanup to do. The previous implementation sent a signal that shutdown was complete once `Serve` returned, which would cancel a timeout context. If the server was still actually cleaning up, we might get an error from `Shutdown` because the context it was using was canceled.

Close the stopped channel once `Shutdown` returns to trigger cleanup.

Fixes #711.