### PR TITLE
Improve reporting on non-zero exit for fs List

### DIFF
--- a/volume/statPowershell.go
+++ b/volume/statPowershell.go
@@ -118,3 +118,10 @@ func ParseStatPowershell(output io.Reader, base string, start string, maxdepth i
 	}
 	return dirmap, nil
 }
+
+// NormalErrorPowerShell returns whether this line of text is normal error output for StatCmdPowerShell.
+//
+// Currently no error messages are considered ignorable.
+func NormalErrorPowerShell(text string) bool {
+	return false
+}


### PR DESCRIPTION
Some non-zero exits are normal with `find` (see examples in code). The messages that caused this can appear on stdout or stderr depending on whether a tty is used or if it's a `stat` executed by `find`. Ignore normal failures, but if we get an unknown one fail `VolumeList` and return the error.

Fixes #742.

Signed-off-by: Michael Smith <michael.smith@puppet.com>