### PR TITLE
Hide fs on exec fail

### DIFF
--- a/plugin/aws/ec2Instance.go
+++ b/plugin/aws/ec2Instance.go
@@ -217,7 +217,7 @@ func (inst *ec2Instance) List(ctx context.Context) ([]plugin.Entry, error) {
 
 	// Include a view of the remote filesystem using volume.FS. Use a small maxdepth because
 	// VMs can have lots of files and SSH is fast.
-	entries = append(entries, volume.NewFS("fs", inst, 3))
+	entries = append(entries, volume.NewFS(ctx, "fs", inst, 3))
 
 	return entries, nil
 }

--- a/plugin/docker/container.go
+++ b/plugin/docker/container.go
@@ -91,7 +91,7 @@ func (c *container) List(ctx context.Context) ([]plugin.Entry, error) {
 
 	// Include a view of the remote filesystem using volume.FS. Use a small maxdepth because
 	// VMs can have lots of files and Exec is fast.
-	return []plugin.Entry{clf, cm, vol.NewFS("fs", c, 3)}, nil
+	return []plugin.Entry{clf, cm, vol.NewFS(ctx, "fs", c, 3)}, nil
 }
 
 func (c *container) Delete(ctx context.Context) (bool, error) {

--- a/plugin/entryBase.go
+++ b/plugin/entryBase.go
@@ -142,7 +142,7 @@ func (e *EntryBase) SetPartialMetadata(obj interface{}) *EntryBase {
 // MarkInaccessible sets the inaccessible attribute and logs a message about why the entry is
 // inaccessible.
 func (e *EntryBase) MarkInaccessible(ctx context.Context, err error) {
-	activity.Record(ctx, "Omitting %v: %v", e.id, err)
+	activity.Warnf(ctx, "Omitting %v: %v", e.id, err)
 	e.isInaccessible = true
 }
 

--- a/plugin/external/coreEntries.go
+++ b/plugin/external/coreEntries.go
@@ -1,6 +1,7 @@
 package external
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -9,7 +10,7 @@ import (
 )
 
 type coreEntry interface {
-	createInstance(parent *pluginEntry, decodedEntry decodedExternalPluginEntry) (plugin.Entry, error)
+	createInstance(ctx context.Context, parent *pluginEntry, decodedEntry decodedExternalPluginEntry) (plugin.Entry, error)
 	template() plugin.Entry
 }
 
@@ -19,7 +20,7 @@ var coreEntries = map[string]coreEntry{
 
 type volumeFS struct{}
 
-func (volumeFS) createInstance(parent *pluginEntry, e decodedExternalPluginEntry) (plugin.Entry, error) {
+func (volumeFS) createInstance(ctx context.Context, parent *pluginEntry, e decodedExternalPluginEntry) (plugin.Entry, error) {
 	var opts struct{ Maxdepth uint }
 	// Use a default of 3 if unspecified.
 	opts.Maxdepth = 3
@@ -28,7 +29,7 @@ func (volumeFS) createInstance(parent *pluginEntry, e decodedExternalPluginEntry
 		return nil, fmt.Errorf("volume filesystem options invalid: %v", err)
 	}
 
-	return volume.NewFS(e.Name, parent, int(opts.Maxdepth)), nil
+	return volume.NewFS(ctx, e.Name, parent, int(opts.Maxdepth)), nil
 }
 
 func (volumeFS) template() plugin.Entry {

--- a/plugin/external/pluginEntry.go
+++ b/plugin/external/pluginEntry.go
@@ -408,7 +408,7 @@ func (e *pluginEntry) List(ctx context.Context) ([]plugin.Entry, error) {
 	entries := make([]plugin.Entry, len(decodedEntries))
 	for i, decodedExternalPluginEntry := range decodedEntries {
 		if coreEnt, ok := coreEntries[decodedExternalPluginEntry.TypeID]; ok {
-			entry, err := coreEnt.createInstance(e, decodedExternalPluginEntry)
+			entry, err := coreEnt.createInstance(ctx, e, decodedExternalPluginEntry)
 			if err != nil {
 				return nil, err
 			}

--- a/plugin/gcp/computeInst.go
+++ b/plugin/gcp/computeInst.go
@@ -60,7 +60,7 @@ func (c *computeInstance) List(ctx context.Context) ([]plugin.Entry, error) {
 		metadataJSONFile,
 		// Include a view of the remote filesystem using volume.FS. Use a small maxdepth because
 		// VMs can have lots of files and SSH is fast.
-		volume.NewFS("fs", c, 3),
+		volume.NewFS(ctx, "fs", c, 3),
 	}, nil
 }
 

--- a/volume/fs.go
+++ b/volume/fs.go
@@ -20,13 +20,18 @@ type FS struct {
 
 // NewFS creates a new FS entry with the given name, using the supplied executor to satisfy volume
 // operations.
-func NewFS(name string, executor plugin.Execable, maxdepth int) *FS {
+func NewFS(ctx context.Context, name string, executor plugin.Execable, maxdepth int) *FS {
 	fs := &FS{
 		EntryBase: plugin.NewEntry(name),
 	}
 	fs.executor = executor
 	fs.maxdepth = maxdepth
 	fs.SetTTLOf(plugin.ListOp, ListTTL)
+
+	if _, err := plugin.List(ctx, fs); err != nil {
+		fs.MarkInaccessible(ctx, err)
+	}
+
 	return fs
 }
 

--- a/volume/statPosix_test.go
+++ b/volume/statPosix_test.go
@@ -223,3 +223,11 @@ func TestNumPathSegments(t *testing.T) {
 	assert.Equal(t, 1, numPathSegments("/foo"))
 	assert.Equal(t, 2, numPathSegments("/foo/bar"))
 }
+
+func TestNormalErrorPOSIX(t *testing.T) {
+	assert.False(t, NormalErrorPOSIX(""))
+	assert.False(t, NormalErrorPOSIX("anything"))
+
+	assert.True(t, NormalErrorPOSIX("find: a mistake"))
+	assert.True(t, NormalErrorPOSIX("stat: something absent"))
+}

--- a/volume/statPowershell_test.go
+++ b/volume/statPowershell_test.go
@@ -96,3 +96,8 @@ func TestParseStatPowershell_Empty(t *testing.T) {
 	assert.Len(t, dmap, 1)
 	assert.Empty(t, dmap[RootPath])
 }
+
+func TestNormalErrorPowerShell(t *testing.T) {
+	assert.False(t, NormalErrorPowerShell(""))
+	assert.False(t, NormalErrorPowerShell("anything"))
+}


### PR DESCRIPTION
Mark `fs` as inaccessible if List errors.

`MarkInaccessible` is usually marked if something is unavailable, either because it doesn't exist or you don't have permission to access it. Either of these can be unexpected, so we should warn when that happens rather than requiring that you dig into `whistory`.

Fixes #696.