### PR TITLE
Refactor tests to be more representative of the real world

### DIFF
--- a/api/rql/ast/asttest/suite.go
+++ b/api/rql/ast/asttest/suite.go
@@ -13,12 +13,11 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-// Suite represents a type that tests RQL AST nodes. N represents the AST node
-// constructor that returns an empty AST node object. It can be overridden by
-// each test. DefaultN represents the default node constructor that should be
-// set when the suite class is created.
-//
-// TODO: Add some more comments once a tested version of this is working.
+// Suite represents a type that tests RQL AST nodes. NodeConstructor represents
+// the AST node constructor that returns an empty AST node object. It can be
+// overridden by each test. DefaultNodeConstructor represents the default node
+// constructor that will be set for each test before they run. It should be
+// initialized when the suite class is created.
 type Suite struct {
 	suite.Suite
 	DefaultNodeConstructor func() rql.ASTNode

--- a/api/rql/ast/metaPrimaryRealWorld_test.go
+++ b/api/rql/ast/metaPrimaryRealWorld_test.go
@@ -22,11 +22,10 @@ type MetaPrimaryRealWorldTestSuite struct {
 
 // TTC => TrueTestCase
 func (s *MetaPrimaryRealWorldTestSuite) TTC(key interface{}, predicate interface{}) {
-	q := Query()
-	s.MUM(q, s.A("meta", s.A("object", s.A(s.A("key", key), predicate))))
-	s.Suite.EETTC(q, s.e)
+	ast := s.A("meta", s.A("object", s.A(s.A("key", key), predicate)))
+	s.Suite.EETTC(ast, s.e)
 	// The entry schema predicate should also be true
-	s.Suite.EESTTC(q, s.s)
+	s.Suite.EESTTC(ast, s.s)
 }
 
 func (s *MetaPrimaryRealWorldTestSuite) TestMetaPrimary() {
@@ -182,6 +181,9 @@ func (s *MetaPrimaryRealWorldTestSuite) TestMetaPrimary() {
 
 func TestMetaPrimaryRealWorld(t *testing.T) {
 	s := new(MetaPrimaryRealWorldTestSuite)
+	s.DefaultNodeConstructor = func() rql.ASTNode {
+		return Query()
+	}
 
 	rawMeta, err := ioutil.ReadFile("testdata/metadata.json")
 	if err != nil {

--- a/api/rql/ast/query_test.go
+++ b/api/rql/ast/query_test.go
@@ -15,16 +15,13 @@ type QueryTestSuite struct {
 
 // QTC => QueryTestCase
 func (s *QueryTestSuite) QTC(rawQuery interface{}, trueV interface{}) {
-	q := Query()
-	if s.NoError(q.Unmarshal(rawQuery)) {
-		switch t := trueV.(type) {
-		case rql.Entry:
-			s.True(q.(rql.EntryPredicate).EvalEntry(t))
-		case *rql.EntrySchema:
-			s.True(q.(rql.EntrySchemaPredicate).EvalEntrySchema(t))
-		default:
-			s.FailNow("t is not an Entry/EntrySchema value, it is instead %T", trueV)
-		}
+	switch t := trueV.(type) {
+	case rql.Entry:
+		s.EETTC(rawQuery, t)
+	case *rql.EntrySchema:
+		s.EESTTC(rawQuery, t)
+	default:
+		s.FailNow("t is not an Entry/EntrySchema value, it is instead %T", trueV)
 	}
 }
 
@@ -109,12 +106,11 @@ func (s *QueryTestSuite) TestCanUnmarshalPEPrimary() {
 }
 
 func (s *QueryTestSuite) TestUnmarshalErrors() {
-	q := Query()
-	s.UMETC(q, s.A(), "expected.*PE.*Primary", true)
-	s.UMETC(q, s.A("name", 1), "expected.*NPE.*StringPredicate", false)
-	s.UMETC(q, s.A("NOT", 1), "expected.*PE.*Primary", true)
-	s.UMETC(q, s.A("AND", 1, 2), "expected.*PE.*Primary", false)
-	s.UMETC(q, s.A("OR", 1, 2), "expected.*PE.*Primary", false)
+	s.UMETC(s.A(), "expected.*PE.*Primary", true)
+	s.UMETC(s.A("name", 1), "expected.*NPE.*StringPredicate", false)
+	s.UMETC(s.A("NOT", 1), "expected.*PE.*Primary", true)
+	s.UMETC(s.A("AND", 1, 2), "expected.*PE.*Primary", false)
+	s.UMETC(s.A("OR", 1, 2), "expected.*PE.*Primary", false)
 }
 
 func (s *QueryTestSuite) testPrimaryWithNPEAction(primaryName string, constructV func(string) interface{}) {
@@ -160,5 +156,9 @@ func (s *QueryTestSuite) testPrimaryWithPEObject(primaryName string, constructV 
 }
 
 func TestQuery(t *testing.T) {
-	suite.Run(t, new(QueryTestSuite))
+	s := new(QueryTestSuite)
+	s.DefaultNodeConstructor = func() rql.ASTNode {
+		return Query()
+	}
+	suite.Run(t, s)
 }

--- a/api/rql/internal/predicate/array_test.go
+++ b/api/rql/internal/predicate/array_test.go
@@ -27,11 +27,14 @@ func (s *ArrayTestSuite) TestMarshal_ElementPredicate() {
 }
 
 func (s *ArrayTestSuite) TestUnmarshalErrors_ElementPredicate() {
+	s.NodeConstructor = func() rql.ASTNode {
+		return Array().(*array).collectionBase.elementPredicate
+	}
+
 	// Start by testing the match errors
-	p := Array().(*array).collectionBase.elementPredicate
-	s.UMETC(p, s.A(), "formatted.*<element_selector>.*PE ValuePredicate", true)
-	s.UMETC(p, s.A(true), "formatted.*<element_selector>.*PE ValuePredicate", true)
-	s.UMETC(p, s.A("foo"), "formatted.*<element_selector>.*PE ValuePredicate", true)
+	s.UMETC(s.A(), "formatted.*<element_selector>.*PE ValuePredicate", true)
+	s.UMETC(s.A(true), "formatted.*<element_selector>.*PE ValuePredicate", true)
+	s.UMETC(s.A("foo"), "formatted.*<element_selector>.*PE ValuePredicate", true)
 
 	// Now test the syntax errors
 	selectors := []interface{}{
@@ -40,66 +43,65 @@ func (s *ArrayTestSuite) TestUnmarshalErrors_ElementPredicate() {
 		float64(1),
 	}
 	for _, selector := range selectors {
-		s.UMETC(p, s.A(selector, s.A("string", s.A("=", "foo")), "bar"), "formatted.*<element_selector>.*PE ValuePredicate", false)
-		s.UMETC(p, s.A(selector), "formatted.*<element_selector>.*PE ValuePredicate.*missing.*PE ValuePredicate", false)
+		s.UMETC(s.A(selector, s.A("string", s.A("=", "foo")), "bar"), "formatted.*<element_selector>.*PE ValuePredicate", false)
+		s.UMETC(s.A(selector), "formatted.*<element_selector>.*PE ValuePredicate.*missing.*PE ValuePredicate", false)
 	}
-	s.UMETC(p, s.A(float64(-10), "foo"), "array.*index.*unsigned.*int", false)
+	s.UMETC(s.A(float64(-10), "foo"), "array.*index.*unsigned.*int", false)
 }
 
 func (s *ArrayTestSuite) TestEvalValue_ElementPredicate() {
-	p := Array()
-
 	// Test "some"
-	s.MUM(p, s.A("array", s.A("some", true)))
-	s.EVFTC(p, "foo", true, []interface{}{false}, []interface{}{})
-	s.EVTTC(p, []interface{}{true}, []interface{}{false, true})
+	ast := s.A("array", s.A("some", true))
+	s.EVFTC(ast, "foo", true, []interface{}{false}, []interface{}{})
+	s.EVTTC(ast, []interface{}{true}, []interface{}{false, true})
 
 	// Test "all"
-	s.MUM(p, s.A("array", s.A("all", true)))
-	s.EVFTC(p, "foo", true, []interface{}{false}, []interface{}{true, false})
-	s.EVTTC(p, []interface{}{true}, []interface{}{true, true})
+	ast = s.A("array", s.A("all", true))
+	s.EVFTC(ast, "foo", true, []interface{}{false}, []interface{}{true, false})
+	s.EVTTC(ast, []interface{}{true}, []interface{}{true, true})
 
 	// Test "n"
-	s.MUM(p, s.A("array", s.A(float64(0), true)))
-	s.EVFTC(p, "foo", true, []interface{}{"foo", "bar"}, []interface{}{false, true})
-	s.EVTTC(p, []interface{}{true}, []interface{}{true, "foo"})
+	ast = s.A("array", s.A(float64(0), true))
+	s.EVFTC(ast, "foo", true, []interface{}{"foo", "bar"}, []interface{}{false, true})
+	s.EVTTC(ast, []interface{}{true}, []interface{}{true, "foo"})
 	// Add a case with a non-empty array
-	s.MUM(p, s.A("array", s.A(float64(1), true)))
-	s.EVFTC(p, "foo", true, []interface{}{true, false})
-	s.EVTTC(p, []interface{}{false, true}, []interface{}{"foo", true})
+	ast = s.A("array", s.A(float64(1), true))
+	s.EVFTC(ast, "foo", true, []interface{}{true, false})
+	s.EVTTC(ast, []interface{}{false, true}, []interface{}{"foo", true})
 }
 
 func (s *ArrayTestSuite) TestEvalValueSchema_ElementPredicate() {
-	p := Array()
 	for _, selector := range []interface{}{"some", "all", float64(0)} {
-		s.MUM(p, s.A("array", s.A(selector, true)))
-		s.EVSFTC(p, VS{"type": "number"}, VS{"type": "object"}, VS{"type": "array", "items": VS{"type": "object"}})
-		s.EVSTTC(p, VS{"type": "array"}, VS{"type": "array", "items": VS{"type": "boolean"}})
+		ast := s.A("array", s.A(selector, true))
+		s.EVSFTC(ast, VS{"type": "number"}, VS{"type": "object"}, VS{"type": "array", "items": VS{"type": "object"}})
+		s.EVSTTC(ast, VS{"type": "array"}, VS{"type": "array", "items": VS{"type": "boolean"}})
 	}
 }
 
 func (s *ArrayTestSuite) TestExpression_AtomAndNot_ElementPredicate() {
-	expr := expression.New("array", true, func() rql.ASTNode {
-		return Array()
-	})
+	s.NodeConstructor = func() rql.ASTNode {
+		return expression.New("array", true, func() rql.ASTNode {
+			return Array()
+		})
+	}
 
 	for _, selector := range []interface{}{"some", "all", float64(0)} {
-		s.MUM(expr, s.A("array", s.A(selector, true)))
-		s.EVFTC(expr, []interface{}{false})
-		s.EVTTC(expr, []interface{}{true})
-		s.EVSFTC(expr, VS{"type": "object"})
-		s.EVSTTC(expr, VS{"type": "array"})
-		s.MUM(expr, s.A("NOT", s.A("array", s.A(selector, true))))
-		s.EVTTC(expr, []interface{}{false})
-		s.EVFTC(expr, []interface{}{true})
-		s.EVSTTC(expr, VS{"type": "array"}, VS{"type": "object"})
+		ast := s.A("array", s.A(selector, true))
+		s.EVFTC(ast, []interface{}{false})
+		s.EVTTC(ast, []interface{}{true})
+		s.EVSFTC(ast, VS{"type": "object"})
+		s.EVSTTC(ast, VS{"type": "array"})
+
+		notAST := s.A("NOT", ast)
+		s.EVTTC(notAST, []interface{}{false})
+		s.EVFTC(notAST, []interface{}{true})
+		s.EVSTTC(notAST, VS{"type": "array"}, VS{"type": "object"})
 	}
 
 	// Assert that the unmarshaled atom doesn't implement the other *Predicate
 	// interfaces
-	s.MUM(expr, s.A("array", s.A("some", true)))
 	s.AssertNotImplemented(
-		expr,
+		s.A("array", s.A("some", true)),
 		asttest.EntryPredicateC,
 		asttest.EntrySchemaPredicateC,
 		asttest.StringPredicateC,
@@ -112,5 +114,8 @@ func (s *ArrayTestSuite) TestExpression_AtomAndNot_ElementPredicate() {
 func TestArray(t *testing.T) {
 	s := new(ArrayTestSuite)
 	s.isArray = true
+	s.DefaultNodeConstructor = func() rql.ASTNode {
+		return Array()
+	}
 	suite.Run(t, s)
 }

--- a/api/rql/internal/predicate/boolean_test.go
+++ b/api/rql/internal/predicate/boolean_test.go
@@ -18,65 +18,54 @@ func (s *BooleanTestSuite) TestMarshal() {
 	s.MTC(Boolean(false), false)
 }
 
-func (s *BooleanTestSuite) TestUnmarshal() {
-	b := Boolean(true)
-	s.UMETC(b, "foo", "foo.*valid.*Boolean.*true.*false", true)
-	s.UMTC(b, true, Boolean(true))
-	s.UMTC(b, false, Boolean(false))
+func (s *BooleanTestSuite) TestUnmarshalErrors() {
+	s.UMETC("foo", "foo.*valid.*Boolean.*true.*false", true)
 }
 
 func (s *BooleanTestSuite) TestEvalValue() {
 	// Test true
-	b := Boolean(true)
-	s.EVFTC(b, false, "foo")
-	s.EVTTC(b, true)
+	s.EVFTC(true, false, "foo")
+	s.EVTTC(true, true)
 
 	// Test false
-	b = Boolean(false)
-	s.EVFTC(b, true, "foo")
-	s.EVTTC(b, false)
+	s.EVFTC(false, true, "foo")
+	s.EVTTC(false, false)
 }
 
 func (s *BooleanTestSuite) TestEvalValueSchema() {
-	b := Boolean(true)
-	s.EVSFTC(b, s.VS("object", "array")...)
-	s.EVSTTC(b, s.VS("boolean")...)
+	s.EVSFTC(true, s.VS("object", "array")...)
+	s.EVSTTC(true, s.VS("boolean")...)
 }
 
 func (s *BooleanTestSuite) TestEvalEntry() {
 	// Test true
-	b := Boolean(true)
-	s.EETTC(b, rql.Entry{})
-
+	s.EETTC(true, rql.Entry{})
 	// Test false
-	b = Boolean(false)
-	s.EEFTC(b, rql.Entry{})
+	s.EEFTC(false, rql.Entry{})
 }
 
 func (s *BooleanTestSuite) TestEvalEntrySchema() {
 	// Test true
-	b := Boolean(true)
-	s.EESTTC(b, &rql.EntrySchema{})
-
+	s.EESTTC(true, &rql.EntrySchema{})
 	// Test false
-	b = Boolean(false)
-	s.EESFTC(b, &rql.EntrySchema{})
+	s.EESFTC(false, &rql.EntrySchema{})
 }
 
 func (s *BooleanTestSuite) TestExpression_AtomAndNot() {
-	expr := expression.New("boolean", true, func() rql.ASTNode {
-		return Boolean(false)
-	})
+	s.NodeConstructor = func() rql.ASTNode {
+		return expression.New("boolean", true, func() rql.ASTNode {
+			return Boolean(false)
+		})
+	}
 
-	s.MUM(expr, true)
-	s.EVFTC(expr, false)
-	s.EVTTC(expr, true)
-	s.EVSFTC(expr, s.VS("object", "array")...)
-	s.EVSTTC(expr, s.VS("boolean")...)
-	s.EETTC(expr, rql.Entry{})
-	s.EESTTC(expr, &rql.EntrySchema{})
+	s.EVFTC(true, false)
+	s.EVTTC(true, true)
+	s.EVSFTC(true, s.VS("object", "array")...)
+	s.EVSTTC(true, s.VS("boolean")...)
+	s.EETTC(true, rql.Entry{})
+	s.EESTTC(true, &rql.EntrySchema{})
 	s.AssertNotImplemented(
-		expr,
+		true,
 		asttest.StringPredicateC,
 		asttest.NumericPredicateC,
 		asttest.TimePredicateC,
@@ -84,12 +73,15 @@ func (s *BooleanTestSuite) TestExpression_AtomAndNot() {
 	)
 
 	// Only for EvalValue and EvalValueSchema
-	s.MUM(expr, []interface{}{"NOT", true})
-	s.EVTTC(expr, false)
-	s.EVFTC(expr, true)
-	s.EVSTTC(expr, s.VS("object", "array", "boolean")...)
+	s.EVTTC(s.A("NOT", true), false)
+	s.EVFTC(s.A("NOT", true), true)
+	s.EVSTTC(s.A("NOT", true), s.VS("object", "array", "boolean")...)
 }
 
 func TestBoolean(t *testing.T) {
-	suite.Run(t, new(BooleanTestSuite))
+	s := new(BooleanTestSuite)
+	s.DefaultNodeConstructor = func() rql.ASTNode {
+		return Boolean(true)
+	}
+	suite.Run(t, s)
 }

--- a/api/rql/internal/predicate/expression/and_test.go
+++ b/api/rql/internal/predicate/expression/and_test.go
@@ -3,24 +3,27 @@ package expression
 import (
 	"testing"
 
+	"github.com/puppetlabs/wash/api/rql"
 	"github.com/stretchr/testify/suite"
 )
 
 func TestAnd(t *testing.T) {
 	s := new(BinOpTestSuite)
+	s.DefaultNodeConstructor = func() rql.ASTNode {
+		return And(newMockP(""), newMockP(""))
+	}
 	s.opName = "AND"
-	s.newOp = And
 	s.testEvalMethod = func(s *BinOpTestSuite, RFTC TCRunFunc, RTTC TCRunFunc, constructV func(string) interface{}) {
-		p := And(newMockP("1"), newMockP("2"))
+		ast := s.A("AND", "1", "2")
 		// p1 == false, p2 == false
-		RFTC(s, p, constructV("3"))
+		RFTC(s, ast, constructV("3"))
 		// false, true
-		RFTC(s, p, constructV("2"))
+		RFTC(s, ast, constructV("2"))
 		// true, false
-		RFTC(s, p, constructV("1"))
+		RFTC(s, ast, constructV("1"))
 		// true, true
-		p.(*and).p2 = p.(*and).p1
-		RTTC(s, p, constructV("1"))
+		ast = s.A("AND", "1", "1")
+		RTTC(s, ast, constructV("1"))
 	}
 	suite.Run(t, s)
 }

--- a/api/rql/internal/predicate/expression/atom_test.go
+++ b/api/rql/internal/predicate/expression/atom_test.go
@@ -3,6 +3,7 @@ package expression
 import (
 	"testing"
 
+	"github.com/puppetlabs/wash/api/rql"
 	"github.com/puppetlabs/wash/api/rql/ast/asttest"
 	"github.com/stretchr/testify/suite"
 )
@@ -18,12 +19,14 @@ func (s *AtomTestSuite) TestMarshal() {
 	s.MTC(Atom(newMockP("10")), "10")
 }
 
-func (s *AtomTestSuite) TestUnmarshal() {
-	p := Atom(&mockPtype{})
-	s.UMETC(p, 1, "string", true)
-	s.UMTC(p, "10", Atom(newMockP("10")))
+func (s *AtomTestSuite) TestUnmarshalErrors() {
+	s.UMETC(1, "string", true)
 }
 
 func TestAtom(t *testing.T) {
-	suite.Run(t, new(AtomTestSuite))
+	s := new(AtomTestSuite)
+	s.DefaultNodeConstructor = func() rql.ASTNode {
+		return Atom(newMockP(""))
+	}
+	suite.Run(t, s)
 }

--- a/api/rql/internal/predicate/expression/binOp_test.go
+++ b/api/rql/internal/predicate/expression/binOp_test.go
@@ -11,39 +11,36 @@ import (
 )
 
 // TCRunFunc => TestCaseRunFunction
-type TCRunFunc = func(*BinOpTestSuite, rql.ASTNode, interface{})
+type TCRunFunc = func(*BinOpTestSuite, interface{}, interface{})
 
 type BinOpTestSuite struct {
 	asttest.Suite
 	opName         string
-	newOp          func(rql.ASTNode, rql.ASTNode) rql.ASTNode
 	testEvalMethod func(s *BinOpTestSuite, RFTC TCRunFunc, RTTC TCRunFunc, constructV func(string) interface{})
 }
 
 func (s *BinOpTestSuite) TestMarshal() {
-	p := s.newOp(newMockP("10"), newMockP("11"))
-	s.MTC(p, s.A(s.opName, "10", "11"))
+	p := s.NodeConstructor()
+	s.MTC(p, s.A(s.opName, "", ""))
 }
 
-func (s *BinOpTestSuite) TestUnmarshal() {
-	p := s.newOp(&mockPtype{}, &mockPtype{})
-	s.UMETC(p, "foo", fmt.Sprintf(`formatted.*"%v".*<pe>.*<pe>`, s.opName), true)
-	s.UMETC(p, s.A(s.opName, "10", "11", "12"), fmt.Sprintf(`"%v".*<pe>.*<pe>`, s.opName), false)
-	s.UMETC(p, s.A(s.opName), fmt.Sprintf("%v.*LHS.*RHS.*expression", s.opName), false)
-	s.UMETC(p, s.A(s.opName, "10"), fmt.Sprintf("%v.*LHS.*RHS.*expression", s.opName), false)
-	s.UMETC(p, s.A(s.opName, "syntax", "10"), fmt.Sprintf("%v.*LHS.*syntax", s.opName), false)
-	s.UMETC(p, s.A(s.opName, "10", "syntax"), fmt.Sprintf("%v.*RHS.*syntax", s.opName), false)
-	s.UMTC(p, s.A(s.opName, "10", "11"), s.newOp(newMockP("10"), newMockP("11")))
+func (s *BinOpTestSuite) TestUnmarshalErrors() {
+	s.UMETC("foo", fmt.Sprintf(`formatted.*"%v".*<pe>.*<pe>`, s.opName), true)
+	s.UMETC(s.A(s.opName, "10", "11", "12"), fmt.Sprintf(`"%v".*<pe>.*<pe>`, s.opName), false)
+	s.UMETC(s.A(s.opName), fmt.Sprintf("%v.*LHS.*RHS.*expression", s.opName), false)
+	s.UMETC(s.A(s.opName, "10"), fmt.Sprintf("%v.*LHS.*RHS.*expression", s.opName), false)
+	s.UMETC(s.A(s.opName, "syntax", "10"), fmt.Sprintf("%v.*LHS.*syntax", s.opName), false)
+	s.UMETC(s.A(s.opName, "10", "syntax"), fmt.Sprintf("%v.*RHS.*syntax", s.opName), false)
 }
 
 func (s *BinOpTestSuite) TestEvalEntry() {
 	s.testEvalMethod(
 		s,
-		func(s *BinOpTestSuite, n rql.ASTNode, falseV interface{}) {
-			s.EEFTC(n, falseV.(rql.Entry))
+		func(s *BinOpTestSuite, ast interface{}, falseV interface{}) {
+			s.EEFTC(ast, falseV.(rql.Entry))
 		},
-		func(s *BinOpTestSuite, n rql.ASTNode, trueV interface{}) {
-			s.EETTC(n, trueV.(rql.Entry))
+		func(s *BinOpTestSuite, ast interface{}, trueV interface{}) {
+			s.EETTC(ast, trueV.(rql.Entry))
 		},
 		func(s string) interface{} {
 			e := rql.Entry{}
@@ -56,11 +53,11 @@ func (s *BinOpTestSuite) TestEvalEntry() {
 func (s *BinOpTestSuite) TestEvalEntrySchema() {
 	s.testEvalMethod(
 		s,
-		func(s *BinOpTestSuite, n rql.ASTNode, falseV interface{}) {
-			s.EESFTC(n, falseV.(*rql.EntrySchema))
+		func(s *BinOpTestSuite, ast interface{}, falseV interface{}) {
+			s.EESFTC(ast, falseV.(*rql.EntrySchema))
 		},
-		func(s *BinOpTestSuite, n rql.ASTNode, trueV interface{}) {
-			s.EESTTC(n, trueV.(*rql.EntrySchema))
+		func(s *BinOpTestSuite, ast interface{}, trueV interface{}) {
+			s.EESTTC(ast, trueV.(*rql.EntrySchema))
 		},
 		func(s string) interface{} {
 			es := &rql.EntrySchema{}
@@ -73,11 +70,11 @@ func (s *BinOpTestSuite) TestEvalEntrySchema() {
 func (s *BinOpTestSuite) TestEvalValue() {
 	s.testEvalMethod(
 		s,
-		func(s *BinOpTestSuite, n rql.ASTNode, falseV interface{}) {
-			s.EVFTC(n, falseV)
+		func(s *BinOpTestSuite, ast interface{}, falseV interface{}) {
+			s.EVFTC(ast, falseV)
 		},
-		func(s *BinOpTestSuite, n rql.ASTNode, trueV interface{}) {
-			s.EVTTC(n, trueV)
+		func(s *BinOpTestSuite, ast interface{}, trueV interface{}) {
+			s.EVTTC(ast, trueV)
 		},
 		func(s string) interface{} {
 			return s
@@ -88,11 +85,11 @@ func (s *BinOpTestSuite) TestEvalValue() {
 func (s *BinOpTestSuite) TestEvalValueSchema() {
 	s.testEvalMethod(
 		s,
-		func(s *BinOpTestSuite, n rql.ASTNode, falseV interface{}) {
-			s.EVSFTC(n, falseV.(map[string]interface{}))
+		func(s *BinOpTestSuite, ast interface{}, falseV interface{}) {
+			s.EVSFTC(ast, falseV.(map[string]interface{}))
 		},
-		func(s *BinOpTestSuite, n rql.ASTNode, trueV interface{}) {
-			s.EVSTTC(n, trueV.(map[string]interface{}))
+		func(s *BinOpTestSuite, ast interface{}, trueV interface{}) {
+			s.EVSTTC(ast, trueV.(map[string]interface{}))
 		},
 		func(s string) interface{} {
 			return map[string]interface{}{
@@ -111,11 +108,11 @@ func (s *BinOpTestSuite) TestEvalValueSchema() {
 func (s *BinOpTestSuite) TestEvalString() {
 	s.testEvalMethod(
 		s,
-		func(s *BinOpTestSuite, n rql.ASTNode, falseV interface{}) {
-			s.ESFTC(n, falseV.(string))
+		func(s *BinOpTestSuite, ast interface{}, falseV interface{}) {
+			s.ESFTC(ast, falseV.(string))
 		},
-		func(s *BinOpTestSuite, n rql.ASTNode, trueV interface{}) {
-			s.ESTTC(n, trueV.(string))
+		func(s *BinOpTestSuite, ast interface{}, trueV interface{}) {
+			s.ESTTC(ast, trueV.(string))
 		},
 		func(s string) interface{} {
 			return s
@@ -126,11 +123,11 @@ func (s *BinOpTestSuite) TestEvalString() {
 func (s *BinOpTestSuite) TestEvalNumeric() {
 	s.testEvalMethod(
 		s,
-		func(s *BinOpTestSuite, n rql.ASTNode, falseV interface{}) {
-			s.ENFTC(n, falseV.(decimal.Decimal))
+		func(s *BinOpTestSuite, ast interface{}, falseV interface{}) {
+			s.ENFTC(ast, falseV.(decimal.Decimal))
 		},
-		func(s *BinOpTestSuite, n rql.ASTNode, trueV interface{}) {
-			s.ENTTC(n, trueV.(decimal.Decimal))
+		func(s *BinOpTestSuite, ast interface{}, trueV interface{}) {
+			s.ENTTC(ast, trueV.(decimal.Decimal))
 		},
 		func(s string) interface{} {
 			d, err := decimal.NewFromString(s)
@@ -145,11 +142,11 @@ func (s *BinOpTestSuite) TestEvalNumeric() {
 func (s *BinOpTestSuite) TestEvalTime() {
 	s.testEvalMethod(
 		s,
-		func(s *BinOpTestSuite, n rql.ASTNode, falseV interface{}) {
-			s.ETFTC(n, falseV.(time.Time))
+		func(s *BinOpTestSuite, ast interface{}, falseV interface{}) {
+			s.ETFTC(ast, falseV.(time.Time))
 		},
-		func(s *BinOpTestSuite, n rql.ASTNode, trueV interface{}) {
-			s.ETTTC(n, trueV.(time.Time))
+		func(s *BinOpTestSuite, ast interface{}, trueV interface{}) {
+			s.ETTTC(ast, trueV.(time.Time))
 		},
 		func(s string) interface{} {
 			d, err := decimal.NewFromString(s)
@@ -164,11 +161,11 @@ func (s *BinOpTestSuite) TestEvalTime() {
 func (s *BinOpTestSuite) TestEvalAction() {
 	s.testEvalMethod(
 		s,
-		func(s *BinOpTestSuite, n rql.ASTNode, falseV interface{}) {
-			s.EAFTC(n, falseV.(plugin.Action))
+		func(s *BinOpTestSuite, ast interface{}, falseV interface{}) {
+			s.EAFTC(ast, falseV.(plugin.Action))
 		},
-		func(s *BinOpTestSuite, n rql.ASTNode, trueV interface{}) {
-			s.EATTC(n, trueV.(plugin.Action))
+		func(s *BinOpTestSuite, ast interface{}, trueV interface{}) {
+			s.EATTC(ast, trueV.(plugin.Action))
 		},
 		func(s string) interface{} {
 			return plugin.Action{Name: s}

--- a/api/rql/internal/predicate/expression/expression_test.go
+++ b/api/rql/internal/predicate/expression/expression_test.go
@@ -26,23 +26,18 @@ type ExpressionTestSuite struct {
 	asttest.Suite
 }
 
-func (s *ExpressionTestSuite) UMTC(input interface{}, expected interface{}) {
-	e := s.mockExpression(true)
-	if s.NoError(e.Unmarshal(input)) {
-		s.Equal(expected, e.Marshal())
-	}
-}
-
 func (s *ExpressionTestSuite) TestUnmarshal_PE_Errors() {
-	e := s.mockExpression(false)
-	s.UMETC(e, 1, "expected.*PE.*mock.*predicate", true)
-	s.UMETC(e, s.A("NOT", "p"), "expected.*PE.*mock.*predicate", true)
-	s.UMETC(e, "syntax", "failed.*unmarshal.*PE.*mock.*predicate.*syntax.*error", false)
+	s.NodeConstructor = func() rql.ASTNode {
+		return s.mockExpression(false)
+	}
+	s.UMETC(1, "expected.*PE.*mock.*predicate", true)
+	s.UMETC(s.A("NOT", "p"), "expected.*PE.*mock.*predicate", true)
+	s.UMETC("syntax", "failed.*unmarshal.*PE.*mock.*predicate.*syntax.*error", false)
 
 	// Here we test that the operators fail to unmarshal "NOT"
 	for _, op := range []string{"AND", "OR"} {
-		s.UMETC(e, s.A(op, s.A("NOT", "p"), "p"), "error.*LHS.*PE", false)
-		s.UMETC(e, s.A(op, "p", s.A("NOT", "p")), "error.*RHS.*PE", false)
+		s.UMETC(s.A(op, s.A("NOT", "p"), "p"), "error.*LHS.*PE", false)
+		s.UMETC(s.A(op, "p", s.A("NOT", "p")), "error.*RHS.*PE", false)
 	}
 }
 
@@ -65,9 +60,11 @@ func (s *ExpressionTestSuite) TestUnmarshal_PE() {
 }
 
 func (s *ExpressionTestSuite) TestUnmarshal_NPE_Errors() {
-	e := s.mockExpression(true)
-	s.UMETC(e, 1, "expected.*NPE.*mock.*predicate", true)
-	s.UMETC(e, "syntax", "failed.*unmarshal.*NPE.*mock.*predicate.*syntax.*error", false)
+	s.NodeConstructor = func() rql.ASTNode {
+		return s.mockExpression(true)
+	}
+	s.UMETC(1, "expected.*NPE.*mock.*predicate", true)
+	s.UMETC("syntax", "failed.*unmarshal.*NPE.*mock.*predicate.*syntax.*error", false)
 }
 
 func (s *ExpressionTestSuite) TestUnmarshal_NPE() {
@@ -186,12 +183,10 @@ func (p *mockPtype) EvalTime(t time.Time) bool {
 }
 
 func (p *mockPtype) EvalAction(action plugin.Action) bool {
-	fmt.Printf("p VALUE == %v\n", p.v)
 	return p.v == action.Name
 }
 
 func (p *mockPtype) SchemaPredicate(svs meta.SatisfyingValueSchema) meta.SchemaPredicate {
-	fmt.Printf("p VALUE == %v\n", p.v)
 	return meta.MakeSchemaPredicate(svs.AddObject(p.v).EndsWithPrimitiveValue())
 }
 

--- a/api/rql/internal/predicate/expression/not_test.go
+++ b/api/rql/internal/predicate/expression/not_test.go
@@ -3,6 +3,7 @@ package expression
 import (
 	"testing"
 
+	"github.com/puppetlabs/wash/api/rql"
 	"github.com/puppetlabs/wash/api/rql/ast/asttest"
 	"github.com/stretchr/testify/suite"
 )
@@ -19,15 +20,17 @@ func (s *NotTestSuite) TestMarshal() {
 	s.MTC(Not(newMockP("10")), s.A("NOT", "10"))
 }
 
-func (s *NotTestSuite) TestUnmarshal() {
-	p := Not(&mockPtype{})
-	s.UMETC(p, 1, `formatted.*"NOT".*<pe>`, true)
-	s.UMETC(p, s.A("NOT", "10", "11"), `formatted.*"NOT".*<pe>`, false)
-	s.UMETC(p, s.A("NOT"), "NOT.*expression", false)
-	s.UMETC(p, s.A("NOT", 1), "NOT.*error.*expression.*string", false)
-	s.UMTC(p, s.A("NOT", "10"), Not(newMockP("10")))
+func (s *NotTestSuite) TestUnmarshalErrors() {
+	s.UMETC(1, `formatted.*"NOT".*<pe>`, true)
+	s.UMETC(s.A("NOT", "10", "11"), `formatted.*"NOT".*<pe>`, false)
+	s.UMETC(s.A("NOT"), "NOT.*expression", false)
+	s.UMETC(s.A("NOT", 1), "NOT.*error.*expression.*string", false)
 }
 
 func TestNot(t *testing.T) {
-	suite.Run(t, new(NotTestSuite))
+	s := new(NotTestSuite)
+	s.DefaultNodeConstructor = func() rql.ASTNode {
+		return Not(&mockPtype{})
+	}
+	suite.Run(t, s)
 }

--- a/api/rql/internal/predicate/expression/or_test.go
+++ b/api/rql/internal/predicate/expression/or_test.go
@@ -3,24 +3,27 @@ package expression
 import (
 	"testing"
 
+	"github.com/puppetlabs/wash/api/rql"
 	"github.com/stretchr/testify/suite"
 )
 
 func TestOr(t *testing.T) {
 	s := new(BinOpTestSuite)
+	s.DefaultNodeConstructor = func() rql.ASTNode {
+		return Or(newMockP(""), newMockP(""))
+	}
 	s.opName = "OR"
-	s.newOp = Or
 	s.testEvalMethod = func(s *BinOpTestSuite, RFTC TCRunFunc, RTTC TCRunFunc, constructV func(string) interface{}) {
-		p := Or(newMockP("1"), newMockP("2"))
+		ast := s.A("OR", "1", "2")
 		// p1 == false, p2 == false
-		RFTC(s, p, constructV("3"))
+		RFTC(s, ast, constructV("3"))
 		// false, true
-		RTTC(s, p, constructV("2"))
+		RTTC(s, ast, constructV("2"))
 		// true, false
-		RTTC(s, p, constructV("1"))
+		RTTC(s, ast, constructV("1"))
 		// true, true
-		p.(*or).p2 = p.(*or).p1
-		RTTC(s, p, constructV("1"))
+		ast = s.A("OR", "1", "1")
+		RTTC(s, ast, constructV("1"))
 	}
 	suite.Run(t, s)
 }

--- a/api/rql/internal/predicate/null_test.go
+++ b/api/rql/internal/predicate/null_test.go
@@ -17,36 +17,33 @@ func (s *NullTestSuite) TestMarshal() {
 	s.MTC(Null(), nil)
 }
 
-func (s *NullTestSuite) TestUnmarshal() {
-	n := Null()
-	s.UMETC(n, "foo", ".*null", true)
-	s.UMTC(n, nil, Null())
+func (s *NullTestSuite) TestUnmarshalErrors() {
+	s.UMETC("foo", ".*null", true)
 }
 
 func (s *NullTestSuite) TestEvalValue() {
-	n := Null()
-	s.EVFTC(n, "foo", 1, true)
-	s.EVTTC(n, nil)
+	s.EVFTC(nil, "foo", 1, true)
+	s.EVTTC(nil, nil)
 }
 
 func (s NullTestSuite) TestEvalValueSchema() {
-	n := Null()
-	s.EVSFTC(n, s.VS("object", "array")...)
-	s.EVSTTC(n, s.VS("null")...)
+	s.EVSFTC(nil, s.VS("object", "array")...)
+	s.EVSTTC(nil, s.VS("null")...)
 }
 
 func (s *NullTestSuite) TestExpression_AtomAndNot() {
-	expr := expression.New("null", true, func() rql.ASTNode {
-		return Null()
-	})
+	s.NodeConstructor = func() rql.ASTNode {
+		return expression.New("null", true, func() rql.ASTNode {
+			return Null()
+		})
+	}
 
-	s.MUM(expr, nil)
-	s.EVFTC(expr, "foo", 1, true)
-	s.EVTTC(expr, nil)
-	s.EVSFTC(expr, s.VS("object", "array")...)
-	s.EVSTTC(expr, s.VS("null")...)
+	s.EVFTC(nil, "foo", 1, true)
+	s.EVTTC(nil, nil)
+	s.EVSFTC(nil, s.VS("object", "array")...)
+	s.EVSTTC(nil, s.VS("null")...)
 	s.AssertNotImplemented(
-		expr,
+		nil,
 		asttest.EntryPredicateC,
 		asttest.EntrySchemaPredicateC,
 		asttest.StringPredicateC,
@@ -55,12 +52,15 @@ func (s *NullTestSuite) TestExpression_AtomAndNot() {
 		asttest.ActionPredicateC,
 	)
 
-	s.MUM(expr, []interface{}{"NOT", nil})
-	s.EVTTC(expr, "foo", 1, true)
-	s.EVFTC(expr, nil)
-	s.EVSTTC(expr, s.VS("null", "object", "array")...)
+	s.EVTTC(s.A("NOT", nil), "foo", 1, true)
+	s.EVFTC(s.A("NOT", nil), nil)
+	s.EVSTTC(s.A("NOT", nil), s.VS("null", "object", "array")...)
 }
 
 func TestNull(t *testing.T) {
-	suite.Run(t, new(NullTestSuite))
+	s := new(NullTestSuite)
+	s.DefaultNodeConstructor = func() rql.ASTNode {
+		return Null()
+	}
+	suite.Run(t, s)
 }

--- a/api/rql/internal/predicate/numeric_test.go
+++ b/api/rql/internal/predicate/numeric_test.go
@@ -10,75 +10,80 @@ import (
 )
 
 type NumericTestSuite struct {
-	PrimitiveValueTestSuite
+	asttest.Suite
 }
 
-func (s *NumericTestSuite) TestNumeric_Marshal() {
+func (s *NumericTestSuite) TestMarshal() {
 	s.MTC(Numeric(LT, s.N("2.3")), s.A("<", "2.3"))
 }
 
-func (s *NumericTestSuite) TestNumeric_Unmarshal() {
-	n := Numeric("", s.N("0"))
-	s.UMETC(n, "foo", "formatted.*<comparison_op>.*<number>", true)
-	s.UMETC(n, s.A(), "formatted.*<comparison_op>.*<number>", true)
-	s.UMETC(n, s.A("<", "foo", "bar"), "formatted.*<comparison_op>.*<number>", false)
-	s.UMETC(n, s.A("<"), "formatted.*<comparison_op>.*<number>.*missing.*number", false)
-	s.UMETC(n, s.A("<", true), "valid.*number", false)
-	s.UMETC(n, s.A("<", "true"), "parse.*true.*number.*exponent", false)
-	s.UMTC(n, s.A("<", 2.3), Numeric(LT, s.N("2.3")))
-	s.UMTC(n, s.A("<", "2.3"), Numeric(LT, s.N("2.3")))
-	// Test unmarshaling a very large value
-	largeV := "10000000000000000000000000000000000000000000000000000000000000000000"
-	s.UMTC(n, s.A("<", largeV), Numeric(LT, s.N(largeV)))
+func (s *NumericTestSuite) TestUnmarshalErrors() {
+	s.UMETC("foo", "formatted.*<comparison_op>.*<number>", true)
+	s.UMETC(s.A(), "formatted.*<comparison_op>.*<number>", true)
+	s.UMETC(s.A("<", "foo", "bar"), "formatted.*<comparison_op>.*<number>", false)
+	s.UMETC(s.A("<"), "formatted.*<comparison_op>.*<number>.*missing.*number", false)
+	s.UMETC(s.A("<", true), "valid.*number", false)
+	s.UMETC(s.A("<", "true"), "parse.*true.*number.*exponent", false)
 }
 
-func (s *NumericTestSuite) TestNumeric_UnmarshalUnsigned() {
-	n := UnsignedNumeric("", s.N("0"))
-	s.UMETC(n, s.A("<", "-10"), "unsigned.*number", false)
+func (s *NumericTestSuite) TestUnmarshalErrors_Unsigned() {
+	s.NodeConstructor = func() rql.ASTNode {
+		return UnsignedNumeric("", s.N("0"))
+	}
+	s.UMETC(s.A("<", "-10"), "unsigned.*number", false)
 }
 
-func (s *NumericTestSuite) TestNumeric_EvalNumeric() {
-	// Test LT
-	n := Numeric(LT, s.N("1"))
-	s.ENFTC(n, s.N("2"), s.N("1"))
-	s.ENTTC(n, s.N("0"))
+func (s *NumericTestSuite) TestEvalNumeric() {
+	// Test LT, and also test
+	ast := s.A("<", "1")
+	s.ENFTC(ast, s.N("2"), s.N("1"))
+	s.ENTTC(ast, s.N("0"))
 
 	// Test LTE
-	n = Numeric(LTE, s.N("1"))
-	s.ENFTC(n, s.N("2"))
-	s.ENTTC(n, s.N("0"), s.N("1"))
+	ast = s.A("<=", "1")
+	s.ENFTC(ast, s.N("2"))
+	s.ENTTC(ast, s.N("0"), s.N("1"))
 
 	// Test GT
-	n = Numeric(GT, s.N("1"))
-	s.ENFTC(n, s.N("0"), s.N("1"))
-	s.ENTTC(n, s.N("2"))
+	ast = s.A(">", "1")
+	s.ENFTC(ast, s.N("0"), s.N("1"))
+	s.ENTTC(ast, s.N("2"))
 
 	// Test GTE
-	n = Numeric(GTE, s.N("1"))
-	s.ENFTC(n, s.N("0"))
-	s.ENTTC(n, s.N("2"), s.N("1"))
+	ast = s.A(">=", "1")
+	s.ENFTC(ast, s.N("0"))
+	s.ENTTC(ast, s.N("2"), s.N("1"))
 
 	// Test EQL
-	n = Numeric(EQL, s.N("1"))
-	s.ENFTC(n, s.N("0"), s.N("2"))
-	s.ENTTC(n, s.N("1"))
+	ast = s.A("=", "1")
+	s.ENFTC(ast, s.N("0"), s.N("2"))
+	s.ENTTC(ast, s.N("1"))
 
 	// TEST NEQL
-	n = Numeric(NEQL, s.N("1"))
-	s.ENFTC(n, s.N("1"))
-	s.ENTTC(n, s.N("0"), s.N("2"))
+	ast = s.A("!=", "1")
+	s.ENFTC(ast, s.N("1"))
+	s.ENTTC(ast, s.N("0"), s.N("2"))
+
+	// Test that we can unmarshal numbers from different types
+	// (float64) and that we can unmarshal very large values
+	s.ENTTC(s.A("<", 1), s.N("0"))
+	largeV := "10000000000000000000000000000000000000000000000000000000000000000000"
+	s.ENTTC(s.A("<", largeV), s.N(largeV[0:10]))
+	s.ENTTC(s.A(">", largeV), s.N(largeV+"0"))
 }
 
-func (s *NumericTestSuite) TestNumeric_Expression_AtomAndNot() {
-	expr := expression.New("numeric", true, func() rql.ASTNode {
-		return Numeric("", s.N("0"))
-	})
+func (s *NumericTestSuite) TestExpression_AtomAndNot() {
+	s.NodeConstructor = func() rql.ASTNode {
+		return expression.New("numeric", true, func() rql.ASTNode {
+			return Numeric("", s.N("0"))
+		})
+	}
 
-	s.MUM(expr, []interface{}{"<", "1"})
-	s.ENFTC(expr, s.N("1"))
-	s.ENTTC(expr, s.N("0"))
+	ast := s.A("<", "1")
+	s.ENFTC(ast, s.N("1"))
+	s.ENTTC(ast, s.N("0"))
 	s.AssertNotImplemented(
-		expr,
+		ast,
 		asttest.EntryPredicateC,
 		asttest.EntrySchemaPredicateC,
 		asttest.ValuePredicateC,
@@ -87,49 +92,61 @@ func (s *NumericTestSuite) TestNumeric_Expression_AtomAndNot() {
 		asttest.ActionPredicateC,
 	)
 
-	s.MUM(expr, []interface{}{"NOT", []interface{}{"<", "1"}})
-	s.ENTTC(expr, s.N("1"))
-	s.ENFTC(expr, s.N("0"))
+	notAST := s.A("NOT", ast)
+	s.ENTTC(notAST, s.N("1"))
+	s.ENFTC(notAST, s.N("0"))
 }
 
-func (s *NumericTestSuite) TestNumericValue_Marshal() {
+func TestNumeric(t *testing.T) {
+	s := new(NumericTestSuite)
+	s.DefaultNodeConstructor = func() rql.ASTNode {
+		return Numeric("", s.N("0"))
+	}
+	suite.Run(t, s)
+}
+
+type NumericValueTestSuite struct {
+	PrimitiveValueTestSuite
+}
+
+func (s *NumericValueTestSuite) TestMarshal() {
 	s.MTC(NumericValue(Numeric(LT, s.N("2.3"))), s.A("number", s.A("<", "2.3")))
 }
 
-func (s *NumericTestSuite) TestNumericValue_Unmarshal() {
-	n := NumericValue(Numeric("", s.N("0")))
-	s.UMETC(n, "foo", "formatted.*number.*NPE NumericPredicate", true)
-	s.UMETC(n, s.A("number", "foo", "bar"), "formatted.*number.*NPE NumericPredicate", false)
-	s.UMETC(n, s.A("number"), "formatted.*number.*NPE NumericPredicate.*missing.*NPE NumericPredicate", false)
-	s.UMETC(n, s.A("number", s.A()), "unmarshalling.*NPE NumericPredicate.*formatted.*<comparison_op>.*<number>", false)
-	s.UMTC(n, s.A("number", s.A("<", "2.3")), NumericValue(Numeric(LT, s.N("2.3"))))
+func (s *NumericValueTestSuite) TestUnmarshalErrors() {
+	s.UMETC("foo", "formatted.*number.*NPE NumericPredicate", true)
+	s.UMETC(s.A("number", "foo", "bar"), "formatted.*number.*NPE NumericPredicate", false)
+	s.UMETC(s.A("number"), "formatted.*number.*NPE NumericPredicate.*missing.*NPE NumericPredicate", false)
+	s.UMETC(s.A("number", s.A()), "unmarshalling.*NPE NumericPredicate.*formatted.*<comparison_op>.*<number>", false)
 }
 
-func (s *NumericTestSuite) TestNumericValue_EvalValue() {
-	n := NumericValue(Numeric(LT, s.N("2.0")))
-	s.EVFTC(n, float64(3), "1")
-	s.EVTTC(n, float64(1))
+func (s *NumericValueTestSuite) TestEvalValue() {
+	ast := s.A("number", s.A("<", "2.0"))
+	s.EVFTC(ast, 3, "1")
+	s.EVTTC(ast, 1)
 	// TestEvalNumeric contained the operator-specific test-cases
 }
 
-func (s NumericTestSuite) TestNumericValue_EvalValueSchema() {
-	n := NumericValue(Numeric(LT, s.N("2.0")))
-	s.EVSFTC(n, s.VS("object", "array")...)
-	s.EVSTTC(n, s.VS("integer", "number", "string")...)
+func (s NumericValueTestSuite) TestEvalValueSchema() {
+	ast := s.A("number", s.A("<", "2.0"))
+	s.EVSFTC(ast, s.VS("object", "array")...)
+	s.EVSTTC(ast, s.VS("integer", "number", "string")...)
 }
 
-func (s *NumericTestSuite) TestNumericValue_Expression_AtomAndNot() {
-	expr := expression.New("numeric", true, func() rql.ASTNode {
-		return NumericValue(Numeric("", s.N("0")))
-	})
+func (s *NumericValueTestSuite) TestExpression_AtomAndNot() {
+	s.NodeConstructor = func() rql.ASTNode {
+		return expression.New("numeric", true, func() rql.ASTNode {
+			return NumericValue(Numeric("", s.N("0")))
+		})
+	}
 
-	s.MUM(expr, []interface{}{"number", []interface{}{"<", "1"}})
-	s.EVFTC(expr, float64(1))
-	s.EVTTC(expr, float64(0))
-	s.EVSFTC(expr, s.VS("object", "array")...)
-	s.EVSTTC(expr, s.VS("integer", "number", "string")...)
+	ast := s.A("number", s.A("<", "1"))
+	s.EVFTC(ast, float64(1))
+	s.EVTTC(ast, float64(0))
+	s.EVSFTC(ast, s.VS("object", "array")...)
+	s.EVSTTC(ast, s.VS("integer", "number", "string")...)
 	s.AssertNotImplemented(
-		expr,
+		ast,
 		asttest.EntryPredicateC,
 		asttest.EntrySchemaPredicateC,
 		asttest.StringPredicateC,
@@ -137,12 +154,16 @@ func (s *NumericTestSuite) TestNumericValue_Expression_AtomAndNot() {
 		asttest.ActionPredicateC,
 	)
 
-	s.MUM(expr, []interface{}{"NOT", []interface{}{"number", []interface{}{"<", "1"}}})
-	s.EVTTC(expr, float64(1))
-	s.EVFTC(expr, float64(0))
-	s.EVSTTC(expr, s.VS("object", "array", "integer", "number", "string")...)
+	notAST := s.A("NOT", ast)
+	s.EVTTC(notAST, float64(1))
+	s.EVFTC(notAST, float64(0))
+	s.EVSTTC(notAST, s.VS("object", "array", "integer", "number", "string")...)
 }
 
-func TestNumeric(t *testing.T) {
-	suite.Run(t, new(NumericTestSuite))
+func TestNumericValue(t *testing.T) {
+	s := new(NumericValueTestSuite)
+	s.DefaultNodeConstructor = func() rql.ASTNode {
+		return NumericValue(Numeric("", s.N("0")))
+	}
+	suite.Run(t, s)
 }

--- a/api/rql/internal/predicate/size_test.go
+++ b/api/rql/internal/predicate/size_test.go
@@ -19,44 +19,43 @@ func (s *SizeTestSuite) TestMarshal() {
 	s.MTC(Size(UnsignedNumeric(LT, s.N("10"))), s.A("size", s.A("<", "10")))
 }
 
-func (s *SizeTestSuite) TestUnmarshal() {
-	p := Size(UnsignedNumeric("", s.N("0")))
-	s.UMETC(p, "foo", `size.*formatted.*"size".*PE NumericPredicate`, true)
-	s.UMETC(p, s.A("foo"), `size.*formatted.*"size".*PE NumericPredicate`, true)
-	s.UMETC(p, s.A("size", "foo", "bar"), `size.*formatted.*"size".*PE NumericPredicate`, false)
-	s.UMETC(p, s.A("size"), `size.*formatted.*"size".*PE NumericPredicate.*missing.*PE NumericPredicate`, false)
-	s.UMETC(p, s.A("size", s.A("<", true)), "size.*PE NumericPredicate.*valid.*number", false)
-	s.UMETC(p, s.A("size", s.A("<", "-10")), "size.*PE NumericPredicate.*unsigned.*number", false)
-	s.UMTC(p, s.A("size", s.A("<", "10")), Size(UnsignedNumeric(LT, s.N("10"))))
+func (s *SizeTestSuite) TestUnmarshalErrors() {
+	s.UMETC("foo", `size.*formatted.*"size".*PE NumericPredicate`, true)
+	s.UMETC(s.A("foo"), `size.*formatted.*"size".*PE NumericPredicate`, true)
+	s.UMETC(s.A("size", "foo", "bar"), `size.*formatted.*"size".*PE NumericPredicate`, false)
+	s.UMETC(s.A("size"), `size.*formatted.*"size".*PE NumericPredicate.*missing.*PE NumericPredicate`, false)
+	s.UMETC(s.A("size", s.A("<", true)), "size.*PE NumericPredicate.*valid.*number", false)
+	s.UMETC(s.A("size", s.A("<", "-10")), "size.*PE NumericPredicate.*unsigned.*number", false)
 }
 
 func (s *SizeTestSuite) TestEvalEntry() {
-	p := Size(UnsignedNumeric(GT, s.N("0")))
+	ast := s.A("size", s.A(">", "0"))
 	e := rql.Entry{}
 	e.Attributes.SetSize(uint64(0))
-	s.EEFTC(p, e)
+	s.EEFTC(ast, e)
 	e.Attributes.SetSize(uint64(1))
-	s.EETTC(p, e)
+	s.EETTC(ast, e)
 }
 
 func (s *SizeTestSuite) TestExpression_Atom() {
-	expr := expression.New("size", true, func() rql.ASTNode {
-		return Size(UnsignedNumeric("", s.N("0")))
-	})
+	s.NodeConstructor = func() rql.ASTNode {
+		return expression.New("size", true, func() rql.ASTNode {
+			return Size(UnsignedNumeric("", s.N("0")))
+		})
+	}
 
-	s.MUM(expr, []interface{}{"size", []interface{}{">", "0"}})
-
+	ast := s.A("size", s.A(">", "0"))
 	e := rql.Entry{}
 	e.Attributes.SetSize(uint64(0))
-	s.EEFTC(expr, e)
+	s.EEFTC(ast, e)
 	e.Attributes.SetSize(uint64(1))
-	s.EETTC(expr, e)
+	s.EETTC(ast, e)
 
 	schema := &rql.EntrySchema{}
-	s.EESTTC(expr, schema)
+	s.EESTTC(ast, schema)
 
 	s.AssertNotImplemented(
-		expr,
+		ast,
 		asttest.StringPredicateC,
 		asttest.NumericPredicateC,
 		asttest.TimePredicateC,
@@ -65,5 +64,9 @@ func (s *SizeTestSuite) TestExpression_Atom() {
 }
 
 func TestSize(t *testing.T) {
-	suite.Run(t, new(SizeTestSuite))
+	s := new(SizeTestSuite)
+	s.DefaultNodeConstructor = func() rql.ASTNode {
+		return Size(UnsignedNumeric("", s.N("0")))
+	}
+	suite.Run(t, s)
 }

--- a/api/rql/internal/predicate/string_test.go
+++ b/api/rql/internal/predicate/string_test.go
@@ -11,108 +11,136 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-type StringTestSuite struct {
-	PrimitiveValueTestSuite
+type StringGlobTestSuite struct {
+	asttest.Suite
 }
 
-func (s *StringTestSuite) TestGlob_Marshal() {
+func (s *StringGlobTestSuite) TestMarshal() {
 	s.MTC(StringGlob("foo"), s.A("glob", "foo"))
 }
 
-func (s *StringTestSuite) TestGlob_Unmarshal() {
-	g := StringGlob("")
-	s.UMETC(g, "foo", `formatted.*"glob".*<glob>`, true)
-	s.UMETC(g, s.A("foo"), `formatted.*"glob".*<glob>`, true)
-	s.UMETC(g, s.A("glob", "foo", "bar"), `formatted.*"glob".*<glob>`, false)
-	s.UMETC(g, s.A("glob"), `formatted.*"glob".*<glob>.*missing.*glob`, false)
-	s.UMETC(g, s.A("glob", 1), "glob.*string", false)
-	s.UMETC(g, s.A("glob", "["), "invalid.*glob.*[.*closing.*]", false)
-	s.UMTC(g, s.A("glob", "foo"), StringGlob("foo"))
+func (s *StringGlobTestSuite) TestUnmarshalErrors() {
+	s.UMETC("foo", `formatted.*"glob".*<glob>`, true)
+	s.UMETC(s.A("foo"), `formatted.*"glob".*<glob>`, true)
+	s.UMETC(s.A("glob", "foo", "bar"), `formatted.*"glob".*<glob>`, false)
+	s.UMETC(s.A("glob"), `formatted.*"glob".*<glob>.*missing.*glob`, false)
+	s.UMETC(s.A("glob", 1), "glob.*string", false)
+	s.UMETC(s.A("glob", "["), "invalid.*glob.*[.*closing.*]", false)
 }
 
-func (s *StringTestSuite) TestGlob_EvalString() {
-	g := StringGlob("foo")
-	s.ESFTC(g, "bar")
-	s.ESTTC(g, "foo")
+func (s *StringGlobTestSuite) TestEvalString() {
+	ast := s.A("glob", "foo")
+	s.ESFTC(ast, "bar")
+	s.ESTTC(ast, "foo")
 }
 
-func (s *StringTestSuite) TestRegex_Marshal() {
+func TestStringGlob(t *testing.T) {
+	s := new(StringGlobTestSuite)
+	s.DefaultNodeConstructor = func() rql.ASTNode {
+		return StringGlob("")
+	}
+	suite.Run(t, s)
+}
+
+type StringRegexTestSuite struct {
+	asttest.Suite
+}
+
+func (s *StringRegexTestSuite) TestMarshal() {
 	s.MTC(StringRegex(regexp.MustCompile("foo")), s.A("regex", "foo"))
 }
 
-func (s *StringTestSuite) TestRegex_Unmarshal() {
-	r := StringRegex(nil)
-	s.UMETC(r, "foo", `formatted.*"regex".*<regex>`, true)
-	s.UMETC(r, s.A("foo"), `formatted.*"regex".*<regex>`, true)
-	s.UMETC(r, s.A("regex", "foo", "bar"), `formatted.*"regex".*<regex>`, false)
-	s.UMETC(r, s.A("regex"), `formatted.*"regex".*<regex>.*missing.*regex`, false)
-	s.UMETC(r, s.A("regex", 1), "regex.*string", false)
-	s.UMETC(r, s.A("regex", "["), "invalid.*regex.*[.*closing.*]", false)
-	s.UMTC(r, s.A("regex", "foo"), StringRegex(regexp.MustCompile("foo")))
+func (s *StringRegexTestSuite) TestUnmarshalErrors() {
+	s.UMETC("foo", `formatted.*"regex".*<regex>`, true)
+	s.UMETC(s.A("foo"), `formatted.*"regex".*<regex>`, true)
+	s.UMETC(s.A("regex", "foo", "bar"), `formatted.*"regex".*<regex>`, false)
+	s.UMETC(s.A("regex"), `formatted.*"regex".*<regex>.*missing.*regex`, false)
+	s.UMETC(s.A("regex", 1), "regex.*string", false)
+	s.UMETC(s.A("regex", "["), "invalid.*regex.*[.*closing.*]", false)
 }
 
-func (s *StringTestSuite) TestRegex_EvalString() {
-	r := StringRegex(regexp.MustCompile("foo"))
-	s.ESFTC(r, "bar")
-	s.ESTTC(r, "foo")
+func (s *StringRegexTestSuite) TestEvalString() {
+	ast := s.A("regex", "foo")
+	s.ESFTC(ast, "bar")
+	s.ESTTC(ast, "foo")
 }
 
-func (s *StringTestSuite) TestEqual_Marshal() {
+func TestStringRegex(t *testing.T) {
+	s := new(StringRegexTestSuite)
+	s.DefaultNodeConstructor = func() rql.ASTNode {
+		return StringRegex(nil)
+	}
+	suite.Run(t, s)
+}
+
+type StringEqualTestSuite struct {
+	asttest.Suite
+}
+
+func (s *StringEqualTestSuite) TestMarshal() {
 	s.MTC(StringEqual("foo"), s.A("=", "foo"))
 }
 
-func (s *StringTestSuite) TestEqual_Unmarshal() {
-	e := StringEqual("")
-	s.UMETC(e, "foo", `formatted.*"=".*<str>`, true)
-	s.UMETC(e, s.A("foo"), `formatted.*"=".*<str>`, true)
-	s.UMETC(e, s.A("=", "foo", "bar"), `formatted.*"=".*<str>`, false)
-	s.UMETC(e, s.A("="), `formatted.*"=".*<str>.*missing.*string`, false)
-	s.UMETC(e, s.A("=", 1), "string", false)
-	s.UMTC(e, s.A("=", "foo"), StringEqual("foo"))
+func (s *StringEqualTestSuite) TestUnmarshalErrors() {
+	s.UMETC("foo", `formatted.*"=".*<str>`, true)
+	s.UMETC(s.A("foo"), `formatted.*"=".*<str>`, true)
+	s.UMETC(s.A("=", "foo", "bar"), `formatted.*"=".*<str>`, false)
+	s.UMETC(s.A("="), `formatted.*"=".*<str>.*missing.*string`, false)
+	s.UMETC(s.A("=", 1), "string", false)
 }
 
-func (s *StringTestSuite) TestEqual_EvalString() {
-	e := StringEqual("foo")
-	s.ESFTC(e, "bar")
-	s.ESTTC(e, "foo")
+func (s *StringEqualTestSuite) TestEvalString() {
+	ast := s.A("=", "foo")
+	s.ESFTC(ast, "bar")
+	s.ESTTC(ast, "foo")
 }
 
-func (s *StringTestSuite) TestString_Marshal() {
+func TestStringEqual(t *testing.T) {
+	s := new(StringEqualTestSuite)
+	s.DefaultNodeConstructor = func() rql.ASTNode {
+		return StringEqual("")
+	}
+	suite.Run(t, s)
+}
+
+type StringTestSuite struct {
+	asttest.Suite
+}
+
+func (s *StringTestSuite) TestMarshal() {
 	p := String().(internal.NonterminalNode)
 	p.SetMatchedNode(StringGlob("foo"))
 	s.MTC(p, StringGlob("foo").Marshal())
 }
 
-func (s *StringTestSuite) TestString_Unmarshal() {
-	p := String()
-	s.UMETC(p, "foo", `formatted.*"glob".*"regex".*"="`, true)
-	s.UMETC(p, s.A("glob", "["), "invalid.*glob", false)
-	s.UMETC(p, s.A("regex", "["), "invalid.*regex", false)
-	s.UMETC(p, s.A("=", true), "string", false)
-
-	s.UMTC(p, s.A("glob", "foo"), StringGlob("foo"))
-	s.UMTC(p, s.A("regex", "foo"), StringRegex(regexp.MustCompile("foo")))
-	s.UMTC(p, s.A("=", "foo"), StringEqual("foo"))
+func (s *StringTestSuite) TestUnmarshalErrors() {
+	s.UMETC("foo", `formatted.*"glob".*"regex".*"="`, true)
+	s.UMETC(s.A("glob", "["), "invalid.*glob", false)
+	s.UMETC(s.A("regex", "["), "invalid.*regex", false)
+	s.UMETC(s.A("=", true), "string", false)
 }
 
-func (s *StringTestSuite) TestString_EvalString() {
-	p := String().(internal.NonterminalNode)
-	p.SetMatchedNode(StringGlob("foo"))
-	s.ESFTC(p, "bar")
-	s.ESTTC(p, "foo")
+func (s *StringTestSuite) TestEvalString() {
+	for _, ptype := range []string{"glob", "regex", "="} {
+		ast := s.A(ptype, "foo")
+		s.ESFTC(ast, "bar")
+		s.ESTTC(ast, "foo")
+	}
 }
 
-func (s *StringTestSuite) TestString_Expression_AtomAndNot() {
-	expr := expression.New("string", true, func() rql.ASTNode {
-		return String()
-	})
+func (s *StringTestSuite) TestExpression_AtomAndNot() {
+	s.NodeConstructor = func() rql.ASTNode {
+		return expression.New("string", true, func() rql.ASTNode {
+			return String()
+		})
+	}
 
 	for _, ptype := range []string{"glob", "regex", "="} {
-		s.MUM(expr, []interface{}{ptype, "foo"})
-		s.ESFTC(expr, "bar")
-		s.ESTTC(expr, "foo")
+		ast := s.A(ptype, "foo")
+		s.ESFTC(ast, "bar")
+		s.ESTTC(ast, "foo")
 		s.AssertNotImplemented(
-			expr,
+			ast,
 			asttest.EntryPredicateC,
 			asttest.EntrySchemaPredicateC,
 			asttest.NumericPredicateC,
@@ -120,52 +148,64 @@ func (s *StringTestSuite) TestString_Expression_AtomAndNot() {
 			asttest.ActionPredicateC,
 		)
 
-		s.MUM(expr, []interface{}{"NOT", []interface{}{ptype, "foo"}})
-		s.ESTTC(expr, "bar")
-		s.ESFTC(expr, "foo")
+		notAST := s.A("NOT", ast)
+		s.ESTTC(notAST, "bar")
+		s.ESFTC(notAST, "foo")
 	}
 }
 
-func (s *StringTestSuite) TestStringValue_Marshal() {
+func TestString(t *testing.T) {
+	s := new(StringTestSuite)
+	s.DefaultNodeConstructor = func() rql.ASTNode {
+		return String()
+	}
+	suite.Run(t, s)
+}
+
+type StringValueTestSuite struct {
+	PrimitiveValueTestSuite
+}
+
+func (s *StringValueTestSuite) TestMarshal() {
 	// This also tests that the StringValue* methods do the right thing
 	s.MTC(StringValueGlob("foo"), s.A("string", s.A("glob", "foo")))
 	s.MTC(StringValueRegex(regexp.MustCompile("foo")), s.A("string", s.A("regex", "foo")))
 	s.MTC(StringValueEqual("foo"), s.A("string", s.A("=", "foo")))
 }
 
-func (s *StringTestSuite) TestStringValue_Unmarshal() {
-	g := StringValueGlob("")
-	s.UMETC(g, "foo", `formatted.*"string".*NPE StringPredicate`, true)
-	s.UMETC(g, s.A("string", "foo", "bar"), `formatted.*"string".*NPE StringPredicate`, false)
-	s.UMETC(g, s.A("string"), `formatted.*"string".*NPE StringPredicate.*missing.*NPE StringPredicate`, false)
-	s.UMETC(g, s.A("string", s.A()), `error.*unmarshalling.*NPE StringPredicate.*formatted.*"glob".*<glob>`, false)
-	s.UMTC(g, s.A("string", s.A("glob", "foo")), StringValueGlob("foo"))
+func (s *StringValueTestSuite) TestUnmarshalErrors() {
+	s.UMETC("foo", `formatted.*"string".*NPE StringPredicate`, true)
+	s.UMETC(s.A("string", "foo", "bar"), `formatted.*"string".*NPE StringPredicate`, false)
+	s.UMETC(s.A("string"), `formatted.*"string".*NPE StringPredicate.*missing.*NPE StringPredicate`, false)
+	s.UMETC(s.A("string", s.A()), `error.*unmarshalling.*NPE StringPredicate.*formatted.*"glob".*<glob>`, false)
 }
 
-func (s *StringTestSuite) TestStringValue_EvalValue() {
-	g := StringValueGlob("foo")
-	s.EVFTC(g, "bar", 1)
-	s.EVTTC(g, "foo")
+func (s *StringValueTestSuite) TestEvalValue() {
+	ast := s.A("string", s.A("glob", "foo"))
+	s.EVFTC(ast, "bar", 1)
+	s.EVTTC(ast, "foo")
 }
 
-func (s NumericTestSuite) TestStringValue_EvalValueSchema() {
-	g := StringValueGlob("foo")
-	s.EVSFTC(g, s.VS("object", "array")...)
-	s.EVSTTC(g, s.VS("string")...)
+func (s *StringValueTestSuite) TestEvalValueSchema() {
+	ast := s.A("string", s.A("glob", "foo"))
+	s.EVSFTC(ast, s.VS("object", "array")...)
+	s.EVSTTC(ast, s.VS("string")...)
 }
 
-func (s *StringTestSuite) TestStringValue_AtomAndNot() {
-	expr := expression.New("string", true, func() rql.ASTNode {
-		return StringValue(String())
-	})
+func (s *StringValueTestSuite) TestExpression_AtomAndNot() {
+	s.NodeConstructor = func() rql.ASTNode {
+		return expression.New("string", true, func() rql.ASTNode {
+			return StringValue(String())
+		})
+	}
 
-	s.MUM(expr, []interface{}{"string", []interface{}{"glob", "foo"}})
-	s.EVFTC(expr, "bar")
-	s.EVTTC(expr, "foo")
-	s.EVSFTC(expr, s.VS("object", "array")...)
-	s.EVSTTC(expr, s.VS("string")...)
+	ast := s.A("string", s.A("glob", "foo"))
+	s.EVFTC(ast, "bar")
+	s.EVTTC(ast, "foo")
+	s.EVSFTC(ast, s.VS("object", "array")...)
+	s.EVSTTC(ast, s.VS("string")...)
 	s.AssertNotImplemented(
-		expr,
+		ast,
 		asttest.EntryPredicateC,
 		asttest.EntrySchemaPredicateC,
 		asttest.NumericPredicateC,
@@ -173,12 +213,16 @@ func (s *StringTestSuite) TestStringValue_AtomAndNot() {
 		asttest.ActionPredicateC,
 	)
 
-	s.MUM(expr, []interface{}{"NOT", []interface{}{"string", []interface{}{"glob", "foo"}}})
-	s.EVTTC(expr, "bar")
-	s.EVFTC(expr, "foo")
-	s.EVSTTC(expr, s.VS("object", "array", "string")...)
+	notAST := s.A("NOT", ast)
+	s.EVTTC(notAST, "bar")
+	s.EVFTC(notAST, "foo")
+	s.EVSTTC(notAST, s.VS("object", "array", "string")...)
 }
 
-func TestString(t *testing.T) {
-	suite.Run(t, new(StringTestSuite))
+func TestStringValue(t *testing.T) {
+	s := new(StringValueTestSuite)
+	s.DefaultNodeConstructor = func() rql.ASTNode {
+		return StringValue(String())
+	}
+	suite.Run(t, s)
 }

--- a/api/rql/internal/primary/atime_test.go
+++ b/api/rql/internal/primary/atime_test.go
@@ -8,16 +8,9 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-type AtimeTestSuite struct {
-	TimeAttrTestSuite
-}
-
 func TestAtime(t *testing.T) {
-	s := new(AtimeTestSuite)
-	s.name = "atime"
-	s.constructP = Atime
-	s.setAttr = func(e *rql.Entry, t time.Time) {
+	s := newTimeAttrTestSuite("atime", Atime, func(e *rql.Entry, t time.Time) {
 		e.Attributes.SetAtime(t)
-	}
+	})
 	suite.Run(t, s)
 }

--- a/api/rql/internal/primary/crtime_test.go
+++ b/api/rql/internal/primary/crtime_test.go
@@ -8,16 +8,9 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-type CrtimeTestSuite struct {
-	TimeAttrTestSuite
-}
-
 func TestCrtime(t *testing.T) {
-	s := new(CrtimeTestSuite)
-	s.name = "crtime"
-	s.constructP = Crtime
-	s.setAttr = func(e *rql.Entry, t time.Time) {
+	s := newTimeAttrTestSuite("crtime", Crtime, func(e *rql.Entry, t time.Time) {
 		e.Attributes.SetCrtime(t)
-	}
+	})
 	suite.Run(t, s)
 }

--- a/api/rql/internal/primary/ctime_test.go
+++ b/api/rql/internal/primary/ctime_test.go
@@ -8,16 +8,9 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-type CtimeTestSuite struct {
-	TimeAttrTestSuite
-}
-
 func TestCtime(t *testing.T) {
-	s := new(CtimeTestSuite)
-	s.name = "ctime"
-	s.constructP = Ctime
-	s.setAttr = func(e *rql.Entry, t time.Time) {
+	s := newTimeAttrTestSuite("ctime", Ctime, func(e *rql.Entry, t time.Time) {
 		e.Attributes.SetCtime(t)
-	}
+	})
 	suite.Run(t, s)
 }

--- a/api/rql/internal/primary/kind_test.go
+++ b/api/rql/internal/primary/kind_test.go
@@ -19,45 +19,45 @@ func (s *KindTestSuite) TestMarshal() {
 }
 
 func (s *KindTestSuite) TestUnmarshal() {
-	n := Kind(predicate.StringGlob(""))
-	s.UMETC(n, "foo", `kind.*formatted.*"kind".*NPE StringPredicate`, true)
-	s.UMETC(n, s.A("foo", s.A("glob", "foo")), `kind.*formatted.*"kind".*NPE StringPredicate`, true)
-	s.UMETC(n, s.A("kind", "foo", "bar"), `kind.*formatted.*"kind".*NPE StringPredicate`, false)
-	s.UMETC(n, s.A("kind"), `kind.*formatted.*"kind".*NPE StringPredicate.*missing.*NPE StringPredicate`, false)
-	s.UMETC(n, s.A("kind", s.A("glob", "[")), "kind.*NPE StringPredicate.*glob", false)
-	s.UMTC(n, s.A("kind", s.A("glob", "foo")), Kind(predicate.StringGlob("foo")))
+	s.UMETC("foo", `kind.*formatted.*"kind".*NPE StringPredicate`, true)
+	s.UMETC(s.A("foo", s.A("glob", "foo")), `kind.*formatted.*"kind".*NPE StringPredicate`, true)
+	s.UMETC(s.A("kind", "foo", "bar"), `kind.*formatted.*"kind".*NPE StringPredicate`, false)
+	s.UMETC(s.A("kind"), `kind.*formatted.*"kind".*NPE StringPredicate.*missing.*NPE StringPredicate`, false)
+	s.UMETC(s.A("kind", s.A("glob", "[")), "kind.*NPE StringPredicate.*glob", false)
 }
 func (s *KindTestSuite) TestEvalEntrySchema() {
-	p := Kind(predicate.StringGlob("foo"))
+	ast := s.A("kind", s.A("glob", "foo"))
 	schema := &rql.EntrySchema{}
 	schema.SetPath("bar")
-	s.EESFTC(p, schema)
+	s.EESFTC(ast, schema)
 	schema.SetPath("foo")
-	s.EESTTC(p, schema)
+	s.EESTTC(ast, schema)
 }
 
 func (s *KindTestSuite) TestExpression_Atom() {
-	expr := expression.New("kind", false, func() rql.ASTNode {
-		return Kind(predicate.String())
-	})
+	s.NodeConstructor = func() rql.ASTNode {
+		return expression.New("kind", false, func() rql.ASTNode {
+			return Kind(predicate.String())
+		})
+	}
 
-	s.MUM(expr, []interface{}{"kind", []interface{}{"glob", "foo"}})
+	ast := s.A("kind", s.A("glob", "foo"))
 	e := rql.Entry{}
-	s.EEFTC(expr, e)
+	s.EEFTC(ast, e)
 	e.Schema = &rql.EntrySchema{}
 	e.Schema.SetPath("bar")
-	s.EETTC(expr, e)
+	s.EETTC(ast, e)
 
 	schema := &rql.EntrySchema{}
 	schema.SetPath("")
-	s.EESFTC(expr, schema)
+	s.EESFTC(ast, schema)
 	schema.SetPath("bar")
-	s.EESFTC(expr, schema)
+	s.EESFTC(ast, schema)
 	schema.SetPath("foo")
-	s.EESTTC(expr, schema)
+	s.EESTTC(ast, schema)
 
 	s.AssertNotImplemented(
-		expr,
+		ast,
 		asttest.ValuePredicateC,
 		asttest.StringPredicateC,
 		asttest.NumericPredicateC,
@@ -67,5 +67,9 @@ func (s *KindTestSuite) TestExpression_Atom() {
 }
 
 func TestKind(t *testing.T) {
-	suite.Run(t, new(KindTestSuite))
+	s := new(KindTestSuite)
+	s.DefaultNodeConstructor = func() rql.ASTNode {
+		return Kind(predicate.String())
+	}
+	suite.Run(t, s)
 }

--- a/api/rql/internal/primary/mtime_test.go
+++ b/api/rql/internal/primary/mtime_test.go
@@ -8,16 +8,9 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-type MtimeTestSuite struct {
-	TimeAttrTestSuite
-}
-
 func TestMtime(t *testing.T) {
-	s := new(MtimeTestSuite)
-	s.name = "mtime"
-	s.constructP = Mtime
-	s.setAttr = func(e *rql.Entry, t time.Time) {
+	s := newTimeAttrTestSuite("mtime", Mtime, func(e *rql.Entry, t time.Time) {
 		e.Attributes.SetMtime(t)
-	}
+	})
 	suite.Run(t, s)
 }


### PR DESCRIPTION
Real-world RQL use involves unmarshaling the AST from JSON then calling
the appropriate Eval methods. The values passed into value predicates
are also unmarshaled JSON values. The unit tests should simulate these
real-world scenarios. Thus, this commit modifies the helpers in
asttest.Suite to ensure that JSON unmarshaled Go types are passed as
input both for the ast and for value predicates.

Signed-off-by: Enis Inan <enis.inan@puppet.com>