### PR TITLE
Fix mistake from previous commit

### DIFF
--- a/cmd/internal/shell/core.go
+++ b/cmd/internal/shell/core.go
@@ -55,7 +55,7 @@ function prompter() {
 
 	if [ -v W ]; then
 		# If the current directory is W, replace with '.'. Else if it's a subdir, show just subpath.
-		if [ "${prompt_path}" = "${W}" ]; then
+		if [ "${PWD}" = "${W}" ]; then
 			prompt_path=.
 		else
 			prompt_path=${PWD/#$W\//}


### PR DESCRIPTION
Now correctly tests PWD instead of prompt_path (which wasn't yet set).

Signed-off-by: Michael Smith <michael.smith@puppet.com>