### PR TITLE
Improve exploring persistent volumes in Kubernetes

### DIFF
--- a/plugin/kubernetes/container-log.go
+++ b/plugin/kubernetes/container-log.go
@@ -22,7 +22,7 @@ func newContainerLogFile(container *container) *containerLogFile {
 	clf := &containerLogFile{
 		EntryBase: plugin.NewEntry("log"),
 	}
-	clf.namespace = container.ns
+	clf.namespace = container.pod.Namespace
 	clf.podName = container.pod.Name
 	clf.containerName = container.Name()
 	clf.client = container.client

--- a/plugin/kubernetes/container.go
+++ b/plugin/kubernetes/container.go
@@ -2,10 +2,8 @@ package kubernetes
 
 import (
 	"context"
-	"io"
 
 	"github.com/pkg/errors"
-	"github.com/puppetlabs/wash/activity"
 	"github.com/puppetlabs/wash/plugin"
 	"github.com/puppetlabs/wash/volume"
 	corev1 "k8s.io/api/core/v1"
@@ -17,20 +15,17 @@ import (
 
 type container struct {
 	plugin.EntryBase
-	client *k8s.Clientset
-	config *rest.Config
-	ns     string
-	pod    *corev1.Pod
+	containerBase
 }
 
-func newContainer(ctx context.Context, client *k8s.Clientset, config *rest.Config, ns string, c *corev1.Container, p *corev1.Pod) (*container, error) {
+func newContainer(ctx context.Context, client *k8s.Clientset, config *rest.Config, c *corev1.Container, p *corev1.Pod) (*container, error) {
 	cntnr := &container{
 		EntryBase: plugin.NewEntry(c.Name),
 	}
 	cntnr.client = client
 	cntnr.config = config
-	cntnr.ns = ns
 	cntnr.pod = p
+	cntnr.container = c
 
 	// Find when the container was started; set this as the creation time
 	for _, ecs := range cntnr.pod.Status.ContainerStatuses {
@@ -80,82 +75,18 @@ func (c *container) List(ctx context.Context) ([]plugin.Entry, error) {
 }
 
 func (c *container) Exec(ctx context.Context, cmd string, args []string, opts plugin.ExecOptions) (plugin.ExecCommand, error) {
-	execRequest := c.client.CoreV1().RESTClient().Post().
-		Resource("pods").
-		Name(c.pod.Name).
-		Namespace(c.ns).
-		SubResource("exec").
-		Param("command", cmd).
-		Param("container", c.Name()).
-		Param("stderr", "true").
-		Param("stdout", "true")
-
-	for _, arg := range args {
-		execRequest = execRequest.Param("command", arg)
-	}
-
-	if opts.Stdin != nil || opts.Tty {
-		execRequest = execRequest.Param("stdin", "true")
-	}
-
-	if opts.Tty {
-		execRequest = execRequest.Param("tty", "true")
-	}
-
-	executor, err := remotecommand.NewSPDYExecutor(c.config, "POST", execRequest.URL())
+	execCmd := plugin.NewExecCommand(ctx)
+	executor, err := c.newExecutor(ctx, cmd, args, remotecommand.StreamOptions{
+		Stdout: execCmd.Stdout(),
+		Stderr: execCmd.Stderr(),
+		Stdin:  opts.Stdin,
+		Tty:    opts.Tty,
+	})
 	if err != nil {
 		return nil, errors.Wrap(err, "kubernetes.container.Exec request")
 	}
 
-	execCmd := plugin.NewExecCommand(ctx)
-
-	// Track when Stream finishes because the calling context may cancel even though the operation
-	// has completed and cause us to invoke the "stop func".
-	done := make(chan struct{})
-
-	// If using a Tty, create an input stream that allows us to send Ctrl-C to end execution;
-	// when a Tty is allocated commands expect user input and will respond to control signals.
-	stdin := opts.Stdin
-	if opts.Tty {
-		r, w := io.Pipe()
-		if stdin != nil {
-			stdin = io.MultiReader(stdin, r)
-		} else {
-			stdin = r
-		}
-
-		execCmd.SetStopFunc(func() {
-			// Close the response on context cancellation. Copying will block until there's more to
-			// read from the exec output. For an action with no more output it may never return.
-			// Append Ctrl-C to input to signal end of execution.
-			select {
-			case <-done:
-				// Passthrough, output completed so no need to cancel.
-			default:
-				// Only cancel when Stream has not completed. If we cancel but Stream has completed, then
-				// we get an error while trying to copy the Write
-				//   E0330 13:54:35.930448   49254 v2.go:105] EOF
-				// from https://github.com/kubernetes/client-go/blob/v10.0.0/tools/remotecommand/v2.go#L105
-				// where it logs the error. I tried to change the log destination, but
-				// https://github.com/kubernetes/client-go/issues/18 seems to preclude that solution.
-				// Calling `klog.SetOutput` didn't do anything.
-				_, err := w.Write([]byte{0x03})
-				activity.Record(ctx, "Sent ETX on context termination: %v", err)
-			}
-			w.Close()
-		})
-	}
-
-	go func() {
-		streamOpts := remotecommand.StreamOptions{
-			Stdout: execCmd.Stdout(),
-			Stderr: execCmd.Stderr(),
-			Stdin:  stdin,
-			Tty:    opts.Tty,
-		}
-		err = executor.Stream(streamOpts)
-		close(done)
-		activity.Record(ctx, "Exec on %v complete: %v", c.Name(), err)
+	errHandler := func(err error) {
 		if err == nil {
 			execCmd.SetExitCode(0)
 		} else if exerr, ok := err.(k8exec.ExitError); ok {
@@ -167,7 +98,9 @@ func (c *container) Exec(ctx context.Context, cmd string, args []string, opts pl
 			execCmd.SetExitCodeErr(err)
 		}
 		execCmd.CloseStreamsWithError(err)
-	}()
+	}
 
+	cleanup := executor.AsyncStream(errHandler)
+	execCmd.SetStopFunc(cleanup)
 	return execCmd, nil
 }

--- a/plugin/kubernetes/containerBase.go
+++ b/plugin/kubernetes/containerBase.go
@@ -1,0 +1,121 @@
+package kubernetes
+
+import (
+	"context"
+	"io"
+
+	"github.com/puppetlabs/wash/activity"
+	corev1 "k8s.io/api/core/v1"
+	k8s "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/remotecommand"
+)
+
+// A general purpose container object that implements executing commands.
+// If the pod contains only a single container, the container object may be omitted.
+type containerBase struct {
+	client    *k8s.Clientset
+	config    *rest.Config
+	pod       *corev1.Pod
+	container *corev1.Container
+}
+
+// Create an executor to run a command using the provided options and context. If you want
+// synchronous results, call `Stream. For asynchronous results call `AsyncStream`.
+func (c *containerBase) newExecutor(ctx context.Context, cmd string, args []string, opts remotecommand.StreamOptions) (executor, error) {
+	execRequest := c.client.CoreV1().RESTClient().Post().
+		Resource("pods").
+		Name(c.pod.Name).
+		Namespace(c.pod.Namespace).
+		SubResource("exec").
+		Param("command", cmd)
+
+	if c.container != nil {
+		execRequest = execRequest.Param("container", c.container.Name)
+	}
+
+	if opts.Stdout != nil {
+		execRequest = execRequest.Param("stdout", "true")
+	}
+
+	if opts.Stderr != nil {
+		execRequest = execRequest.Param("stderr", "true")
+	}
+
+	if opts.Stdin != nil || opts.Tty {
+		execRequest = execRequest.Param("stdin", "true")
+	}
+
+	if opts.Tty {
+		execRequest = execRequest.Param("tty", "true")
+	}
+
+	for _, arg := range args {
+		execRequest = execRequest.Param("command", arg)
+	}
+
+	e, err := remotecommand.NewSPDYExecutor(c.config, "POST", execRequest.URL())
+	return executor{ctx: ctx, exec: e, opts: opts, name: c.String()}, err
+}
+
+func (c *containerBase) String() string {
+	s := c.pod.Namespace + "/" + c.pod.Name
+	if c.container != nil {
+		s += "/" + c.container.Name
+	}
+	return s
+}
+
+type executor struct {
+	ctx  context.Context
+	exec remotecommand.Executor
+	opts remotecommand.StreamOptions
+	name string
+}
+
+func (e executor) Stream() error {
+	return e.exec.Stream(e.opts)
+}
+
+func (e executor) AsyncStream(errHandler func(error)) (cleanup func()) {
+	// Track when Stream finishes because the calling context may cancel even though the operation
+	// has completed and cause us to invoke the "stop func".
+	done := make(chan struct{})
+
+	// If using a Tty, create an input stream that allows us to send Ctrl-C to end execution;
+	// when a Tty is allocated commands expect user input and will respond to control signals.
+	opts := e.opts
+	if opts.Tty {
+		r, w := io.Pipe()
+		if opts.Stdin != nil {
+			opts.Stdin = io.MultiReader(opts.Stdin, r)
+		} else {
+			opts.Stdin = r
+		}
+
+		cleanup = func() {
+			// Close the response on context cancellation. Copying will block until there's more to
+			// read from the exec output. For an action with no more output it may never return.
+			// Append Ctrl-C to input to signal end of execution.
+			select {
+			case <-done:
+				// Passthrough, output completed so no need to cancel.
+			default:
+				// Only cancel when Stream has not completed. If we cancel but Stream has completed
+				// we get an error while trying to copy the Write that can surface in multiple ways.
+				_, err := w.Write([]byte{0x03})
+				activity.Record(e.ctx, "Sent ETX on context termination: %v", err)
+			}
+			w.Close()
+		}
+	}
+
+	go func() {
+		err := e.exec.Stream(opts)
+		close(done)
+		activity.Record(e.ctx, "Exec on %v complete: %v", e.name, err)
+		errHandler(err)
+	}()
+
+	return
+}

--- a/plugin/kubernetes/pod.go
+++ b/plugin/kubernetes/pod.go
@@ -54,7 +54,7 @@ func (p *pod) List(ctx context.Context) ([]plugin.Entry, error) {
 
 	entries := make([]plugin.Entry, len(pd.Spec.Containers))
 	for i, c := range pd.Spec.Containers {
-		c, err := newContainer(ctx, p.client, p.config, p.ns, &c, pd)
+		c, err := newContainer(ctx, p.client, p.config, &c, pd)
 		if err != nil {
 			return nil, err
 		}

--- a/plugin/kubernetes/pvcsDir.go
+++ b/plugin/kubernetes/pvcsDir.go
@@ -6,11 +6,13 @@ import (
 	"github.com/puppetlabs/wash/plugin"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8s "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 )
 
 type pvcsDir struct {
 	plugin.EntryBase
 	client *k8s.Clientset
+	config *rest.Config
 	ns     string
 }
 
@@ -19,6 +21,7 @@ func newPVCSDir(ns *namespace) *pvcsDir {
 		EntryBase: plugin.NewEntry("persistentvolumeclaims"),
 	}
 	pv.client = ns.client
+	pv.config = ns.config
 	pv.ns = ns.Name()
 	return pv
 }
@@ -43,7 +46,7 @@ func (pv *pvcsDir) List(ctx context.Context) ([]plugin.Entry, error) {
 	}
 	entries := make([]plugin.Entry, len(pvcList.Items))
 	for i, p := range pvcList.Items {
-		entries[i] = newPVC(pvcI, pv.client.CoreV1().Pods(pv.ns), &p)
+		entries[i] = newPVC(pvcI, pv.client, pv.config, pv.ns, &p)
 	}
 	return entries, nil
 }

--- a/plugin/kubernetes/tempContainer.go
+++ b/plugin/kubernetes/tempContainer.go
@@ -1,0 +1,112 @@
+package kubernetes
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/puppetlabs/wash/activity"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+	typedv1 "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+// A temporary container with tools for handling cleanup.
+type tempContainer struct {
+	pod  *corev1.Pod
+	podi typedv1.PodInterface
+}
+
+// Create a container that mounts a pvc to a default mountpoint and waits for 7 days.
+func createContainer(podi typedv1.PodInterface, volumeClaim, mountpoint string) (c tempContainer, err error) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "wash",
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "busybox",
+					Image: "busybox",
+					Args:  []string{"sleep", "604800"},
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("1m"),
+							corev1.ResourceMemory: resource.MustParse("10Mi"),
+						},
+					},
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      volumeClaim,
+							MountPath: mountpoint,
+							ReadOnly:  true,
+						},
+					},
+				},
+			},
+			RestartPolicy: corev1.RestartPolicyNever,
+			Volumes: []corev1.Volume{
+				{
+					Name: volumeClaim,
+					VolumeSource: corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+							ClaimName: volumeClaim,
+							ReadOnly:  true,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	c.podi = podi
+	c.pod, err = podi.Create(pod)
+	return
+}
+
+var errPodTerminated = errors.New("Pod terminated unexpectedly")
+
+func (c *tempContainer) waitOnCreation(ctx context.Context) error {
+	watchOpts := metav1.ListOptions{FieldSelector: "metadata.name=" + c.pod.Name}
+	watcher, err := c.podi.Watch(watchOpts)
+	if err != nil {
+		return err
+	}
+	defer watcher.Stop()
+
+	ch := watcher.ResultChan()
+	for {
+		select {
+		case e, ok := <-ch:
+			if !ok {
+				return fmt.Errorf("Channel error waiting for pod %v: %v", c, e)
+			}
+			switch e.Type {
+			case watch.Modified:
+				switch e.Object.(*corev1.Pod).Status.Phase {
+				case corev1.PodRunning:
+					// Success, we have a running pod.
+					return nil
+				case corev1.PodSucceeded:
+					return errPodTerminated
+				case corev1.PodFailed:
+					return errPodTerminated
+				case corev1.PodUnknown:
+					activity.Record(ctx, "Unknown state for pod %v: %v", c, e.Object)
+				}
+			case watch.Error:
+				return fmt.Errorf("Pod %v errored: %v", c, e.Object)
+			}
+		case <-time.After(30 * time.Second):
+			return fmt.Errorf("Timed out waiting for pod %v", c)
+		}
+	}
+}
+
+func (c *tempContainer) delete() error {
+	var deleteImmediately int64 = 0
+	return c.podi.Delete(c.pod.Name, &metav1.DeleteOptions{GracePeriodSeconds: &deleteImmediately})
+}


### PR DESCRIPTION
Inspect volume on existing pod if it's already mounted, so we don't try to mount a ReadWriteOnce volume a 2nd time and fail.

Add resource requests when creating a pod to view persistent volumes that are not mounted anywhere.

Fixes #758 and resolves #568.