### PR TITLE
Make kubernetes containers a directory

### DIFF
--- a/plugin/kubernetes/container-log.go
+++ b/plugin/kubernetes/container-log.go
@@ -1,0 +1,64 @@
+package kubernetes
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/puppetlabs/wash/activity"
+	"github.com/puppetlabs/wash/plugin"
+	corev1 "k8s.io/api/core/v1"
+	k8s "k8s.io/client-go/kubernetes"
+)
+
+type containerLogFile struct {
+	plugin.EntryBase
+	namespace, podName, containerName string
+	client                            *k8s.Clientset
+}
+
+func newContainerLogFile(container *container) *containerLogFile {
+	clf := &containerLogFile{
+		EntryBase: plugin.NewEntry("log"),
+	}
+	clf.namespace = container.ns
+	clf.podName = container.pod.Name
+	clf.containerName = container.Name()
+	clf.client = container.client
+	return clf
+}
+
+func (clf *containerLogFile) Schema() *plugin.EntrySchema {
+	return plugin.NewEntrySchema(clf, "log").IsSingleton()
+}
+
+func (clf *containerLogFile) Read(ctx context.Context) ([]byte, error) {
+	logOptions := corev1.PodLogOptions{
+		Container: clf.containerName,
+	}
+	req := clf.client.CoreV1().Pods(clf.namespace).GetLogs(clf.podName, &logOptions)
+	rdr, err := req.Stream()
+	if err != nil {
+		return nil, err
+	}
+	var buf bytes.Buffer
+	var n int64
+	if n, err = buf.ReadFrom(rdr); err != nil {
+		return nil, fmt.Errorf("unable to read logs: %v", err)
+	}
+	activity.Record(ctx, "Read %v bytes of %v log", n, clf.containerName)
+
+	return buf.Bytes(), nil
+}
+
+func (clf *containerLogFile) Stream(ctx context.Context) (io.ReadCloser, error) {
+	var tailLines int64 = 10
+	logOptions := corev1.PodLogOptions{
+		Container: clf.containerName,
+		Follow:    true,
+		TailLines: &tailLines,
+	}
+	req := clf.client.CoreV1().Pods(clf.namespace).GetLogs(clf.podName, &logOptions)
+	return req.Stream()
+}


### PR DESCRIPTION
Change the Kubernetes container entry to a directory mirroring the Docker container structure: log, metadata, filesystem.

Also fixes using a tty with the container's exec method (which was previously unused).

Resolves #203.

Signed-off-by: Michael Smith <michael.smith@puppet.com>