### PR TITLE
Update and tune linter for lower memory use

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
   global:
   - PROJECT_NAME=wash
   - WASH_DISABLE_ANALYTICS=true
-  - GOLANGCI_LINT_VERSION=v1.19.1
+  - GOLANGCI_LINT_VERSION=v1.24.0
   - BATS_VERSION=v1.1.0
 jobs:
   include:
@@ -36,7 +36,7 @@ jobs:
   - name: Lint with golangci-lint
     before_script:
     - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin $GOLANGCI_LINT_VERSION
-    script: GOGC=20 golangci-lint run -v --concurrency 1 --deadline 3m # https://github.com/golangci/golangci-lint/issues/337#issuecomment-510136513
+    script: GOGC=10 golangci-lint run -v --concurrency 1 --deadline 3m # https://github.com/golangci/golangci-lint/issues/337#issuecomment-510136513
   - stage: deploy
     name: Deploy to GitHub Releases
     if: tag IS present

--- a/api/error.go
+++ b/api/error.go
@@ -168,7 +168,7 @@ func invalidIntParam(name, value string) *errorResponse {
 func invalidPathsResponse() *errorResponse {
 	return &errorResponse{http.StatusBadRequest, newErrorObj(
 		apitypes.InvalidPaths,
-		fmt.Sprintf("Request must include one 'path' query parameter"),
+		"Request must include one 'path' query parameter",
 		apitypes.ErrorFields{},
 	)}
 }

--- a/api/rql/ast/metaPrimaryRealWorld_test.go
+++ b/api/rql/ast/metaPrimaryRealWorld_test.go
@@ -187,7 +187,7 @@ func TestMetaPrimaryRealWorld(t *testing.T) {
 
 	rawMeta, err := ioutil.ReadFile("testdata/metadata.json")
 	if err != nil {
-		t.Fatal(fmt.Sprintf("Failed to read testdata/metadata.json"))
+		t.Fatal(fmt.Sprintf("Failed to read testdata/metadata.json: %v", err))
 	}
 	var m map[string]interface{}
 	if err := json.Unmarshal(rawMeta, &m); err != nil {
@@ -197,7 +197,7 @@ func TestMetaPrimaryRealWorld(t *testing.T) {
 
 	rawMetaSchema, err := ioutil.ReadFile("testdata/metadataSchema.json")
 	if err != nil {
-		t.Fatal(fmt.Sprintf("Failed to read testdata/metadataSchema.json"))
+		t.Fatal(fmt.Sprintf("Failed to read testdata/metadataSchema.json: %v", err))
 	}
 	var metaSchema *plugin.JSONSchema
 	if err := json.Unmarshal(rawMetaSchema, &metaSchema); err != nil {


### PR DESCRIPTION
With updates to dependencies, golangci-lint is sometimes running out of memory in CI. Update golangci-lint and try tuning GOGC according to https://github.com/golangci/golangci-lint#memory-usage-of-golangci-lint

Signed-off-by: Michael Smith <michael.smith@puppet.com>