### PR TITLE
Make ls long output more consistent with other ls implementations

### DIFF
--- a/cmd/ls.go
+++ b/cmd/ls.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -60,14 +61,17 @@ func formatItem(item lsItem, longFormat bool) [][]string {
 		if !longFormat {
 			row = []string{cname(entry)}
 		} else {
-			var mtimeStr string
+			mtimeStr, sizeStr := "<mtime unknown>", "<size unknown>"
 			if entry.Attributes.HasMtime() {
 				mtimeStr = formatTime(entry.Attributes.Mtime())
-			} else {
-				mtimeStr = "<mtime unknown>"
 			}
+			if entry.Attributes.HasSize() {
+				sizeStr = strconv.FormatUint(entry.Attributes.Size(), 10)
+			}
+
+			sort.Strings(entry.Actions)
 			verbs := strings.Join(entry.Actions, ", ")
-			row = []string{cname(entry), mtimeStr, verbs}
+			row = []string{verbs, sizeStr, mtimeStr, cname(entry)}
 		}
 
 		rows = append(rows, row)


### PR DESCRIPTION
New format displays: verbs, size, mtime, name
```
delete, read, write   223     17 Jun 20 20:32 UTC   MAINT.md
delete, read, write   5106    17 Jun 20 20:32 UTC   README.md
delete, read, write   18734   17 Jun 20 20:24 UTC   wash-logo-lg.png
delete, read, write   9264    17 Jun 20 20:24 UTC   wash-logo.png
```

This is more consistent with other `ls` implementations, although it still leaves out owner/group because they're not relevant to most objects in Wash.