### PR TITLE
Lower logging cause of inaccessible to journal log

### DIFF
--- a/plugin/entryBase.go
+++ b/plugin/entryBase.go
@@ -142,7 +142,7 @@ func (e *EntryBase) SetPartialMetadata(obj interface{}) *EntryBase {
 // MarkInaccessible sets the inaccessible attribute and logs a message about why the entry is
 // inaccessible.
 func (e *EntryBase) MarkInaccessible(ctx context.Context, err error) {
-	activity.Warnf(ctx, "Omitting %v: %v", e.id, err)
+	activity.Record(ctx, "Omitting %v: %v", e.id, err)
 	e.isInaccessible = true
 }
 


### PR DESCRIPTION
Stops logging directly to the console because it's common that a user does not have access to some resources and interferes with normal use.

Signed-off-by: Michael Smith <michael.smith@puppet.com>