### PR TITLE
Update default branch to main

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: Lint and Test
 
 on: 
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 env:
   WASH_DISABLE_ANALYTICS: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ For example, the Docker plugin has multiple files implementing components of a c
 
 ### Releases
 
-Releases are done through the GitHub's [Draft a new release](https://github.com/puppetlabs/wash/releases/new). A [GitHub Action](https://github.com/puppetlabs/wash/blob/master/.github/workflows/release.yml) will build and upload assets and open a PR against https://github.com/puppetlabs/homebrew-puppet to update to the new release.
+Releases are done through the GitHub's [Draft a new release](https://github.com/puppetlabs/wash/releases/new). A [GitHub Action](https://github.com/puppetlabs/wash/blob/main/.github/workflows/release.yml) will build and upload assets and open a PR against https://github.com/puppetlabs/homebrew-puppet to update to the new release.
 
 Release announcements are:
 

--- a/CORE_PLUGIN_DEVELOPMENT.md
+++ b/CORE_PLUGIN_DEVELOPMENT.md
@@ -23,13 +23,13 @@ TIP: If there will only ever be one instance of the entry type - such as a named
 
 Create a new directory in [plugin] for the plugin.
 
-Create an object that implements the [Root](https://godoc.org/github.com/puppetlabs/wash/plugin#Root) interface. This would typically be in a `root.go` file. See [docker/root.go](https://github.com/puppetlabs/wash/blob/master/plugin/docker/root.go) for an example.
+Create an object that implements the [Root](https://godoc.org/github.com/puppetlabs/wash/plugin#Root) interface. This would typically be in a `root.go` file. See [docker/root.go](https://github.com/puppetlabs/wash/blob/main/plugin/docker/root.go) for an example.
 
 NOTE: The `Init` method initializes the Root object's `EntryBase` configuration and any credentials.
 
 ### Extending the plugin
 
-Each entry in the plugin's hierarchy should be a new type. This pattern's adopted by the existing core plugins (e.g. [ec2Instance](https://github.com/puppetlabs/wash/blob/master/plugin/aws/ec2Instance.go) in AWS; [container](https://github.com/puppetlabs/wash/blob/master/plugin/docker/container.go) in Docker). It is meant to make your plugin modular and easier to maintain.
+Each entry in the plugin's hierarchy should be a new type. This pattern's adopted by the existing core plugins (e.g. [ec2Instance](https://github.com/puppetlabs/wash/blob/main/plugin/aws/ec2Instance.go) in AWS; [container](https://github.com/puppetlabs/wash/blob/main/plugin/docker/container.go) in Docker). It is meant to make your plugin modular and easier to maintain.
 
 - Entries with children ("directories") should implement the `Parent` interface.
 - Entries with content should implement `Readable`.

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -111,8 +111,8 @@ Once we've found some resources, we'd like to see what they're doing. The defaul
 ```fish
 > tail -f /aws/resources/ec2/vm-106.puppet.com /aws/resources/ec2/vm-107.puppet.com:/var/log/nginx/access.log /aws/resources/lambda/michael-lambda-17 /aws/resources/s3/michael-bucket1 /kubernetes/gke_shared-k8s_us-west1-a_shared-k8s-dev/dujour-dev/pods/r0raxmg1fg276o05wmmqancki8w-dujour-84c7b497cc-fd7m4
 ==> /aws/resources/ec2/vm-107.puppet.com:/var/log/syslog <==
-Jan  2 23:53:50 pe-master systemd[1]: Starting User Manager for UID 1000...
-Jan  2 23:53:50 pe-master systemd[1]: Started Session 25386 of user ubuntu.
+Jan  2 23:53:50 pe-server systemd[1]: Starting User Manager for UID 1000...
+Jan  2 23:53:50 pe-server systemd[1]: Started Session 25386 of user ubuntu.
 
 ==> /aws/resources/ec2/vm-107.puppet.com:/var/log/nginx/access.log <==
 10.0.25.192 - - [20/Dec/2018:18:03:58 +0000] "GET /index.html HTTP/1.1" 200 603 "https://vm-107.puppet.com/" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_1) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0.1 Safari/605.1.15" "-"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ For an introduction to Wash, see our main site at https://pup.pt/wash.
 
 ## Community Feedback
 
-We're actively soliciting community feedback and input on our [roadmap](#roadmap)! Don't hesitate to file issues for new features, new plugin types, new primitives, new command-line tools, or anything else that crosses your mind. You can also chat with us directly on [`#wash`](https://puppetcommunity.slack.com/app_redirect?channel=wash) on [Slack](https://slack.puppet.com/). Please abide by our [code of conduct](https://github.com/puppetlabs/wash/blob/master/CODE_OF_CONDUCT.md) when interacting with the community.
+We're actively soliciting community feedback and input on our [roadmap](#roadmap)! Don't hesitate to file issues for new features, new plugin types, new primitives, new command-line tools, or anything else that crosses your mind. You can also chat with us directly on [`#wash`](https://puppetcommunity.slack.com/app_redirect?channel=wash) on [Slack](https://slack.puppet.com/). Please abide by our [code of conduct](https://github.com/puppetlabs/wash/blob/main/CODE_OF_CONDUCT.md) when interacting with the community.
 
 See the [roadmap](#roadmap) below to see what we've got planned!
 

--- a/api/rql/walker.go
+++ b/api/rql/walker.go
@@ -40,7 +40,7 @@ func (w *walkerImpl) Walk(ctx context.Context, start plugin.Entry) ([]Entry, err
 	}
 	// TODO: Re-introduce something like SchemaRequired() so we can optimize
 	// the traversal if w.q is a schema-predicate. See
-	// https://github.com/puppetlabs/wash/blob/master/cmd/internal/find/walker.go#L47-L52
+	// https://github.com/puppetlabs/wash/blob/main/cmd/internal/find/walker.go#L47-L52
 	entries, err := w.walk(ctx, &startEntry, 0)
 	if err != nil {
 		return nil, err

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -18,8 +18,8 @@ There are tons of ways to get involved with Wash, whether or not you're a progra
 
 - Are you an old skool command-line gearhead with, like, *opinions* about how things should work on a command line? We'd love your help on improving the shell experience for Wash. How can our unixy Wash commands behave better? Are there new commands we should build? What colors and formatting should we use for `wash ls`? If we implemented `wash fortune`, what quotes should be in there?!
 
-- Have some ideas on how to spice up the website? Please let us know, or feel free to put up a PR! Our website uses Jekyll; its source is in our [Github repo](https://github.com/puppetlabs/wash/tree/master/docs).
+- Have some ideas on how to spice up the website? Please let us know, or feel free to put up a PR! Our website uses Jekyll; its source is in our [Github repo](https://github.com/puppetlabs/wash/tree/main/docs).
 
-- Want to help us [build out or extend the shipped plugins](https://github.com/puppetlabs/wash/blob/master/CORE_PLUGIN_DEVELOPMENT.md)? Feel free to put up a PR!
+- Want to help us [build out or extend the shipped plugins](https://github.com/puppetlabs/wash/blob/main/CORE_PLUGIN_DEVELOPMENT.md)? Feel free to put up a PR!
 
-Come check us out on [Github](https://github.com/puppetlabs/wash), and in particular check out the [contribution guidelines](https://github.com/puppetlabs/wash/blob/master/contributing.md) and the [code of conduct](https://github.com/puppetlabs/wash/blob/master/code_of_conduct.md).
+Come check us out on [Github](https://github.com/puppetlabs/wash), and in particular check out the [contribution guidelines](https://github.com/puppetlabs/wash/blob/main/contributing.md) and the [code of conduct](https://github.com/puppetlabs/wash/blob/main/code_of_conduct.md).


### PR DESCRIPTION
Switches away from `master`, which has an oppressive history. See https://tools.ietf.org/id/draft-knodel-terminology-00.html.