### PR TITLE
Fix error output when temporary pod fails

### DIFF
--- a/plugin/kubernetes/tempContainer.go
+++ b/plugin/kubernetes/tempContainer.go
@@ -110,3 +110,7 @@ func (c *tempContainer) delete(ctx context.Context) error {
 	var deleteImmediately int64 = 0
 	return c.podi.Delete(ctx, c.pod.Name, metav1.DeleteOptions{GracePeriodSeconds: &deleteImmediately})
 }
+
+func (c *tempContainer) String() string {
+	return c.pod.String()
+}


### PR DESCRIPTION
Adds a `String` method to print the pod metadata and status when starting a temporary pod fails.